### PR TITLE
feat(#421) : add default cluster and namespace

### DIFF
--- a/pkg/bot/slack.go
+++ b/pkg/bot/slack.go
@@ -134,7 +134,8 @@ func setupDefaultChannelForKubeCtl(client slack.Client, channelName string, clus
 	msgOpt := slack.MsgOptionText(fmt.Sprintf(execute.DefaultClusterForKubectl, clusterName), false)
 	channelID, _, err := client.PostMessage(channelName, msgOpt, slack.MsgOptionAsUser(true))
 	if err != nil {
-		log.Errorf("Error in sending slack message %s", err.Error())
+		log.Errorf("Error in sending slack message to channel %s : %s", channelName, err.Error())
+		return
 	}
 	if namespace == "" {
 		namespace = "default"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -217,7 +217,7 @@ type Webhook struct {
 type Kubectl struct {
 	Enabled          bool
 	Commands         Commands
-	DefaultNamespace string
+	DefaultNamespace string `yaml:"defaultNamespace"`
 	RestrictAccess   bool `yaml:"restrictAccess"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,6 +88,10 @@ var CommunicationConfigFileName = "comm_config.yaml"
 // Notify flag to toggle event notification
 var Notify = true
 
+//KubeCtlLinkedChannels is a set that contains the channel ID (as a key)of all channels linked to
+//this cluster and containing the default namespace as a value
+var KubeCtlLinkedChannels map[string]string = make(map[string]string)
+
 // NotifType to change notification type
 type NotifType string
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -218,7 +218,7 @@ type Kubectl struct {
 	Enabled          bool
 	Commands         Commands
 	DefaultNamespace string `yaml:"defaultNamespace"`
-	RestrictAccess   bool `yaml:"restrictAccess"`
+	RestrictAccess   bool   `yaml:"restrictAccess"`
 }
 
 // Commands allowed in bot

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -80,13 +80,22 @@ var (
 
 const (
 	notifierStopMsg    = "Sure! I won't send you notifications from cluster '%s' anymore."
-	unsupportedCmdMsg  = "Command not supported. Please run /botkubehelp to see supported commands."
+	//UnsupportedCmdMsg message displayed when the command is not supported
+	UnsupportedCmdMsg  = "Command not supported. Please run /botkubehelp to see supported commands."
 	kubectlDisabledMsg = "Sorry, the admin hasn't given me the permission to execute kubectl command on cluster '%s'."
 	filterNameMissing  = "You forgot to pass filter name. Please pass one of the following valid filters:\n\n%s"
 	filterEnabled      = "I have enabled '%s' filter on '%s' cluster."
 	filterDisabled     = "Done. I won't run '%s' filter on '%s' cluster."
-	//DefaultClusterForKubectl sent when setting a new default cluster for kubectl
+	//DefaultClusterForKubectl message sent when querying default cluster for kubectl
 	DefaultClusterForKubectl = "The default cluster for kubectl commands is : %s"
+	//DefaultClusterForKubectlAccepted messsage sent when cluster is accepted to be default 
+	DefaultClusterForKubectlAccepted = "Using cluster %s as default for kubectl commands"
+
+	//DefaultNamespaceForKubectl message sent when querying for default namespace
+	DefaultNamespaceForKubectl = "The default namespace for cluster %s is %s"
+	//DefaultNamespaceForKubectlAccepted message sent when default namespace is set
+	DefaultNamespaceForKubectlAccepted = "Using default namespace %s for cluster %s"
+
 
 	// NotifierStartMsg notifier enabled response message
 	NotifierStartMsg = "Brace yourselves, notifications are coming from cluster '%s'."
@@ -254,7 +263,7 @@ func printDefaultMsg(p config.BotPlatform) string {
 	if p == config.TeamsBot {
 		return teamsUnsupportedCmdMsg
 	}
-	return unsupportedCmdMsg
+	return UnsupportedCmdMsg
 }
 
 // Trim single and double quotes from ends of string
@@ -342,7 +351,7 @@ func (e *DefaultExecutor) runDefaultCommand(args []string, clusterName string, c
 			return ""
 		case defaultNamespaceCmd:
 			if isManagedChannel {
-				return fmt.Sprintf("The default namespace for cluster %s is %s", clusterName, config.KubeCtlLinkedChannels[channelID])
+				return fmt.Sprintf(DefaultNamespaceForKubectl, clusterName, config.KubeCtlLinkedChannels[channelID])
 			} // else another cluster may be the default
 			return ""
 		default: //unhandled command
@@ -361,7 +370,7 @@ func (e *DefaultExecutor) runDefaultCommand(args []string, clusterName string, c
 						namespace = "default"
 					}
 					config.KubeCtlLinkedChannels[channelID] = namespace
-					return fmt.Sprintf("using cluster %s as default for kubectl commands", clusterName)
+					return fmt.Sprintf(DefaultClusterForKubectlAccepted, clusterName)
 				} //else kubectl not allowed on this channel so say it
 				return fmt.Sprintf(kubectlDisabledMsg, clusterName)
 			} //else removes this channel from the list of channel linked to this cluster for kubectl
@@ -370,7 +379,7 @@ func (e *DefaultExecutor) runDefaultCommand(args []string, clusterName string, c
 		case defaultNamespaceCmd: //want to set default namespace so check if it is the right cluster
 			if isManagedChannel {
 				config.KubeCtlLinkedChannels[channelID] = args[1]
-				return fmt.Sprintf("Using default namespace %s for cluster %s", args[1], clusterName)
+				return fmt.Sprintf(DefaultNamespaceForKubectlAccepted, args[1], clusterName)
 			} // else another cluster may be the default
 			return ""
 		default: //unhandled command

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -79,7 +79,7 @@ var (
 )
 
 const (
-	notifierStopMsg    = "Sure! I won't send you notifications from cluster '%s' anymore."
+	notifierStopMsg = "Sure! I won't send you notifications from cluster '%s' anymore."
 	//UnsupportedCmdMsg message displayed when the command is not supported
 	UnsupportedCmdMsg  = "Command not supported. Please run /botkubehelp to see supported commands."
 	kubectlDisabledMsg = "Sorry, the admin hasn't given me the permission to execute kubectl command on cluster '%s'."
@@ -88,14 +88,13 @@ const (
 	filterDisabled     = "Done. I won't run '%s' filter on '%s' cluster."
 	//DefaultClusterForKubectl message sent when querying default cluster for kubectl
 	DefaultClusterForKubectl = "The default cluster for kubectl commands is : %s"
-	//DefaultClusterForKubectlAccepted message sent when cluster is accepted to be default 
+	//DefaultClusterForKubectlAccepted message sent when cluster is accepted to be default
 	DefaultClusterForKubectlAccepted = "Using cluster %s as default for kubectl commands"
 
 	//DefaultNamespaceForKubectl message sent when querying for default namespace
 	DefaultNamespaceForKubectl = "The default namespace for cluster %s is %s"
 	//DefaultNamespaceForKubectlAccepted message sent when default namespace is set
 	DefaultNamespaceForKubectlAccepted = "Using default namespace %s for cluster %s"
-
 
 	// NotifierStartMsg notifier enabled response message
 	NotifierStartMsg = "Brace yourselves, notifications are coming from cluster '%s'."

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -88,7 +88,7 @@ const (
 	filterDisabled     = "Done. I won't run '%s' filter on '%s' cluster."
 	//DefaultClusterForKubectl message sent when querying default cluster for kubectl
 	DefaultClusterForKubectl = "The default cluster for kubectl commands is : %s"
-	//DefaultClusterForKubectlAccepted messsage sent when cluster is accepted to be default 
+	//DefaultClusterForKubectlAccepted message sent when cluster is accepted to be default 
 	DefaultClusterForKubectlAccepted = "Using cluster %s as default for kubectl commands"
 
 	//DefaultNamespaceForKubectl message sent when querying for default namespace
@@ -362,7 +362,7 @@ func (e *DefaultExecutor) runDefaultCommand(args []string, clusterName string, c
 	if len(args) > 1 {
 		switch args[0] {
 		case defaultClusterCmd:
-			if args[1] == clusterName { //default command is targetting this cluster :)
+			if args[1] == clusterName { //default command is targeting this cluster :)
 				if kubectlAllowed {
 					//adding the channel to the channels linked to this cluster
 					namespace := config.KubeCtlLinkedChannels[channelID] //to avoid changing the namespace is it was previously set

--- a/pkg/execute/fake_executor.go
+++ b/pkg/execute/fake_executor.go
@@ -34,6 +34,7 @@ var KubectlResponse = map[string]string{
 	"-n default get pods": "NAME                           READY   STATUS    RESTARTS   AGE\n" +
 		"nginx-xxxxxxx-yyyyyyy          1/1     Running   1          1d",
 	"-c " + kubectlBinary + " version --short=true | grep Server": fmt.Sprintf("Server Version: %s\n", K8sVersion),
+	"-n foo get pods" : "result for get pods",
 }
 
 // FakeRunner mocks Run

--- a/pkg/execute/fake_executor.go
+++ b/pkg/execute/fake_executor.go
@@ -34,7 +34,7 @@ var KubectlResponse = map[string]string{
 	"-n default get pods": "NAME                           READY   STATUS    RESTARTS   AGE\n" +
 		"nginx-xxxxxxx-yyyyyyy          1/1     Running   1          1d",
 	"-c " + kubectlBinary + " version --short=true | grep Server": fmt.Sprintf("Server Version: %s\n", K8sVersion),
-	"-n foo get pods" : "result for get pods",
+	"-n foo get pods": "result for get pods",
 }
 
 // FakeRunner mocks Run

--- a/test/e2e/command/botkube.go
+++ b/test/e2e/command/botkube.go
@@ -210,20 +210,19 @@ func (c *context) testNotifierCommand(t *testing.T) {
 	})
 }
 
-
 // Test default cluster
 // - @BotKube cluster => should return <current cluster>
 // - @Botkube cluster foo => return "" (this should disable the default cluster)
 // - @Botkube cluster => return ""
-// - @Botkube cluster <current cluster> => return default <current cluster> is used 
+// - @Botkube cluster <current cluster> => return default <current cluster> is used
 func (c *context) testDefaultClusterCommand(t *testing.T) {
 	defer func() {
 		// set back the default cluster value
-		config.KubeCtlLinkedChannels = map[string]string{c.Config.Communications.Slack.Channel:c.Config.Settings.Kubectl.DefaultNamespace}
+		config.KubeCtlLinkedChannels = map[string]string{c.Config.Communications.Slack.Channel: c.Config.Settings.Kubectl.DefaultNamespace}
 	}()
 	t.Run("default cluster command", func(t *testing.T) {
 		if c.TestEnv.Config.Communications.Slack.Enabled {
-  		// Send "cluster" to a channel, response should be the <current cluster>
+			// Send "cluster" to a channel, response should be the <current cluster>
 			c.SlackServer.SendMessageToBot(c.Config.Communications.Slack.Channel, "cluster")
 			m := c.GetLastMessageAndAssert(t)
 			assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
@@ -242,7 +241,7 @@ func (c *context) testDefaultClusterCommand(t *testing.T) {
 			c.SlackServer.SendMessageToBot(c.Config.Communications.Slack.Channel, fmt.Sprintf("cluster %s", c.Config.Settings.ClusterName))
 			m = c.GetLastMessageAndAssert(t)
 			assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
-			assert.Equal(t, "```" + fmt.Sprintf(execute.DefaultClusterForKubectlAccepted, c.Config.Settings.ClusterName)+"```", m.Text)
+			assert.Equal(t, "```"+fmt.Sprintf(execute.DefaultClusterForKubectlAccepted, c.Config.Settings.ClusterName)+"```", m.Text)
 		}
 	})
 }
@@ -254,7 +253,7 @@ func (c *context) testDefaultClusterCommand(t *testing.T) {
 func (c *context) testDefaultNamespaceCommand(t *testing.T) {
 	defer func() {
 		// set back the default cluster value
-		config.KubeCtlLinkedChannels = map[string]string{c.Config.Communications.Slack.Channel:c.Config.Settings.Kubectl.DefaultNamespace}
+		config.KubeCtlLinkedChannels = map[string]string{c.Config.Communications.Slack.Channel: c.Config.Settings.Kubectl.DefaultNamespace}
 	}()
 	t.Run("default namespace", func(t *testing.T) {
 		if c.TestEnv.Config.Communications.Slack.Enabled {
@@ -284,7 +283,7 @@ func (c *context) testDefaultNamespaceCommand(t *testing.T) {
 func (c *context) testDefaultNamespaceWithKubectlCommands(t *testing.T) {
 	defer func() {
 		// set back the default cluster value
-		config.KubeCtlLinkedChannels = map[string]string{c.Config.Communications.Slack.Channel:c.Config.Settings.Kubectl.DefaultNamespace}
+		config.KubeCtlLinkedChannels = map[string]string{c.Config.Communications.Slack.Channel: c.Config.Settings.Kubectl.DefaultNamespace}
 	}()
 	t.Run("default namespace", func(t *testing.T) {
 		if c.TestEnv.Config.Communications.Slack.Enabled {
@@ -295,13 +294,10 @@ func (c *context) testDefaultNamespaceWithKubectlCommands(t *testing.T) {
 			c.SlackServer.SendMessageToBot(c.Config.Communications.Slack.Channel, "get pods")
 			m := c.GetLastMessageAndAssert(t)
 			assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
-			assert.Equal(t, fmt.Sprintf("```Cluster: %s\n%s```", c.Config.Settings.ClusterName,execute.KubectlResponse["-n foo get pods"]), m.Text)
+			assert.Equal(t, fmt.Sprintf("```Cluster: %s\n%s```", c.Config.Settings.ClusterName, execute.KubectlResponse["-n foo get pods"]), m.Text)
 		}
 	})
 }
-
-
-
 
 func (c *context) GetLastMessageAndAssert(t *testing.T) slack.Message {
 	// Get last seen slack message
@@ -311,5 +307,5 @@ func (c *context) GetLastMessageAndAssert(t *testing.T) slack.Message {
 	m := slack.Message{}
 	err := json.Unmarshal([]byte(*lastSeenMsg), &m)
 	assert.NoError(t, err, "message should decode properly")
-	return m	
+	return m
 }

--- a/test/e2e/command/kubectl.go
+++ b/test/e2e/command/kubectl.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/infracloudio/botkube/pkg/execute"
 	"github.com/infracloudio/botkube/test/e2e/env"
+	"github.com/infracloudio/botkube/test/e2e/utils"
 	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
 )
@@ -51,7 +52,7 @@ func (c *context) testKubectlCommand(t *testing.T) {
 		},
 		"BotKube get pods out of configured channel": {
 			command:  "get pods",
-			expected: fmt.Sprintf("<@U023BECGF> get pods"),
+			expected: fmt.Sprintf("%s get pods", utils.SlackEmptyResponsePrefix),
 			channel:  "dummy",
 		},
 		"kubectl command on forbidden verb and resource": {
@@ -91,6 +92,9 @@ func (c *context) Run(t *testing.T) {
 	// Run kubectl tests
 	t.Run("Test Kubectl command", c.testKubectlCommand)
 	t.Run("Test BotKube command", c.testBotkubeCommand)
+	t.Run("Test BotKube default command", c.testDefaultClusterCommand)
+	t.Run("Test BotKube default command", c.testDefaultNamespaceCommand)
+	t.Run("Test kubectl command with default namespace", c.testDefaultNamespaceWithKubectlCommands)
 	t.Run("Test disable notifier", c.testNotifierCommand)
 }
 

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -35,6 +35,10 @@ import (
 	"github.com/infracloudio/botkube/pkg/utils"
 )
 
+//SlackEmptyResponsePrefix prefix user by the fake bot when no
+// response is sent back to identify the previous command
+const	SlackEmptyResponsePrefix = "<@U023BECGF>"
+
 // SlackMessage structure
 type SlackMessage struct {
 	Text        string

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -37,7 +37,7 @@ import (
 
 //SlackEmptyResponsePrefix prefix user by the fake bot when no
 // response is sent back to identify the previous command
-const	SlackEmptyResponsePrefix = "<@U023BECGF>"
+const SlackEmptyResponsePrefix = "<@U023BECGF>"
 
 // SlackMessage structure
 type SlackMessage struct {


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request
 - Bug fix Pull Request

##### SUMMARY
This PR add a default behaviour for kubectl command where a channel can now have a default cluster and a default namespace associated with it to avoid repeating those when doing kubectl commands.
There is only an implementation for slack.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->

Fixes #421 and #429
