### PR TITLE
Handle multiple configurations for multiple bots and sinks

### DIFF
--- a/cmd/botkube/main.go
+++ b/cmd/botkube/main.go
@@ -179,7 +179,10 @@ func run() error {
 		}
 
 		if commGroupCfg.Teams.Enabled {
-			tb := bot.NewTeams(commGroupLogger.WithField(botLogFieldKey, "MS Teams"), commGroupCfg.Teams, conf.Settings.ClusterName, executorFactory, reporter)
+			tb, err := bot.NewTeams(commGroupLogger.WithField(botLogFieldKey, "MS Teams"), commGroupCfg.Teams, conf.Settings.ClusterName, executorFactory, reporter)
+			if err != nil {
+				return reportFatalError("while creating Teams bot", err)
+			}
 			notifiers = append(notifiers, tb)
 			errGroup.Go(func() error {
 				defer analytics.ReportPanicIfOccurs(commGroupLogger, reporter)

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/vrischmann/envconfig v1.3.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/text v0.3.7
-	gopkg.in/yaml.v3 v3.0.0
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -1790,8 +1790,8 @@ gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
-gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=

--- a/helm/botkube/e2e-test-values.yaml
+++ b/helm/botkube/e2e-test-values.yaml
@@ -5,13 +5,22 @@ communications:
       token: "" # Provide a valid token for BotKube app
       channels:
         'default':
-          name: ""           # Test will override that
+          name: "" # Tests will override this temporarily
           bindings:
             executors:
               - kubectl-read-only
               - kubectl-wait-cmd
               - kubectl-exec-cmd
               - kubectl-allow-all
+            sources:
+              - k8s-events
+        'secondary':
+          name: "" # Tests will override this temporarily
+          bindings:
+            executors:
+              - kubectl-read-only
+            sources:
+              - k8s-events
 
 sources:
   'k8s-events':

--- a/helm/botkube/templates/tests/e2e-test.yaml
+++ b/helm/botkube/templates/tests/e2e-test.yaml
@@ -32,8 +32,10 @@ spec:
           value: "{{ .Values.e2eTest.deployment.waitTimeout }}"
         - name: DEPLOYMENT_ENVS_SLACK_ENABLED_NAME
           value: "BOTKUBE_COMMUNICATIONS_DEFAULT-GROUP_SLACK_ENABLED"
-        - name: DEPLOYMENT_ENVS_SLACK_CHANNEL_ID_NAME
+        - name: DEPLOYMENT_ENVS_DEFAULT_SLACK_CHANNEL_ID_NAME
           value: "BOTKUBE_COMMUNICATIONS_DEFAULT-GROUP_SLACK_CHANNELS_DEFAULT_NAME"
+        - name: DEPLOYMENT_ENVS_SECONDARY_SLACK_CHANNEL_ID_NAME
+          value: "BOTKUBE_COMMUNICATIONS_DEFAULT-GROUP_SLACK_CHANNELS_SECONDARY_NAME"
         - name: CLUSTER_NAME
           value: "{{ .Values.settings.clusterName }}"
         - name: SLACK_BOT_NAME

--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -8,6 +8,10 @@ import (
 	"github.com/kubeshop/botkube/pkg/execute"
 )
 
+const (
+	defaultNotifyValue = true
+)
+
 // Bot connects to communication channels and reads/sends messages. It is a two-way integration.
 type Bot interface {
 	Start(ctx context.Context) error
@@ -17,7 +21,7 @@ type Bot interface {
 
 // ExecutorFactory facilitates creation of execute.Executor instances.
 type ExecutorFactory interface {
-	NewDefault(platform config.CommPlatformIntegration, notifierHandler execute.NotifierHandler, isAuthChannel bool, message string) execute.Executor
+	NewDefault(platform config.CommPlatformIntegration, notifierHandler execute.NotifierHandler, isAuthChannel bool, conversationID string, bindings []string, message string) execute.Executor
 }
 
 // AnalyticsReporter defines a reporter that collects analytics data.
@@ -35,4 +39,16 @@ type FatalErrorAnalyticsReporter interface {
 
 	// Close cleans up the reporter resources.
 	Close() error
+}
+
+type channelConfigByID struct {
+	config.ChannelBindingsByID
+
+	notify bool
+}
+
+type channelConfigByName struct {
+	config.ChannelBindingsByName
+
+	notify bool
 }

--- a/pkg/bot/discord.go
+++ b/pkg/bot/discord.go
@@ -26,7 +26,10 @@ var _ Bot = &Discord{}
 
 // customTimeFormat holds custom time format string.
 const (
-	customTimeFormat          = "2006-01-02T15:04:05Z"
+	customTimeFormat = "2006-01-02T15:04:05Z"
+
+	// discordBotMentionRegexFmt supports also nicknames (the exclamation mark).
+	// Read more: https://discordjs.guide/miscellaneous/parsing-mention-arguments.html#how-discord-mentions-work
 	discordBotMentionRegexFmt = "^<@!?%s>"
 )
 
@@ -66,18 +69,17 @@ type discordMessage struct {
 
 // NewDiscord creates a new Discord instance.
 func NewDiscord(log logrus.FieldLogger, cfg config.Discord, executorFactory ExecutorFactory, reporter AnalyticsReporter) (*Discord, error) {
+	botMentionRegex, err := discordBotMentionRegex(cfg.BotID)
+	if err != nil {
+		return nil, err
+	}
+
 	api, err := discordgo.New("Bot " + cfg.Token)
 	if err != nil {
 		return nil, fmt.Errorf("while creating Discord session: %w", err)
 	}
 
 	channelsCfg := discordChannelsConfigFrom(cfg.Channels)
-
-	// Support nicknames (exclamation mark) as well: https://discordjs.guide/miscellaneous/parsing-mention-arguments.html#how-discord-mentions-work
-	botMentionRegex, err := discordBotMentionRegex(cfg.BotID)
-	if err != nil {
-		return nil, err
-	}
 
 	return &Discord{
 		log:             log,

--- a/pkg/bot/discord.go
+++ b/pkg/bot/discord.go
@@ -139,7 +139,7 @@ func (b *Discord) SendEvent(_ context.Context, event events.Event) (err error) {
 
 	msgToSend := b.formatMessage(event)
 
-	var errs error
+	errs := multierror.New()
 	for _, channelID := range b.getChannelsToNotify() {
 		msg := msgToSend // copy as the struct is modified when using Discord API client
 		if _, err := b.api.ChannelMessageSendComplex(channelID, &msg); err != nil {
@@ -150,13 +150,13 @@ func (b *Discord) SendEvent(_ context.Context, event events.Event) (err error) {
 		b.log.Debugf("Event successfully sent to channel %q", channelID)
 	}
 
-	return nil
+	return errs.ErrorOrNil()
 }
 
 // SendMessage sends message to Discord channel.
 // Context is not supported by client: See https://github.com/bwmarrin/discordgo/issues/752.
 func (b *Discord) SendMessage(_ context.Context, msg string) error {
-	var errs error
+	errs := multierror.New()
 	for _, channel := range b.getChannels() {
 		channelID := channel.ID
 		b.log.Debugf(">> Sending message to channel %q: %+v", channelID, msg)
@@ -167,7 +167,7 @@ func (b *Discord) SendMessage(_ context.Context, msg string) error {
 		b.log.Debugf("Message successfully sent to channel %q", channelID)
 	}
 
-	return errs
+	return errs.ErrorOrNil()
 }
 
 // IntegrationName describes the integration name.

--- a/pkg/bot/discord_fmt.go
+++ b/pkg/bot/discord_fmt.go
@@ -10,10 +10,10 @@ import (
 	formatx "github.com/kubeshop/botkube/pkg/format"
 )
 
-func (b *Discord) formatMessage(event events.Event, notification config.Notification) discordgo.MessageSend {
+func (b *Discord) formatMessage(event events.Event) discordgo.MessageSend {
 	var messageEmbed discordgo.MessageEmbed
 
-	switch notification.Type {
+	switch b.notification.Type {
 	case config.LongNotification:
 		// generate Long notification message
 		messageEmbed = b.longNotification(event)

--- a/pkg/bot/discord_test.go
+++ b/pkg/bot/discord_test.go
@@ -1,0 +1,57 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscord_FindAndTrimBotMention(t *testing.T) {
+	/// given
+	botID := "976786722706821120"
+	testCases := []struct {
+		Name               string
+		Input              string
+		ExpectedTrimmedMsg string
+		ExpectedFound      bool
+	}{
+		{
+			Name:               "Mention",
+			Input:              "<@976786722706821120> get pods",
+			ExpectedFound:      true,
+			ExpectedTrimmedMsg: " get pods",
+		},
+		{
+			Name:               "Nickname",
+			Input:              "<@!976786722706821120> get pods",
+			ExpectedFound:      true,
+			ExpectedTrimmedMsg: " get pods",
+		},
+		{
+			Name:          "Not at the beginning",
+			Input:         "Not at the beginning <@!976786722706821120> get pods",
+			ExpectedFound: false,
+		},
+		{
+			Name:          "Different mention",
+			Input:         "<@97678> get pods",
+			ExpectedFound: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			botMentionRegex, err := discordBotMentionRegex(botID)
+			require.NoError(t, err)
+			b := &Discord{botMentionRegex: botMentionRegex}
+
+			// when
+			actualTrimmedMsg, actualFound := b.findAndTrimBotMention(tc.Input)
+
+			// then
+			assert.Equal(t, tc.ExpectedFound, actualFound)
+			assert.Equal(t, tc.ExpectedTrimmedMsg, actualTrimmedMsg)
+		})
+	}
+}

--- a/pkg/bot/mattermost.go
+++ b/pkg/bot/mattermost.go
@@ -321,7 +321,7 @@ func (b *Mattermost) SendEvent(_ context.Context, event events.Event) error {
 	b.log.Debugf(">> Sending to Mattermost: %+v", event)
 	attachment := b.formatAttachments(event)
 
-	var errs error
+	errs := multierror.New()
 	for _, channelID := range b.getChannelsToNotify(event) {
 		post := &model.Post{
 			Props: map[string]interface{}{
@@ -339,7 +339,7 @@ func (b *Mattermost) SendEvent(_ context.Context, event events.Event) error {
 		b.log.Debugf("Event successfully sent to channel %q", post.ChannelId)
 	}
 
-	return errs
+	return errs.ErrorOrNil()
 }
 
 func (b *Mattermost) getChannelsToNotify(event events.Event) []string {
@@ -362,7 +362,7 @@ func (b *Mattermost) getChannelsToNotify(event events.Event) []string {
 
 // SendMessage sends message to Mattermost channel
 func (b *Mattermost) SendMessage(_ context.Context, msg string) error {
-	var errs error
+	errs := multierror.New()
 	for _, channel := range b.getChannels() {
 		channelID := channel.ID
 		b.log.Debugf(">> Sending message to channel %q: %+v", channelID, msg)
@@ -376,7 +376,7 @@ func (b *Mattermost) SendMessage(_ context.Context, msg string) error {
 
 		b.log.Debugf("Message successfully sent to channel %q", channelID)
 	}
-	return errs
+	return errs.ErrorOrNil()
 }
 
 func (b *Mattermost) findAndTrimBotMention(msg string) (string, bool) {

--- a/pkg/bot/mattermost.go
+++ b/pkg/bot/mattermost.go
@@ -2,11 +2,9 @@ package bot
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -15,6 +13,7 @@ import (
 
 	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/events"
+	"github.com/kubeshop/botkube/pkg/execute"
 	formatx "github.com/kubeshop/botkube/pkg/format"
 	"github.com/kubeshop/botkube/pkg/multierror"
 )
@@ -26,21 +25,14 @@ import (
 
 var _ Bot = &Mattermost{}
 
-// mmChannelType to find Mattermost channel type
-type mmChannelType string
-
-const (
-	mmChannelPrivate mmChannelType = "P"
-	mmChannelPublic  mmChannelType = "O"
-)
-
 const (
 	// WebSocketProtocol stores protocol initials for web socket
 	WebSocketProtocol = "ws://"
 	// WebSocketSecureProtocol stores protocol initials for web socket
 	WebSocketSecureProtocol = "wss://"
 
-	httpsScheme = "https"
+	httpsScheme                  = "https"
+	mattermostBotMentionRegexFmt = "^@(?i)%s"
 )
 
 // TODO:
@@ -52,19 +44,17 @@ type Mattermost struct {
 	log             logrus.FieldLogger
 	executorFactory ExecutorFactory
 	reporter        AnalyticsReporter
-	notifyMutex     sync.RWMutex
-	notify          bool
-
-	Notification     config.Notification
-	Token            string
-	BotName          string
-	TeamName         string
-	ChannelID        string
-	ServerURL        string
-	WebSocketURL     string
-	WSClient         *model.WebSocketClient
-	APIClient        *model.Client4
-	ExecutorBindings []string
+	notification    config.Notification
+	serverURL       string
+	botName         string
+	teamName        string
+	webSocketURL    string
+	wsClient        *model.WebSocketClient
+	apiClient       *model.Client4
+	channelsMutex   sync.RWMutex
+	channels        map[string]channelConfigByID
+	notifyMutex     sync.Mutex
+	botMentionRegex *regexp.Regexp
 }
 
 // mattermostMessage contains message details to execute command and send back the result
@@ -80,12 +70,15 @@ type mattermostMessage struct {
 }
 
 // NewMattermost creates a new Mattermost instance.
-func NewMattermost(log logrus.FieldLogger, c *config.Config, executorFactory ExecutorFactory, reporter AnalyticsReporter) (*Mattermost, error) {
-	mattermost := c.Communications.GetFirst().Mattermost
-
-	checkURL, err := url.Parse(mattermost.URL)
+func NewMattermost(log logrus.FieldLogger, cfg config.Mattermost, executorFactory ExecutorFactory, reporter AnalyticsReporter) (*Mattermost, error) {
+	botMentionRegex, err := mattermostBotMentionRegex(cfg.BotName)
 	if err != nil {
-		return nil, fmt.Errorf("while parsing Mattermost URL %q: %w", mattermost.URL, err)
+		return nil, err
+	}
+
+	checkURL, err := url.Parse(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("while parsing Mattermost URL %q: %w", cfg.URL, err)
 	}
 
 	// Create WebSocketClient and handle messages
@@ -94,32 +87,31 @@ func NewMattermost(log logrus.FieldLogger, c *config.Config, executorFactory Exe
 		webSocketURL = WebSocketSecureProtocol + checkURL.Host
 	}
 
-	client := model.NewAPIv4Client(mattermost.URL)
-	client.SetOAuthToken(mattermost.Token)
+	client := model.NewAPIv4Client(cfg.URL)
+	client.SetOAuthToken(cfg.Token)
 
-	botTeam, resp := client.GetTeamByName(mattermost.Team, "")
+	botTeam, resp := client.GetTeamByName(cfg.Team, "")
 	if resp.Error != nil {
-		return nil, resp.Error
+		return nil, fmt.Errorf("while getting team by name: %w", resp.Error)
 	}
-	channel, resp := client.GetChannelByName(mattermost.Channels.GetFirst().Name, botTeam.Id, "")
-	if resp.Error != nil {
-		return nil, resp.Error
+
+	channelsByIDCfg, err := mattermostChannelsCfgFrom(client, botTeam.Id, cfg.Channels)
+	if err != nil {
+		return nil, fmt.Errorf("while producing channels configuration map by ID: %w", err)
 	}
 
 	return &Mattermost{
-		log:              log,
-		executorFactory:  executorFactory,
-		reporter:         reporter,
-		notify:           true, // enabled by default
-		Notification:     mattermost.Notification,
-		ServerURL:        mattermost.URL,
-		BotName:          mattermost.BotName,
-		Token:            mattermost.Token,
-		TeamName:         mattermost.Team,
-		ChannelID:        channel.Id,
-		ExecutorBindings: mattermost.Channels.GetFirst().Bindings.Executors,
-		APIClient:        client,
-		WebSocketURL:     webSocketURL,
+		log:             log,
+		executorFactory: executorFactory,
+		reporter:        reporter,
+		notification:    cfg.Notification,
+		serverURL:       cfg.URL,
+		botName:         cfg.BotName,
+		teamName:        cfg.Team,
+		apiClient:       client,
+		webSocketURL:    webSocketURL,
+		channels:        channelsByIDCfg,
+		botMentionRegex: botMentionRegex,
 	}, nil
 }
 
@@ -130,7 +122,7 @@ func (b *Mattermost) Start(ctx context.Context) error {
 	// Check connection to Mattermost server
 	err := b.checkServerConnection()
 	if err != nil {
-		return fmt.Errorf("while pinging Mattermost server %q: %w", b.ServerURL, err)
+		return fmt.Errorf("while pinging Mattermost server %q: %w", b.serverURL, err)
 	}
 
 	err = b.reporter.ReportBotEnabled(b.IntegrationName())
@@ -149,7 +141,7 @@ func (b *Mattermost) Start(ctx context.Context) error {
 			return nil
 		default:
 			var appErr *model.AppError
-			b.WSClient, appErr = model.NewWebSocketClient4(b.WebSocketURL, b.APIClient.AuthToken)
+			b.wsClient, appErr = model.NewWebSocketClient4(b.webSocketURL, b.apiClient.AuthToken)
 			if appErr != nil {
 				return fmt.Errorf("while creating WebSocket connection: %w", appErr)
 			}
@@ -168,45 +160,53 @@ func (b *Mattermost) Type() config.IntegrationType {
 	return config.BotIntegrationType
 }
 
-// NotificationsEnabled returns current notification status.
-func (b *Mattermost) NotificationsEnabled() bool {
-	b.notifyMutex.RLock()
-	defer b.notifyMutex.RUnlock()
-	return b.notify
+// NotificationsEnabled returns current notification status for a given channel ID.
+func (b *Mattermost) NotificationsEnabled(channelID string) bool {
+	channel, exists := b.getChannels()[channelID]
+	if !exists {
+		return false
+	}
+
+	return channel.notify
 }
 
-// SetNotificationsEnabled sets a new notification status.
-func (b *Mattermost) SetNotificationsEnabled(enabled bool) error {
+// SetNotificationsEnabled sets a new notification status for a given channel ID.
+func (b *Mattermost) SetNotificationsEnabled(channelID string, enabled bool) error {
+	// avoid race conditions with using the setter concurrently, as we set whole map
 	b.notifyMutex.Lock()
 	defer b.notifyMutex.Unlock()
-	b.notify = enabled
+
+	channels := b.getChannels()
+	channel, exists := channels[channelID]
+	if !exists {
+		return execute.ErrNotificationsNotConfigured
+	}
+
+	channel.notify = enabled
+	channels[channelID] = channel
+	b.setChannels(channels)
+
 	return nil
 }
 
 // Check incoming message and take action
 func (mm *mattermostMessage) handleMessage(b *Mattermost) {
 	post := model.PostFromJson(strings.NewReader(mm.Event.Data["post"].(string)))
-	channelType := mmChannelType(mm.Event.Data["channel_type"].(string))
-	if channelType == mmChannelPrivate || channelType == mmChannelPublic {
-		// Message posted in a channel
-		// Serve only if starts with mention
-		if !strings.HasPrefix(strings.ToLower(post.Message), fmt.Sprintf("@%s ", strings.ToLower(b.BotName))) {
-			return
-		}
+
+	// Handle message only if starts with mention
+	trimmedMsg, found := b.findAndTrimBotMention(post.Message)
+	if !found {
+		b.log.Debugf("Ignoring message as it doesn't contain %q mention", b.botName)
+		return
 	}
+	mm.Request = trimmedMsg
 
-	// Check if message posted in authenticated channel
-	if mm.Event.Broadcast.ChannelId == b.ChannelID {
-		mm.IsAuthChannel = true
-	}
-	mm.log.Debugf("Received mattermost event: %+v", mm.Event.Data)
+	channelID := mm.Event.Broadcast.ChannelId
+	channel, exists := b.getChannels()[channelID]
+	mm.IsAuthChannel = exists
 
-	// remove @BotKube prefix if exists
-	r := regexp.MustCompile(`^(?i)@BotKube `)
-	mm.Request = r.ReplaceAllString(post.Message, ``)
-
-	e := mm.executorFactory.NewDefault(b.IntegrationName(), b, mm.IsAuthChannel, mm.Request)
-	mm.Response = e.Execute(b.ExecutorBindings)
+	e := mm.executorFactory.NewDefault(b.IntegrationName(), b, mm.IsAuthChannel, channelID, channel.Bindings.Executors, mm.Request)
+	mm.Response = e.Execute()
 	mm.sendMessage()
 }
 
@@ -240,12 +240,12 @@ func (mm mattermostMessage) sendMessage() {
 // Check if Mattermost server is reachable
 func (b *Mattermost) checkServerConnection() error {
 	// Check api connection
-	if _, resp := b.APIClient.GetOldClientConfig(""); resp.Error != nil {
+	if _, resp := b.apiClient.GetOldClientConfig(""); resp.Error != nil {
 		return resp.Error
 	}
 
 	// Get channel list
-	_, resp := b.APIClient.GetTeamByName(b.TeamName, "")
+	_, resp := b.apiClient.GetTeamByName(b.teamName, "")
 	if resp.Error != nil {
 		return resp.Error
 	}
@@ -254,34 +254,34 @@ func (b *Mattermost) checkServerConnection() error {
 
 // Check if team exists in Mattermost
 func (b *Mattermost) getTeam() *model.Team {
-	botTeam, resp := b.APIClient.GetTeamByName(b.TeamName, "")
+	botTeam, resp := b.apiClient.GetTeamByName(b.teamName, "")
 	if resp.Error != nil {
-		b.log.Fatalf("There was a problem finding Mattermost team %s. %s", b.TeamName, resp.Error)
+		b.log.Fatalf("There was a problem finding Mattermost team %s. %s", b.teamName, resp.Error)
 	}
 	return botTeam
 }
 
 // Check if BotKube user exists in Mattermost
 func (b *Mattermost) getUser() *model.User {
-	users, resp := b.APIClient.AutocompleteUsersInTeam(b.getTeam().Id, b.BotName, 1, "")
+	users, resp := b.apiClient.AutocompleteUsersInTeam(b.getTeam().Id, b.botName, 1, "")
 	if resp.Error != nil {
-		b.log.Fatalf("There was a problem finding Mattermost user %s. %s", b.BotName, resp.Error)
+		b.log.Fatalf("There was a problem finding Mattermost user %s. %s", b.botName, resp.Error)
 	}
 	return users.Users[0]
 }
 
 func (b *Mattermost) listen(ctx context.Context) {
-	b.WSClient.Listen()
-	defer b.WSClient.Close()
+	b.wsClient.Listen()
+	defer b.wsClient.Close()
 	for {
 		select {
 		case <-ctx.Done():
 			b.log.Info("Shutdown requested. Finishing...")
 			return
-		case event, ok := <-b.WSClient.EventChannel:
+		case event, ok := <-b.wsClient.EventChannel:
 			if !ok {
-				if b.WSClient.ListenError != nil {
-					b.log.Debugf("while listening on websocket connection: %s", b.WSClient.ListenError.Error())
+				if b.wsClient.ListenError != nil {
+					b.log.Debugf("while listening on websocket connection: %s", b.wsClient.ListenError.Error())
 				}
 
 				b.log.Info("Incoming events channel closed. Finishing...")
@@ -309,7 +309,7 @@ func (b *Mattermost) listen(ctx context.Context) {
 				executorFactory: b.executorFactory,
 				Event:           event,
 				IsAuthChannel:   false,
-				APIClient:       b.APIClient,
+				APIClient:       b.apiClient,
 			}
 			mm.handleMessage(b)
 		}
@@ -317,92 +317,113 @@ func (b *Mattermost) listen(ctx context.Context) {
 }
 
 // SendEvent sends event notification to Mattermost
-func (b *Mattermost) SendEvent(ctx context.Context, event events.Event) error {
-	if !b.notify {
-		b.log.Info("Notifications are disabled. Skipping event...")
-		return nil
-	}
-
+func (b *Mattermost) SendEvent(_ context.Context, event events.Event) error {
 	b.log.Debugf(">> Sending to Mattermost: %+v", event)
+	attachment := b.formatAttachments(event)
 
-	var fields []*model.SlackAttachmentField
-
-	switch b.Notification.Type {
-	case config.LongNotification:
-		fields = b.longNotification(event)
-	case config.ShortNotification:
-		fallthrough
-
-	default:
-		// set missing cluster name to event object
-		fields = b.shortNotification(event)
-	}
-
-	attachment := []*model.SlackAttachment{
-		{
-			Color:     attachmentColor[event.Level],
-			Title:     event.Title,
-			Fields:    fields,
-			Footer:    "BotKube",
-			Timestamp: json.Number(strconv.FormatInt(event.TimeStamp.Unix(), 10)),
-		},
-	}
-
-	targetChannel := event.Channel
-	if targetChannel == "" {
-		// empty value in event.channel sends notifications to default channel.
-		targetChannel = b.ChannelID
-	}
-	isDefaultChannel := targetChannel == b.ChannelID
-
-	post := &model.Post{
-		Props: map[string]interface{}{
-			"attachments": attachment,
-		},
-		ChannelId: targetChannel,
-	}
-
-	_, resp := b.APIClient.CreatePost(post)
-	if resp.Error != nil {
-		createPostWrappedErr := fmt.Errorf("while posting message to channel %q: %w", targetChannel, resp.Error)
-
-		if isDefaultChannel {
-			return createPostWrappedErr
+	var errs error
+	for _, channelID := range b.getChannelsToNotify(event) {
+		post := &model.Post{
+			Props: map[string]interface{}{
+				"attachments": attachment,
+			},
+			ChannelId: channelID,
 		}
 
-		// fallback to default channel
-
-		// send error message to default channel
-		msg := fmt.Sprintf("Unable to send message to channel %q: `%s`\n```add Botkube app to the channel %q\nMissed events follows below:```", targetChannel, resp.Error, targetChannel)
-		sendMessageErr := b.SendMessage(ctx, msg)
-		if sendMessageErr != nil {
-			return multierror.Append(createPostWrappedErr, sendMessageErr)
+		_, resp := b.apiClient.CreatePost(post)
+		if resp.Error != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while posting message to channel %q: %w", channelID, resp.Error))
+			continue
 		}
 
-		// sending missed event to default channel
-		// reset channel, so it will be defaulted
-		event.Channel = ""
-		sendEventErr := b.SendEvent(ctx, event)
-		if sendEventErr != nil {
-			return multierror.Append(createPostWrappedErr, sendEventErr)
-		}
-
-		return createPostWrappedErr
+		b.log.Debugf("Event successfully sent to channel %q", post.ChannelId)
 	}
 
-	b.log.Debugf("Event successfully sent to channel %q", post.ChannelId)
-	return nil
+	return errs
+}
+
+func (b *Mattermost) getChannelsToNotify(event events.Event) []string {
+	if event.Channel != "" {
+		return []string{event.Channel}
+	}
+
+	// TODO(https://github.com/kubeshop/botkube/issues/596): Support source bindings - filter events here or at source level and pass it every time via event property?
+	var channelsToNotify []string
+	for _, channelCfg := range b.getChannels() {
+		if !channelCfg.notify {
+			b.log.Info("Skipping notification for channel %q as notifications are disabled.", channelCfg.Identifier())
+			continue
+		}
+
+		channelsToNotify = append(channelsToNotify, channelCfg.Identifier())
+	}
+	return channelsToNotify
 }
 
 // SendMessage sends message to Mattermost channel
 func (b *Mattermost) SendMessage(_ context.Context, msg string) error {
-	post := &model.Post{
-		ChannelId: b.ChannelID,
-		Message:   msg,
+	var errs error
+	for _, channel := range b.getChannels() {
+		channelID := channel.ID
+		b.log.Debugf(">> Sending message to channel %q: %+v", channelID, msg)
+		post := &model.Post{
+			ChannelId: channelID,
+			Message:   msg,
+		}
+		if _, resp := b.apiClient.CreatePost(post); resp.Error != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while creating a post: %w", resp.Error))
+		}
+
+		b.log.Debugf("Message successfully sent to channel %q", channelID)
 	}
-	if _, resp := b.APIClient.CreatePost(post); resp.Error != nil {
-		return fmt.Errorf("while creating a post: %w", resp.Error)
+	return errs
+}
+
+func (b *Mattermost) findAndTrimBotMention(msg string) (string, bool) {
+	if !b.botMentionRegex.MatchString(msg) {
+		return "", false
 	}
 
-	return nil
+	return b.botMentionRegex.ReplaceAllString(msg, ""), true
+}
+
+func (b *Mattermost) getChannels() map[string]channelConfigByID {
+	b.channelsMutex.RLock()
+	defer b.channelsMutex.RUnlock()
+	return b.channels
+}
+
+func (b *Mattermost) setChannels(channels map[string]channelConfigByID) {
+	b.channelsMutex.Lock()
+	defer b.channelsMutex.Unlock()
+	b.channels = channels
+}
+
+func mattermostChannelsCfgFrom(client *model.Client4, teamID string, channelsCfg config.IdentifiableMap[config.ChannelBindingsByName]) (map[string]channelConfigByID, error) {
+	res := make(map[string]channelConfigByID)
+	for _, channCfg := range channelsCfg {
+		fetchedChannel, resp := client.GetChannelByName(channCfg.Identifier(), teamID, "")
+		if resp.Error != nil {
+			return nil, fmt.Errorf("while getting channel by name %q: %w", channCfg.Name, resp.Error)
+		}
+
+		res[fetchedChannel.Id] = channelConfigByID{
+			ChannelBindingsByID: config.ChannelBindingsByID{
+				ID:       fetchedChannel.Id,
+				Bindings: channCfg.Bindings,
+			},
+			notify: defaultNotifyValue,
+		}
+	}
+
+	return res, nil
+}
+
+func mattermostBotMentionRegex(botName string) (*regexp.Regexp, error) {
+	botMentionRegex, err := regexp.Compile(fmt.Sprintf(mattermostBotMentionRegexFmt, botName))
+	if err != nil {
+		return nil, fmt.Errorf("while compiling bot mention regex: %w", err)
+	}
+
+	return botMentionRegex, nil
 }

--- a/pkg/bot/mattermost_fmt.go
+++ b/pkg/bot/mattermost_fmt.go
@@ -1,11 +1,38 @@
 package bot
 
 import (
+	"encoding/json"
+	"strconv"
+
 	"github.com/mattermost/mattermost-server/v5/model"
 
+	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/events"
 	formatx "github.com/kubeshop/botkube/pkg/format"
 )
+
+func (b *Mattermost) formatAttachments(event events.Event) []*model.SlackAttachment {
+	var fields []*model.SlackAttachmentField
+	switch b.notification.Type {
+	case config.LongNotification:
+		fields = b.longNotification(event)
+	case config.ShortNotification:
+		fallthrough
+	default:
+		// set missing cluster name to the event object
+		fields = b.shortNotification(event)
+	}
+
+	return []*model.SlackAttachment{
+		{
+			Color:     attachmentColor[event.Level],
+			Title:     event.Title,
+			Fields:    fields,
+			Footer:    "BotKube",
+			Timestamp: json.Number(strconv.FormatInt(event.TimeStamp.Unix(), 10)),
+		},
+	}
+}
 
 func (b *Mattermost) longNotification(event events.Event) []*model.SlackAttachmentField {
 	fields := []*model.SlackAttachmentField{

--- a/pkg/bot/mattermost_test.go
+++ b/pkg/bot/mattermost_test.go
@@ -1,0 +1,64 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMattermost_FindAndTrimBotMention(t *testing.T) {
+	/// given
+	botName := "BotKube"
+	testCases := []struct {
+		Name               string
+		Input              string
+		ExpectedTrimmedMsg string
+		ExpectedFound      bool
+	}{
+		{
+			Name:               "Mention",
+			Input:              "@BotKube get pods",
+			ExpectedFound:      true,
+			ExpectedTrimmedMsg: " get pods",
+		},
+		{
+			Name:               "Lowercase",
+			Input:              "@botkube get pods",
+			ExpectedFound:      true,
+			ExpectedTrimmedMsg: " get pods",
+		},
+		{
+			Name:               "Yet another different casing",
+			Input:              "@BOTKUBE get pods",
+			ExpectedFound:      true,
+			ExpectedTrimmedMsg: " get pods",
+		},
+		{
+			Name:          "Not at the beginning",
+			Input:         "Not at the beginning @BotKube get pods",
+			ExpectedFound: false,
+		},
+		{
+			Name:          "Different mention",
+			Input:         "@bootkube get pods",
+			ExpectedFound: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			botMentionRegex, err := mattermostBotMentionRegex(botName)
+			require.NoError(t, err)
+			b := &Mattermost{botMentionRegex: botMentionRegex}
+			require.NoError(t, err)
+
+			// when
+			actualTrimmedMsg, actualFound := b.findAndTrimBotMention(tc.Input)
+
+			// then
+			assert.Equal(t, tc.ExpectedFound, actualFound)
+			assert.Equal(t, tc.ExpectedTrimmedMsg, actualTrimmedMsg)
+		})
+	}
+}

--- a/pkg/bot/slack.go
+++ b/pkg/bot/slack.go
@@ -275,7 +275,7 @@ func (b *Slack) SendEvent(ctx context.Context, event events.Event) error {
 	b.log.Debugf(">> Sending to Slack: %+v", event)
 	attachment := b.formatMessage(event)
 
-	var errs error
+	errs := multierror.New()
 	for _, channelName := range b.getChannelsToNotify(event) {
 		channelID, timestamp, err := b.client.PostMessageContext(ctx, channelName, slack.MsgOptionAttachments(attachment), slack.MsgOptionAsUser(true))
 		if err != nil {
@@ -286,7 +286,7 @@ func (b *Slack) SendEvent(ctx context.Context, event events.Event) error {
 		b.log.Debugf("Event successfully sent to channel %q (ID: %q) at %b", channelName, channelID, timestamp)
 	}
 
-	return errs
+	return errs.ErrorOrNil()
 }
 
 func (b *Slack) getChannelsToNotify(event events.Event) []string {
@@ -310,7 +310,7 @@ func (b *Slack) getChannelsToNotify(event events.Event) []string {
 
 // SendMessage sends message to slack channel
 func (b *Slack) SendMessage(ctx context.Context, msg string) error {
-	var errs error
+	errs := multierror.New()
 	for _, channel := range b.getChannels() {
 		channelName := channel.Name
 		b.log.Debugf(">> Sending message to channel %q: %+v", channelName, msg)
@@ -322,7 +322,7 @@ func (b *Slack) SendMessage(ctx context.Context, msg string) error {
 		b.log.Debugf("Message successfully sent to channel %b at %b", channelID, timestamp)
 	}
 
-	return errs
+	return errs.ErrorOrNil()
 }
 
 func (b *Slack) getChannels() map[string]channelConfigByName {

--- a/pkg/bot/slack.go
+++ b/pkg/bot/slack.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubeshop/botkube/internal/analytics"
 	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/events"
+	"github.com/kubeshop/botkube/pkg/execute"
 	formatx "github.com/kubeshop/botkube/pkg/format"
 	"github.com/kubeshop/botkube/pkg/multierror"
 )
@@ -23,10 +24,7 @@ import (
 
 var _ Bot = &Slack{}
 
-const (
-	sendFailureMessageFmt = "Unable to send message to channel `%s`: `%s`\n```add Botkube app to the channel %s\nMissed events follows below:```"
-	channelNotFoundCode   = "channel_not_found"
-)
+const slackBotMentionPrefixFmt = "<@%s>"
 
 var attachmentColor = map[config.Level]string{
 	config.Info:     "good",
@@ -41,14 +39,12 @@ type Slack struct {
 	log             logrus.FieldLogger
 	executorFactory ExecutorFactory
 	reporter        FatalErrorAnalyticsReporter
-	notifyMutex     sync.RWMutex
-	notify          bool
 	botID           string
-
-	Client           *slack.Client
-	Notification     config.Notification
-	ChannelName      string
-	ExecutorBindings []string
+	client          *slack.Client
+	notification    config.Notification
+	channelsMutex   sync.RWMutex
+	channels        map[string]channelConfigByName
+	notifyMutex     sync.Mutex
 }
 
 // slackMessage contains message details to execute command and send back the result
@@ -56,19 +52,16 @@ type slackMessage struct {
 	log             logrus.FieldLogger
 	executorFactory ExecutorFactory
 
-	Event         *slack.MessageEvent
-	BotID         string
-	Request       string
-	Response      string
-	IsAuthChannel bool
-	RTM           *slack.RTM
+	Event    *slack.MessageEvent
+	BotID    string
+	Request  string
+	Response string
+	RTM      *slack.RTM
 }
 
 // NewSlack creates a new Slack instance.
-func NewSlack(log logrus.FieldLogger, c *config.Config, executorFactory ExecutorFactory, reporter FatalErrorAnalyticsReporter) (*Slack, error) {
-	slackCfg := c.Communications.GetFirst().Slack
-
-	client := slack.New(slackCfg.Token)
+func NewSlack(log logrus.FieldLogger, cfg config.Slack, executorFactory ExecutorFactory, reporter FatalErrorAnalyticsReporter) (*Slack, error) {
+	client := slack.New(cfg.Token)
 
 	authResp, err := client.AuthTest()
 	if err != nil {
@@ -76,16 +69,19 @@ func NewSlack(log logrus.FieldLogger, c *config.Config, executorFactory Executor
 	}
 	botID := authResp.UserID
 
+	channels := slackChannelsConfigFrom(cfg.Channels)
+	if err != nil {
+		return nil, fmt.Errorf("while producing channels configuration map by ID: %w", err)
+	}
+
 	return &Slack{
-		log:              log,
-		executorFactory:  executorFactory,
-		reporter:         reporter,
-		notify:           true, // enabled by default
-		botID:            botID,
-		Client:           client,
-		Notification:     slackCfg.Notification,
-		ChannelName:      slackCfg.Channels.GetFirst().Name,
-		ExecutorBindings: slackCfg.Channels.GetFirst().Bindings.Executors,
+		log:             log,
+		executorFactory: executorFactory,
+		reporter:        reporter,
+		botID:           botID,
+		client:          client,
+		notification:    cfg.Notification,
+		channels:        channels,
 	}, nil
 }
 
@@ -93,7 +89,7 @@ func NewSlack(log logrus.FieldLogger, c *config.Config, executorFactory Executor
 func (b *Slack) Start(ctx context.Context) error {
 	b.log.Info("Starting bot")
 
-	rtm := b.Client.NewRTM()
+	rtm := b.client.NewRTM()
 	go func() {
 		defer analytics.ReportPanicIfOccurs(b.log, b.reporter)
 		rtm.ManageConnection()
@@ -172,48 +168,59 @@ func (b *Slack) IntegrationName() config.CommPlatformIntegration {
 	return config.SlackCommPlatformIntegration
 }
 
-// NotificationsEnabled returns current notification status.
-func (b *Slack) NotificationsEnabled() bool {
-	b.notifyMutex.RLock()
-	defer b.notifyMutex.RUnlock()
-	return b.notify
+// NotificationsEnabled returns current notification status for a given channel name.
+func (b *Slack) NotificationsEnabled(channelName string) bool {
+	channel, exists := b.getChannels()[channelName]
+	if !exists {
+		return false
+	}
+
+	return channel.notify
 }
 
-// SetNotificationsEnabled sets a new notification status.
-func (b *Slack) SetNotificationsEnabled(enabled bool) error {
+// SetNotificationsEnabled sets a new notification status for a given channel name.
+func (b *Slack) SetNotificationsEnabled(channelName string, enabled bool) error {
+	// avoid race conditions with using the setter concurrently, as we set whole map
 	b.notifyMutex.Lock()
 	defer b.notifyMutex.Unlock()
-	b.notify = enabled
+
+	channels := b.getChannels()
+	channel, exists := channels[channelName]
+	if !exists {
+		return execute.ErrNotificationsNotConfigured
+	}
+
+	channel.notify = enabled
+	channels[channelName] = channel
+	b.setChannels(channels)
+
 	return nil
 }
 
 func (sm *slackMessage) HandleMessage(b *Slack) error {
-	// Check if message posted in authenticated channel
-	info, err := b.Client.GetConversationInfo(sm.Event.Channel, true)
-	if err == nil {
-		if info.IsChannel || info.IsPrivate {
-			// Message posted in a channel
-			// Serve only if starts with mention
-			if !strings.HasPrefix(sm.Event.Text, "<@"+sm.BotID+">") {
-				sm.log.Debugf("Ignoring message as it doesn't contain %q prefix", sm.BotID)
-				return nil
-			}
-			// Serve only if current channel is in config
-			if b.ChannelName == info.Name {
-				sm.IsAuthChannel = true
-			}
-		}
-	}
-	// Serve only if current channel is in config
-	if b.ChannelName == sm.Event.Channel {
-		sm.IsAuthChannel = true
+	// Handle message only if it starts with bot mention
+	if !strings.HasPrefix(sm.Event.Text, fmt.Sprintf(slackBotMentionPrefixFmt, sm.BotID)) {
+		sm.log.Debugf("Ignoring message as it doesn't contain %q prefix", sm.BotID)
+		return nil
 	}
 
-	// Trim the @BotKube prefix
-	sm.Request = strings.TrimPrefix(sm.Event.Text, "<@"+sm.BotID+">")
+	// Unfortunately we need to do a call for channel name based on ID every time a message arrives.
+	// I wanted to query for channel IDs based on names and prepare a map in the `slackChannelsConfigFrom`,
+	// but unfortunately BotKube would need another scope (get all conversations).
+	// Keeping current way of doing this until we come up with a better idea.
+	channelID := sm.Event.Channel
+	info, err := b.client.GetConversationInfo(channelID, true)
+	if err != nil {
+		return fmt.Errorf("while getting conversation info: %w", err)
+	}
 
-	e := sm.executorFactory.NewDefault(b.IntegrationName(), b, sm.IsAuthChannel, sm.Request)
-	sm.Response = e.Execute(b.ExecutorBindings)
+	channel, isAuthChannel := b.getChannels()[info.Name]
+
+	// Trim the BotKube bot prefix
+	sm.Request = strings.TrimPrefix(sm.Event.Text, fmt.Sprintf(slackBotMentionPrefixFmt, sm.BotID))
+
+	e := sm.executorFactory.NewDefault(b.IntegrationName(), b, isAuthChannel, info.Name, channel.Bindings.Executors, sm.Request)
+	sm.Response = e.Execute()
 	err = sm.Send()
 	if err != nil {
 		return fmt.Errorf("while sending message: %w", err)
@@ -259,61 +266,79 @@ func (sm *slackMessage) Send() error {
 
 // SendEvent sends event notification to slack
 func (b *Slack) SendEvent(ctx context.Context, event events.Event) error {
-	if !b.notify {
-		b.log.Info("Notifications are disabled. Skipping event...")
-		return nil
-	}
+	b.log.Debugf(">> Sending to Slack: %+v", event)
+	attachment := b.formatMessage(event)
 
-	b.log.Debugf(">> Sending to slack: %+v", event)
-	attachment := b.formatMessage(event, b.Notification)
-
-	targetChannel := event.Channel
-	if targetChannel == "" {
-		// empty value in event.channel sends notifications to default channel.
-		targetChannel = b.ChannelName
-	}
-	isDefaultChannel := targetChannel == b.ChannelName
-
-	channelID, timestamp, err := b.Client.PostMessage(targetChannel, slack.MsgOptionAttachments(attachment), slack.MsgOptionAsUser(true))
-	if err != nil {
-		postMessageWrappedErr := fmt.Errorf("while posting message to channel %q: %w", targetChannel, err)
-
-		if isDefaultChannel || err.Error() != channelNotFoundCode {
-			return postMessageWrappedErr
+	var errs error
+	for _, channelName := range b.getChannelsToNotify(event) {
+		channelID, timestamp, err := b.client.PostMessageContext(ctx, channelName, slack.MsgOptionAttachments(attachment), slack.MsgOptionAsUser(true))
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while posting message to channel %q: %w", channelName, err))
+			continue
 		}
 
-		// channel not found, fallback to default channel
-
-		// send error message to default channel
-		msg := fmt.Sprintf(sendFailureMessageFmt, targetChannel, err.Error(), targetChannel)
-		sendMessageErr := b.SendMessage(ctx, msg)
-		if sendMessageErr != nil {
-			return multierror.Append(postMessageWrappedErr, sendMessageErr)
-		}
-
-		// sending missed event to default channel
-		// reset channel, so it will be defaulted
-		event.Channel = ""
-		sendEventErr := b.SendEvent(ctx, event)
-		if sendEventErr != nil {
-			return multierror.Append(postMessageWrappedErr, sendEventErr)
-		}
-
-		return postMessageWrappedErr
+		b.log.Debugf("Event successfully sent to channel %q (ID: %q) at %b", channelName, channelID, timestamp)
 	}
 
-	b.log.Debugf("Event successfully sent to channel %q at %b", channelID, timestamp)
-	return nil
+	return errs
+}
+
+func (b *Slack) getChannelsToNotify(event events.Event) []string {
+	// support custom event routing
+	if event.Channel != "" {
+		return []string{event.Channel}
+	}
+
+	// TODO(https://github.com/kubeshop/botkube/issues/596): Support source bindings - filter events here or at source level and pass it every time via event property?
+	var channelsToNotify []string
+	for _, channelCfg := range b.getChannels() {
+		if !channelCfg.notify {
+			b.log.Info("Skipping notification for channel %q as notifications are disabled.", channelCfg.Identifier())
+			continue
+		}
+
+		channelsToNotify = append(channelsToNotify, channelCfg.Identifier())
+	}
+	return channelsToNotify
 }
 
 // SendMessage sends message to slack channel
 func (b *Slack) SendMessage(ctx context.Context, msg string) error {
-	b.log.Debugf(">> Sending to slack: %+v", msg)
-	channelID, timestamp, err := b.Client.PostMessageContext(ctx, b.ChannelName, slack.MsgOptionText(msg, false), slack.MsgOptionAsUser(true))
-	if err != nil {
-		return fmt.Errorf("while sending Slack message to channel %q: %w", b.ChannelName, err)
+	var errs error
+	for _, channel := range b.getChannels() {
+		channelName := channel.Name
+		b.log.Debugf(">> Sending message to channel %q: %+v", channelName, msg)
+		channelID, timestamp, err := b.client.PostMessageContext(ctx, channelName, slack.MsgOptionText(msg, false), slack.MsgOptionAsUser(true))
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while sending Slack message to channel %q: %w", channelName, err))
+			continue
+		}
+		b.log.Debugf("Message successfully sent to channel %b at %b", channelID, timestamp)
 	}
 
-	b.log.Debugf("Message successfully sent to channel %b at %b", channelID, timestamp)
-	return nil
+	return errs
+}
+
+func (b *Slack) getChannels() map[string]channelConfigByName {
+	b.channelsMutex.RLock()
+	defer b.channelsMutex.RUnlock()
+	return b.channels
+}
+
+func (b *Slack) setChannels(channels map[string]channelConfigByName) {
+	b.channelsMutex.Lock()
+	defer b.channelsMutex.Unlock()
+	b.channels = channels
+}
+
+func slackChannelsConfigFrom(channelsCfg config.IdentifiableMap[config.ChannelBindingsByName]) map[string]channelConfigByName {
+	channels := make(map[string]channelConfigByName)
+	for _, channCfg := range channelsCfg {
+		channels[channCfg.Identifier()] = channelConfigByName{
+			ChannelBindingsByName: channCfg,
+			notify:                defaultNotifyValue,
+		}
+	}
+
+	return channels
 }

--- a/pkg/bot/slack_fmt.go
+++ b/pkg/bot/slack_fmt.go
@@ -12,16 +12,15 @@ import (
 	formatx "github.com/kubeshop/botkube/pkg/format"
 )
 
-func (b *Slack) formatMessage(event events.Event, notification config.Notification) (attachment slack.Attachment) {
-	switch notification.Type {
+func (b *Slack) formatMessage(event events.Event) slack.Attachment {
+	var attachment slack.Attachment
+
+	switch b.notification.Type {
 	case config.LongNotification:
 		attachment = b.longNotification(event)
-
 	case config.ShortNotification:
 		fallthrough
-
 	default:
-		// set missing cluster name to an event object
 		attachment = b.shortNotification(event)
 	}
 

--- a/pkg/bot/slack_test.go
+++ b/pkg/bot/slack_test.go
@@ -1,0 +1,52 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlack_FindAndTrimBotMention(t *testing.T) {
+	/// given
+	botName := "BotKube"
+	testCases := []struct {
+		Name               string
+		Input              string
+		ExpectedTrimmedMsg string
+		ExpectedFound      bool
+	}{
+		{
+			Name:               "Mention",
+			Input:              "<@BotKube> get pods",
+			ExpectedFound:      true,
+			ExpectedTrimmedMsg: " get pods",
+		},
+		{
+			Name:          "Not at the beginning",
+			Input:         "Not at the beginning <@BotKube> get pods",
+			ExpectedFound: false,
+		},
+		{
+			Name:          "Different mention",
+			Input:         "<@bootkube> get pods",
+			ExpectedFound: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			botMentionRegex, err := slackBotMentionRegex(botName)
+			require.NoError(t, err)
+			b := &Slack{botMentionRegex: botMentionRegex}
+			require.NoError(t, err)
+
+			// when
+			actualTrimmedMsg, actualFound := b.findAndTrimBotMention(tc.Input)
+
+			// then
+			assert.Equal(t, tc.ExpectedFound, actualFound)
+			assert.Equal(t, tc.ExpectedTrimmedMsg, actualTrimmedMsg)
+		})
+	}
+}

--- a/pkg/bot/teams.go
+++ b/pkg/bot/teams.go
@@ -316,7 +316,7 @@ func (b *Teams) SendEvent(ctx context.Context, event events.Event) error {
 	b.log.Debugf(">> Sending to Teams: %+v", event)
 	card := b.formatMessage(event, b.Notification)
 
-	var errs error
+	errs := multierror.New()
 	for _, convRef := range b.getConversationRefsToNotify() {
 		err := b.sendProactiveMessage(ctx, convRef, card)
 		if err != nil {
@@ -327,12 +327,12 @@ func (b *Teams) SendEvent(ctx context.Context, event events.Event) error {
 		b.log.Debugf("Event successfully sent to channel %q at %b", convRef.ChannelID)
 	}
 
-	return errs
+	return errs.ErrorOrNil()
 }
 
 // SendMessage sends message to MsTeams
 func (b *Teams) SendMessage(ctx context.Context, msg string) error {
-	var errs error
+	errs := multierror.New()
 	for _, convCfg := range b.getConversations() {
 		channelID := convCfg.ref.ChannelID
 
@@ -349,7 +349,7 @@ func (b *Teams) SendMessage(ctx context.Context, msg string) error {
 		b.log.Debugf("Message successfully sent to channel %q", channelID)
 	}
 
-	return errs
+	return errs.ErrorOrNil()
 }
 
 // IntegrationName describes the integration name.

--- a/pkg/bot/teams_test.go
+++ b/pkg/bot/teams_test.go
@@ -1,0 +1,49 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTeams_TrimBotMention(t *testing.T) {
+	/// given
+	botName := "BotKube"
+	testCases := []struct {
+		Name               string
+		Input              string
+		ExpectedTrimmedMsg string
+	}{
+		{
+			Name:               "Mention",
+			Input:              "<at>BotKube</at> get pods",
+			ExpectedTrimmedMsg: " get pods",
+		},
+		{
+			Name:               "Not at the beginning",
+			Input:              "Not at the beginning <at>BotKube</at> get pods",
+			ExpectedTrimmedMsg: "Not at the beginning <at>BotKube</at> get pods",
+		},
+		{
+			Name:               "Different mention",
+			Input:              "<at>bootkube</at> get pods",
+			ExpectedTrimmedMsg: "<at>bootkube</at> get pods",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			botMentionRegex, err := teamsBotMentionRegex(botName)
+			require.NoError(t, err)
+			b := &Teams{botMentionRegex: botMentionRegex}
+			require.NoError(t, err)
+
+			// when
+			actualTrimmedMsg := b.trimBotMention(tc.Input)
+
+			// then
+			assert.Equal(t, tc.ExpectedTrimmedMsg, actualTrimmedMsg)
+		})
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -158,12 +158,10 @@ func TestLoadedConfigValidation(t *testing.T) {
 			configFiles: nil,
 		},
 		{
-			// TODO(remove): https://github.com/kubeshop/botkube/issues/596
 			name: "empty executors and communications settings",
 			expErrMsg: heredoc.Doc(`
-				while validating loaded configuration: 2 errors occurred:
-					* Key: 'Config.Executors' Error:Field validation for 'Executors' failed on the 'min' tag
-					* Key: 'Config.Communications' Error:Field validation for 'Communications' failed on the 'eq' tag`),
+				while validating loaded configuration: 1 error occurred:
+					* Key: 'Config.Communications' Error:Field validation for 'Communications' failed on the 'min' tag`),
 			configFiles: []string{
 				testdataFile(t, "empty-executors-communications.yaml"),
 			},

--- a/pkg/config/testdata/TestLoadConfigSuccess/config-all.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config-all.yaml
@@ -34,14 +34,11 @@ communications: # req 1 elm.
       enabled: false
       appID: 'APPLICATION_ID'
       appPassword: 'APPLICATION_PASSWORD'
-      channels:
-        'alias':
-          name: 'TEAMS_CHANNEL_ID'
-          bindings:
-            executors:
-              - kubectl-read-only
-            sources:
-              - k8s-events
+      bindings:
+        executors:
+          - kubectl-read-only
+        sources:
+          - k8s-events
       notification:
         type: short
       port: 3978

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -320,14 +320,11 @@ communications:
             appPassword: APPLICATION_PASSWORD
             team: ""
             port: "3978"
-            channels:
-                alias:
-                    name: TEAMS_CHANNEL_ID
-                    bindings:
-                        sources:
-                            - k8s-events
-                        executors:
-                            - kubectl-read-only
+            bindings:
+                sources:
+                    - k8s-events
+                executors:
+                    - kubectl-read-only
             notification:
                 type: short
         webhook:

--- a/pkg/controller/notifier.go
+++ b/pkg/controller/notifier.go
@@ -16,6 +16,7 @@ type Notifier interface {
 
 	// SendMessage is used for notifying about BotKube start/stop listening, possible BotKube upgrades and other events.
 	// Some integrations may decide to ignore such messages and have SendMessage method no-op.
+	// TODO: Consider option per channel to turn on/off "announcements" (BotKube start/stop/upgrade notify/config change.
 	SendMessage(context.Context, string) error
 
 	// IntegrationName returns a name of a given communication platform.

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -21,7 +21,7 @@ type DefaultExecutorFactory struct {
 
 // Executor is an interface for processes to execute commands
 type Executor interface {
-	Execute(bindings []string) string
+	Execute() string
 }
 
 // AnalyticsReporter defines a reporter that collects analytics data.
@@ -54,7 +54,7 @@ func NewExecutorFactory(log logrus.FieldLogger, runCmdFn CommandRunnerFunc, cfg 
 }
 
 // NewDefault creates new Default Executor.
-func (f *DefaultExecutorFactory) NewDefault(platform config.CommPlatformIntegration, notifierHandler NotifierHandler, isAuthChannel bool, message string) Executor {
+func (f *DefaultExecutorFactory) NewDefault(platform config.CommPlatformIntegration, notifierHandler NotifierHandler, isAuthChannel bool, conversationID string, bindings []string, message string) Executor {
 	return &DefaultExecutor{
 		log:               f.log,
 		runCmdFn:          f.runCmdFn,
@@ -65,8 +65,10 @@ func (f *DefaultExecutorFactory) NewDefault(platform config.CommPlatformIntegrat
 		filterEngine:      f.filterEngine,
 
 		notifierHandler: notifierHandler,
-		IsAuthChannel:   isAuthChannel,
-		Message:         message,
-		Platform:        platform,
+		isAuthChannel:   isAuthChannel,
+		bindings:        bindings,
+		message:         message,
+		platform:        platform,
+		conversationID:  conversationID,
 	}
 }

--- a/pkg/sink/elasticsearch.go
+++ b/pkg/sink/elasticsearch.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/events"
+	"github.com/kubeshop/botkube/pkg/multierror"
 )
 
 var _ Sink = &Elasticsearch{}
@@ -40,14 +41,8 @@ const (
 type Elasticsearch struct {
 	log      logrus.FieldLogger
 	reporter AnalyticsReporter
-
-	ELSClient     *elastic.Client
-	Server        string
-	SkipTLSVerify bool
-	Index         string
-	Shards        int
-	Replicas      int
-	IndexType     string
+	client   *elastic.Client
+	indices  map[string]config.ELSIndex
 }
 
 // NewElasticsearch creates a new Elasticsearch instance.
@@ -113,13 +108,10 @@ func NewElasticsearch(log logrus.FieldLogger, c config.Elasticsearch, reporter A
 	}
 
 	esNotifier := &Elasticsearch{
-		log:       log,
-		reporter:  reporter,
-		ELSClient: elsClient,
-		Index:     c.Indices.GetFirst().Name,
-		IndexType: c.Indices.GetFirst().Type,
-		Shards:    c.Indices.GetFirst().Shards,
-		Replicas:  c.Indices.GetFirst().Replicas,
+		log:      log,
+		reporter: reporter,
+		client:   elsClient,
+		indices:  c.Indices,
 	}
 
 	err = reporter.ReportSinkEnabled(esNotifier.IntegrationName())
@@ -142,11 +134,11 @@ type index struct {
 	Replicas int `json:"number_of_replicas"`
 }
 
-func (e *Elasticsearch) flushIndex(ctx context.Context, event interface{}) error {
+func (e *Elasticsearch) flushIndex(ctx context.Context, indexCfg config.ELSIndex, event interface{}) error {
 	// Construct the ELS Index Name with timestamp suffix
-	indexName := e.Index + "-" + time.Now().Format(indexSuffixFormat)
+	indexName := indexCfg.Name + "-" + time.Now().Format(indexSuffixFormat)
 	// Create index if not exists
-	exists, err := e.ELSClient.IndexExists(indexName).Do(ctx)
+	exists, err := e.client.IndexExists(indexName).Do(ctx)
 	if err != nil {
 		return fmt.Errorf("while getting index: %w", err)
 	}
@@ -155,23 +147,23 @@ func (e *Elasticsearch) flushIndex(ctx context.Context, event interface{}) error
 		mapping := mapping{
 			Settings: settings{
 				index{
-					Shards:   e.Shards,
-					Replicas: e.Replicas,
+					Shards:   indexCfg.Shards,
+					Replicas: indexCfg.Replicas,
 				},
 			},
 		}
-		_, err := e.ELSClient.CreateIndex(indexName).BodyJson(mapping).Do(ctx)
+		_, err := e.client.CreateIndex(indexName).BodyJson(mapping).Do(ctx)
 		if err != nil {
 			return fmt.Errorf("while creating index: %w", err)
 		}
 	}
 
 	// Send event to els
-	_, err = e.ELSClient.Index().Index(indexName).Type(e.IndexType).BodyJson(event).Do(ctx)
+	_, err = e.client.Index().Index(indexName).Type(indexCfg.Type).BodyJson(event).Do(ctx)
 	if err != nil {
 		return fmt.Errorf("while posting data to ELS: %w", err)
 	}
-	_, err = e.ELSClient.Flush().Index(indexName).Do(ctx)
+	_, err = e.client.Flush().Index(indexName).Do(ctx)
 	if err != nil {
 		return fmt.Errorf("while flushing data in ELS: %w", err)
 	}
@@ -183,12 +175,19 @@ func (e *Elasticsearch) flushIndex(ctx context.Context, event interface{}) error
 func (e *Elasticsearch) SendEvent(ctx context.Context, event events.Event) (err error) {
 	e.log.Debugf(">> Sending to Elasticsearch: %+v", event)
 
-	// Create index if not exists
-	if err := e.flushIndex(ctx, event); err != nil {
-		return fmt.Errorf("while sending event to Elasticsearch: %w", err)
+	var errs error
+	// TODO(https://github.com/kubeshop/botkube/issues/596): Support source bindings - filter events here or at source level and pass it every time via event property?
+	for _, indexCfg := range e.indices {
+		err := e.flushIndex(ctx, indexCfg, event)
+		if err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("while sending event to Elasticsearch index %q: %w", indexCfg.Name, err))
+			continue
+		}
+
+		e.log.Debugf("Event successfully sent to Elasticsearch index %q", indexCfg.Name)
 	}
 
-	return nil
+	return errs
 }
 
 // SendMessage is no-op

--- a/pkg/sink/elasticsearch.go
+++ b/pkg/sink/elasticsearch.go
@@ -175,7 +175,7 @@ func (e *Elasticsearch) flushIndex(ctx context.Context, indexCfg config.ELSIndex
 func (e *Elasticsearch) SendEvent(ctx context.Context, event events.Event) (err error) {
 	e.log.Debugf(">> Sending to Elasticsearch: %+v", event)
 
-	var errs error
+	errs := multierror.New()
 	// TODO(https://github.com/kubeshop/botkube/issues/596): Support source bindings - filter events here or at source level and pass it every time via event property?
 	for _, indexCfg := range e.indices {
 		err := e.flushIndex(ctx, indexCfg, event)
@@ -187,7 +187,7 @@ func (e *Elasticsearch) SendEvent(ctx context.Context, event events.Event) (err 
 		e.log.Debugf("Event successfully sent to Elasticsearch index %q", indexCfg.Name)
 	}
 
-	return errs
+	return errs.ErrorOrNil()
 }
 
 // SendMessage is no-op

--- a/test/README.md
+++ b/test/README.md
@@ -71,7 +71,7 @@ This directory contains E2E tests which are run against BotKube installed on Kub
     ```bash
     helm install botkube --namespace botkube ./helm/botkube --wait --create-namespace \
       -f ./helm/botkube/e2e-test-values.yaml \
-      --set communications.slack.token="${SLACK_BOT_TOKEN}" \
+      --set communications.default-group.slack.token="${SLACK_BOT_TOKEN}" \
       --set image.registry="${IMAGE_REGISTRY}" \
       --set image.repository="${IMAGE_REPOSITORY}" \
       --set image.tag="${IMAGE_TAG}" \

--- a/test/e2e/slack_test.go
+++ b/test/e2e/slack_test.go
@@ -380,7 +380,7 @@ func TestSlack(t *testing.T) {
 
 		t.Log("Stopping notifier...")
 		command := "notifier stop"
-		expectedMessage := codeBlock(fmt.Sprintf("Sure! I won't send you notifications from cluster %q here.", appCfg.ClusterName))
+		expectedMessage := codeBlock(fmt.Sprintf("Sure! I won't send you notifications from cluster '%s' here.", appCfg.ClusterName))
 
 		slackTester.PostMessageToBot(t, channel.Name, command)
 		err = slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
@@ -388,14 +388,14 @@ func TestSlack(t *testing.T) {
 
 		t.Log("Getting notifier status from second channel...")
 		command = "notifier status"
-		expectedMessage = codeBlock(fmt.Sprintf("Notifications from cluster %q are enabled here.", appCfg.ClusterName))
+		expectedMessage = codeBlock(fmt.Sprintf("Notifications from cluster '%s' are enabled here.", appCfg.ClusterName))
 		slackTester.PostMessageToBot(t, secondChannel.Name, command)
 		err = slackTester.WaitForLastMessageEqual(botUserID, secondChannel.ID, expectedMessage)
 		assert.NoError(t, err)
 
 		t.Log("Getting notifier status from first channel...")
 		command = "notifier status"
-		expectedMessage = codeBlock(fmt.Sprintf("Notifications from cluster %q are disabled here.", appCfg.ClusterName))
+		expectedMessage = codeBlock(fmt.Sprintf("Notifications from cluster '%s' are disabled here.", appCfg.ClusterName))
 		slackTester.PostMessageToBot(t, channel.Name, command)
 		err = slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
 		assert.NoError(t, err)
@@ -426,7 +426,7 @@ func TestSlack(t *testing.T) {
 
 		t.Log("Starting notifier")
 		command = "notifier start"
-		expectedMessage = codeBlock(fmt.Sprintf("Brace yourselves, incoming notifications from cluster %q.", appCfg.ClusterName))
+		expectedMessage = codeBlock(fmt.Sprintf("Brace yourselves, incoming notifications from cluster '%s'.", appCfg.ClusterName))
 		slackTester.PostMessageToBot(t, channel.Name, command)
 		err = slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
 		require.NoError(t, err)

--- a/test/e2e/slack_tester_test.go
+++ b/test/e2e/slack_tester_test.go
@@ -185,10 +185,10 @@ func (s *slackTester) WaitForMessagePosted(userID, channelID string, limitMessag
 }
 
 func (s *slackTester) WaitForMessagesPostedOnChannels(userID string, channelIDs []string, limitMessages int, msgAssertFn func(msg slack.Message) bool) error {
-	var errs error
+	errs := multierror.New()
 	for _, channelID := range channelIDs {
 		errs = multierror.Append(errs, s.WaitForMessagePosted(userID, channelID, limitMessages, msgAssertFn))
 	}
 
-	return errs
+	return errs.ErrorOrNil()
 }

--- a/test/e2e/slack_tester_test.go
+++ b/test/e2e/slack_tester_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/kubeshop/botkube/pkg/multierror"
 )
 
 const recentMessagesLimit = 5
@@ -135,6 +137,12 @@ func (s *slackTester) WaitForLastMessageEqual(userID, channelID string, expected
 	})
 }
 
+func (s *slackTester) WaitForLastMessageEqualOnChannels(userID string, channelIDs []string, expectedMsg string) error {
+	return s.WaitForMessagesPostedOnChannels(userID, channelIDs, 1, func(msg slack.Message) bool {
+		return msg.Text == expectedMsg
+	})
+}
+
 func (s *slackTester) WaitForMessagePosted(userID, channelID string, limitMessages int, msgAssertFn func(msg slack.Message) bool) error {
 	var fetchedMessages []slack.Message
 	var lastErr error
@@ -174,4 +182,13 @@ func (s *slackTester) WaitForMessagePosted(userID, channelID string, limitMessag
 	}
 
 	return nil
+}
+
+func (s *slackTester) WaitForMessagesPostedOnChannels(userID string, channelIDs []string, limitMessages int, msgAssertFn func(msg slack.Message) bool) error {
+	var errs error
+	for _, channelID := range channelIDs {
+		errs = multierror.Append(errs, s.WaitForMessagePosted(userID, channelID, limitMessages, msgAssertFn))
+	}
+
+	return errs
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Spawn multiple bots and sinks for each communication group
- Support multiple notification channels for all bots
- Support multiple indices for Elasticsearch sink
- Support toggling notifications on / off by channel for all bots
- Refactor trimming message prefix for all bots (+ add unit tests)
- Do not fall back to sending notifications to default channel (as there are no "default channel") when annotation config is wrong; instead, report an error
- Pass executor bindings to Executor
- Always return when running notifier commands (even if in not authorized channel)
- Add E2E tests
- Fix outdated E2E instructions
- Fix security vulnerability with yaml library

## Testing

I tested all integrations:

- [x] Slack
- [x] Discord
- [x] Mattermost
- [x] Teams
- [x] Elasticsearch
- [x] Webhook  

### Hints

#### Configuration

Use the following uber config to test multi-channel configuration:

```yaml
communications:
  'default-group':
    # Settings for Slack
    slack:
      enabled: true
      token: {{TOKEN}}
      channels:
        'default':
          name: botkube-test
          bindings:
            executors:
              - kubectl-read-only
            sources:
              - k8s-events
        'two':
          name: general
          bindings:
            executors:
              - kubectl-read-only
            sources:
              - k8s-events

    mattermost:
      enabled: false
      botName: botkube
      notiftype: short
      team: org
      token: {{TOKEN}}
      url: http://mattermost-team-edition.default:8065
      channels:
        'default':
          name: "general"
          bindings:
            executors:
              - kubectl-read-only
            sources:
              - k8s-events
        'test':
          name: "test"
          bindings:
            executors:
              - kubectl-read-only
            sources:
              - k8s-events
      notification:
        type: short                             # Change notification type short/long you want to receive. Type is optional and default is short.

    # Settings for MS Teams
    teams:
      enabled: false
      appID: "{{APP ID}}
      appPassword: "{{APP PASS}}"
      botName: "PKBotKube"
      port: 3978
      notification:
        type: short

    # Settings for Discord
    discord:
      enabled: true
      botID: "{{BOT ID}}
      token: "{{BOT TOKEN}}"
      channels:
        'default':
          id: "{{CHAN ID 1}}"
          bindings:
            executors:
              - kubectl-read-only
            sources:
              - k8s-events
        'test':
          id: "{{CHAN ID 2}}"
          bindings:
            executors:
              - kubectl-read-only
            sources:
              - k8s-events
      notification:
        type: short                             # Change notification type short/long you want to receive. Type is optional and default is short.

    elasticsearch:
      enabled: false
      server: http://elasticsearch-master.default:9200
      username: elastic
      password: changeme
      skipTLSVerify: false                      # toggle verification of TLS certificate of the Elastic nodes. Verification is skipped when option is true. Enable to connect to clusters with self-signed certs
      # ELS index settings
      indices:
        'botkube':
          name: botkube
          type: botkube-event
          shards: 1
          bindings:
            sources:
              - "k8s-events"
            # executors - not allowed in this case, ES is "sink" only.
        'botkube2':
          name: botkube2
          type: botkube-event2
          shards: 1
          bindings:
            sources:
              - "k8s-events"
            # executors - not allowed in this case, ES is "sink" only.
    # Settings for Webhook
    webhook:
      enabled: false
      url: http://echo-server.default

settings:
  clusterName: dev
executors:
  'kubectl-read-only':
    kubectl:
      enabled: true

image:
  repository: kubeshop/pr/botkube
  tag: '670-PR'
  pullPolicy: Always
e2eTest:
  image:
    repository: "kubeshop/pr/botkube-test"
    tag: "670-PR"
    pullPolicy: Always
```

You can duplicate the config for as `second-group` communication group as well. However, remember that such config doesn't make much sense, as separate communication groups are for different workspaces to avoid duplicate reponse. But I don't believe you'd like to create another test workspaces just to test these features 🙂 

```bash
helm install botkube --namespace botkube ./helm/botkube -f /tmp/values.yaml --wait
```

#### Webhook

You can install Echo server twice to test multiple communication groups:
```
helm install echo-server ealenn/echo-server --set application.logs.ignore.ping=true --set application.enable.environment=false --wait
helm install echo-server ealenn/echo-server --set application.logs.ignore.ping=true --set application.enable.environment=false --wait -n test --create-namespace

kubectl logs -l app.kubernetes.io/name=echo-server -f
kubectl logs -l app.kubernetes.io/name=echo-server -n test -f
```

## To do

- Integration tests
- Manual testing of all bots and sinks

## Related issue(s)

Resolves #666