### PR TITLE
Get Go version from the go.mod file on CI

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -6,7 +6,6 @@ on:
       - main
 
 env:
-  GO_VERSION: 1.18
   HELM_VERSION: v3.9.0
   K3D_VERSION: v5.4.3
   INTEGRATION_TESTS_TIMEOUT: 10m
@@ -29,7 +28,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: 'go.mod'
         cache: true
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   push:
   pull_request:
 env:
-  GO_VERSION: 1.18
   HELM_VERSION: v3.9.0
   GOLANGCI_LINT_VERSION: v1.46.2
   GOLANGCI_LINT_TIMEOUT: 5m
@@ -17,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
           cache: true
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -50,7 +49,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
           cache: true
       - name: Run tests
         run: make test
@@ -67,7 +66,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
           cache: true
       - name: Build
         run: make

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -22,7 +22,6 @@ on:
       - 'resource_config.yaml.tpl'
 
 env:
-  GO_VERSION: 1.18
   HELM_VERSION: v3.9.0
   K3D_VERSION: v5.4.3
   PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -52,7 +51,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Install GoReleaser


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Get Go version from the go.mod file on CI


I found out that there is a nice feature that we can use https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file. As a result, we have a single source of truth about used Go version. As we don't test our code with multiple version (matrix) it's IMO a great solution.

