### PR TITLE
Add option to get clustername from google metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/infracloudio/botkube
 
 require (
+	cloud.google.com/go v0.38.0
 	github.com/Masterminds/squirrel v1.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.32.12
 	github.com/blang/semver v3.5.1+incompatible // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"cloud.google.com/go/compute/metadata"
 	"gopkg.in/yaml.v2"
 )
 
@@ -275,6 +276,15 @@ func New() (*Config, error) {
 
 	if len(b) != 0 {
 		yaml.Unmarshal(b, c)
+	}
+
+	if c.Settings.ClusterName == "%google_metadata%" {
+		clusterName, err := metadata.InstanceAttributeValue("cluster-name")
+		if err != nil {
+			return nil, err
+		}
+
+		c.Settings.ClusterName = clusterName
 	}
 
 	comm, err := NewCommunicationsConfig()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -278,7 +278,7 @@ func New() (*Config, error) {
 		yaml.Unmarshal(b, c)
 	}
 
-	if c.Settings.ClusterName == "%google_metadata%" {
+	if c.Settings.ClusterName == "+google_metadata+" {
 		clusterName, err := metadata.InstanceAttributeValue("cluster-name")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This adds the option to get the cluster name from google metadata server. This is very useful in a multicluster setup on GCP that we use.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->
`cloud.google.com/go v0.38.0`
