### PR TITLE
Return executors enabled only in a given channel

### DIFF
--- a/helm/botkube/e2e-test-values.yaml
+++ b/helm/botkube/e2e-test-values.yaml
@@ -77,6 +77,15 @@ executors:
       commands:
         verbs: [ "get" ]
         resources: [ "deployments" ]
+  'kubectl-not-bound-to-any-channel':
+    kubectl:
+      enabled: true
+      namespaces:
+        include:
+          - all
+      commands:
+        verbs: [ "port-forward" ]
+        resources: [ "deployments" ]
 
 settings:
   clusterName: sample

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -17,6 +17,7 @@ type DefaultExecutorFactory struct {
 	analyticsReporter AnalyticsReporter
 	notifierExecutor  *NotifierExecutor
 	kubectlExecutor   *Kubectl
+	merger            *kubectl.Merger
 }
 
 // Executor is an interface for processes to execute commands
@@ -43,6 +44,7 @@ func NewExecutorFactory(log logrus.FieldLogger, runCmdFn CommandRunnerFunc, cfg 
 			cfg,
 			analyticsReporter,
 		),
+		merger: merger,
 		kubectlExecutor: NewKubectl(
 			log.WithField("component", "Kubectl Executor"),
 			cfg,
@@ -63,12 +65,12 @@ func (f *DefaultExecutorFactory) NewDefault(platform config.CommPlatformIntegrat
 		kubectlExecutor:   f.kubectlExecutor,
 		notifierExecutor:  f.notifierExecutor,
 		filterEngine:      f.filterEngine,
-
-		notifierHandler: notifierHandler,
-		isAuthChannel:   isAuthChannel,
-		bindings:        bindings,
-		message:         message,
-		platform:        platform,
-		conversationID:  conversationID,
+		merger:            f.merger,
+		notifierHandler:   notifierHandler,
+		isAuthChannel:     isAuthChannel,
+		bindings:          bindings,
+		message:           message,
+		platform:          platform,
+		conversationID:    conversationID,
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Return executors enabled only in a given channel. Previously, all enabled executors were displayed, even if a given channel didn't have suitable bindings for it.

Fix https://github.com/kubeshop/botkube/issues/668
