### PR TITLE
 Handle recommendations even if no such resources are configured for notifications

### DIFF
--- a/helm/botkube/e2e-test-values.yaml
+++ b/helm/botkube/e2e-test-values.yaml
@@ -25,6 +25,13 @@ communications:
 sources:
   'k8s-events':
     kubernetes:
+      recommendations:
+        pod:
+          noLatestImageTag: true
+          labelsSet: true
+        ingress:
+          backendServiceValid: false
+          tlsSecretValid: false
       resources:
         - name: v1/configmaps
           namespaces:
@@ -34,12 +41,6 @@ sources:
             - create
             - update
             - delete
-        - name: v1/pods
-          namespaces:
-            include:
-              - botkube
-          events:
-            - create
   'k8s-updates':
     kubernetes:
       resources:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -168,8 +168,28 @@ type Sources struct {
 
 // KubernetesSource contains configuration for Kubernetes sources.
 type KubernetesSource struct {
-	Recommendations Recommendations `yaml:"recommendations"`
-	Resources       []Resource      `yaml:"resources" validate:"dive"`
+	Recommendations Recommendations     `yaml:"recommendations"`
+	Resources       KubernetesResources `yaml:"resources" validate:"dive"`
+}
+
+// KubernetesResources contains configuration for Kubernetes resources.
+type KubernetesResources []Resource
+
+// IsAllowed checks if a given resource event is allowed according to the configuration.
+func (r *KubernetesResources) IsAllowed(resourceName, namespace string, eventType EventType) bool {
+	if r == nil || len(*r) == 0 {
+		return false
+	}
+
+	for _, resource := range *r {
+		if resource.Name == resourceName &&
+			resource.Events.Contains(eventType) &&
+			resource.Namespaces.IsAllowed(namespace) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Recommendations contains configuration for various recommendation insights.
@@ -209,10 +229,33 @@ type Analytics struct {
 
 // Resource contains resources to watch
 type Resource struct {
-	Name          string        `yaml:"name"`
-	Namespaces    Namespaces    `yaml:"namespaces"`
-	Events        []EventType   `yaml:"events"`
-	UpdateSetting UpdateSetting `yaml:"updateSetting"`
+	Name          string                   `yaml:"name"`
+	Namespaces    Namespaces               `yaml:"namespaces"`
+	Events        KubernetesResourceEvents `yaml:"events"`
+	UpdateSetting UpdateSetting            `yaml:"updateSetting"`
+}
+
+// KubernetesResourceEvents contains events to watch for a resource.
+type KubernetesResourceEvents []EventType
+
+// Contains checks if event is contained in the events slice.
+// If the slice contains AllEvent, then the result is true.
+func (e *KubernetesResourceEvents) Contains(eventType EventType) bool {
+	if e == nil {
+		return false
+	}
+
+	for _, event := range *e {
+		if event == AllEvent {
+			return true
+		}
+
+		if event == eventType {
+			return true
+		}
+	}
+
+	return false
 }
 
 // UpdateSetting struct defines updateEvent fields specification

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,7 +120,7 @@ const (
 
 // Config structure of configuration yaml file
 type Config struct {
-	Sources        IndexableMap[Sources]     `yaml:"sources" validate:"dive"`
+	Sources        map[string]Sources        `yaml:"sources" validate:"dive"`
 	Executors      map[string]Executors      `yaml:"executors" validate:"dive"`
 	Communications map[string]Communications `yaml:"communications"  validate:"required,min=1"`
 
@@ -541,22 +541,6 @@ func normalizeConfigEnvName(name string) string {
 	}
 
 	return strings.ReplaceAll(buff.String(), nestedFieldDelimiter, configDelimiter)
-}
-
-// IndexableMap provides an option to construct an indexable map.
-type IndexableMap[T any] map[string]T
-
-// GetFirst returns the first map element.
-// It's not deterministic if map has more than one element.
-// TODO(remove): https://github.com/kubeshop/botkube/issues/596
-func (t IndexableMap[T]) GetFirst() T {
-	var empty T
-
-	for _, v := range t {
-		return v
-	}
-
-	return empty
 }
 
 // IdentifiableMap provides an option to construct an indexable map for identifiable items.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -279,7 +279,7 @@ func (c *Controller) sendEvent(ctx context.Context, obj interface{}, resource st
 	}
 
 	if recommendation.ShouldIgnoreEvent(recCfg, c.conf.Sources, sources, event) {
-		c.log.Debugf("Skipping event because there are no recommendations: %#v", event)
+		c.log.Debugf("Skipping event as it is related to recommendation informers and doesn't have any recommendations: %#v", event)
 		return
 	}
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -39,6 +39,11 @@ type Event struct {
 	Warnings        []string
 }
 
+// HasRecommendationsOrWarnings returns true if event has recommendations or warnings.
+func (e *Event) HasRecommendationsOrWarnings() bool {
+	return len(e.Recommendations) > 0 || len(e.Warnings) > 0
+}
+
 // LevelMap is a map of event type to Level
 var LevelMap = map[config.EventType]config.Level{
 	config.CreateEvent:  config.Info,

--- a/pkg/ptr/ptr.go
+++ b/pkg/ptr/ptr.go
@@ -12,3 +12,12 @@ func ToBool(in *bool) bool {
 func Bool(in bool) *bool {
 	return &in
 }
+
+// IsTrue returns true if the given pointer is not nil and its value is true.
+func IsTrue(in *bool) bool {
+	if in == nil {
+		return false
+	}
+
+	return *in
+}

--- a/pkg/recommendation/export_test.go
+++ b/pkg/recommendation/export_test.go
@@ -3,3 +3,11 @@ package recommendation
 func (s *AggregatedRunner) Recommendations() []Recommendation {
 	return s.recommendations
 }
+
+func PodResourceName() string {
+	return podsResourceName
+}
+
+func IngressResourceName() string {
+	return ingressResourceName
+}

--- a/pkg/recommendation/factory_test.go
+++ b/pkg/recommendation/factory_test.go
@@ -64,18 +64,30 @@ func TestFactory_NewForSources(t *testing.T) {
 		"IngressBackendServiceValid",
 		"IngressTLSSecretValid",
 	}
+	expectedRecCfg := config.Recommendations{
+		Pod: config.PodRecommendations{
+			NoLatestImageTag: ptr.Bool(false),
+			LabelsSet:        ptr.Bool(true),
+		},
+		Ingress: config.IngressRecommendations{
+			BackendServiceValid: ptr.Bool(true),
+			TLSSecretValid:      ptr.Bool(true),
+		},
+	}
+
 	logger, _ := logtest.NewNullLogger()
 	factory := recommendation.NewFactory(logger, nil)
 
 	// when
-	res := factory.NewForSources(sources, mapKeyOrder)
-	actual := res.Recommendations()
+	recRunner, recCfg := factory.NewForSources(sources, mapKeyOrder)
+	actualRecomms := recRunner.Recommendations()
 
 	// then
-	require.Len(t, actual, len(expectedNames))
+	assert.Equal(t, expectedRecCfg, recCfg)
+	require.Len(t, actualRecomms, len(expectedNames))
 
 	var actualNames []string
-	for _, r := range actual {
+	for _, r := range actualRecomms {
 		actualNames = append(actualNames, r.Name())
 	}
 

--- a/pkg/recommendation/resource_events.go
+++ b/pkg/recommendation/resource_events.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	podsResourceName    = "v1/pods"
-	ingressResourceName = "networking.k8s.io/v1/ingress"
+	ingressResourceName = "networking.k8s.io/v1/ingresses"
 )
 
 // ResourceEventsForConfig returns the resource event map for a given source recommendations config.

--- a/pkg/recommendation/resource_events.go
+++ b/pkg/recommendation/resource_events.go
@@ -1,0 +1,64 @@
+package recommendation
+
+import (
+	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/events"
+	"github.com/kubeshop/botkube/pkg/ptr"
+)
+
+const (
+	podsResourceName    = "v1/pods"
+	ingressResourceName = "networking.k8s.io/v1/ingress"
+)
+
+// ResourceEventsForConfig returns the resource event map for a given source recommendations config.
+func ResourceEventsForConfig(recCfg config.Recommendations) map[string]config.EventType {
+	resNames := make(map[string]config.EventType)
+
+	if ptr.IsTrue(recCfg.Ingress.TLSSecretValid) || ptr.IsTrue(recCfg.Ingress.BackendServiceValid) {
+		resNames[ingressResourceName] = config.CreateEvent
+	}
+
+	if ptr.IsTrue(recCfg.Pod.NoLatestImageTag) || ptr.IsTrue(recCfg.Pod.LabelsSet) {
+		resNames[podsResourceName] = config.CreateEvent
+	}
+
+	return resNames
+}
+
+// ShouldIgnoreEvent returns true if user doesn't listen to events for a given resource, apart from enabled recommendations.
+func ShouldIgnoreEvent(recCfg config.Recommendations, sources map[string]config.Sources, sourceBindings []string, event events.Event) bool {
+	if event.HasRecommendationsOrWarnings() {
+		// shouldn't be skipped
+		return false
+	}
+
+	res := ResourceEventsForConfig(recCfg)
+	recommEventType, ok := res[event.Resource]
+	if !ok {
+		// this event doesn't relate to recommendations, finish early
+		return false
+	}
+
+	if event.Type != recommEventType {
+		// this event doesn't relate to recommendations, finish early
+		return false
+	}
+
+	// Resource + event type matches the ones configured from recommendation.
+	// Check if user listens to this event.
+	for _, key := range sourceBindings {
+		source, exists := sources[key]
+		if !exists {
+			continue
+		}
+
+		// sources are appended, so we need to check the first source that has a given resource with event
+		if source.Kubernetes.Resources.IsAllowed(event.Resource, event.Namespace, event.Type) {
+			return false
+		}
+	}
+
+	// The event is related to recommendations informers. No recommendations there, so it should be skipped.
+	return true
+}

--- a/pkg/recommendation/resource_events_test.go
+++ b/pkg/recommendation/resource_events_test.go
@@ -1,0 +1,258 @@
+package recommendation_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/events"
+	"github.com/kubeshop/botkube/pkg/ptr"
+	"github.com/kubeshop/botkube/pkg/recommendation"
+)
+
+func TestResourceEventsForConfig(t *testing.T) {
+	// given
+	testCases := []struct {
+		Name     string
+		RecCfg   config.Recommendations
+		Expected map[string]config.EventType
+	}{
+		{
+			Name: "Pod Labels Set",
+			RecCfg: config.Recommendations{
+				Pod: config.PodRecommendations{
+					LabelsSet: ptr.Bool(true),
+				},
+			},
+			Expected: map[string]config.EventType{
+				"v1/pods": config.CreateEvent,
+			},
+		},
+		{
+			Name: "Pod No Latest Image Tag",
+			RecCfg: config.Recommendations{
+				Pod: config.PodRecommendations{
+					NoLatestImageTag: ptr.Bool(true),
+				},
+			},
+			Expected: map[string]config.EventType{
+				"v1/pods": config.CreateEvent,
+			},
+		},
+		{
+			Name: "Ingress Backend Service Valid",
+			RecCfg: config.Recommendations{
+				Ingress: config.IngressRecommendations{
+					BackendServiceValid: ptr.Bool(true),
+				},
+			},
+			Expected: map[string]config.EventType{
+				"networking.k8s.io/v1/ingress": config.CreateEvent,
+			},
+		},
+		{
+			Name: "Ingress TLS Secret Valid",
+			RecCfg: config.Recommendations{
+				Ingress: config.IngressRecommendations{
+					TLSSecretValid: ptr.Bool(true),
+				},
+			},
+			Expected: map[string]config.EventType{
+				"networking.k8s.io/v1/ingress": config.CreateEvent,
+			},
+		},
+		{
+			Name: "All",
+			RecCfg: config.Recommendations{
+				Pod: config.PodRecommendations{
+					LabelsSet: ptr.Bool(true),
+				},
+				Ingress: config.IngressRecommendations{
+					TLSSecretValid: ptr.Bool(true),
+				},
+			},
+			Expected: map[string]config.EventType{
+				"v1/pods":                      config.CreateEvent,
+				"networking.k8s.io/v1/ingress": config.CreateEvent,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			// when
+			actual := recommendation.ResourceEventsForConfig(testCase.RecCfg)
+
+			// then
+			assert.Equal(t, testCase.Expected, actual)
+		})
+	}
+}
+
+func TestShouldIgnoreEvent(t *testing.T) {
+	// given
+	sources := fixSources()
+	testCases := []struct {
+		Name                string
+		InputConfig         config.Recommendations
+		InputSourceBindings []string
+		InputEvent          events.Event
+		Expected            bool
+	}{
+		{
+			Name: "Has recommendations",
+			InputEvent: events.Event{
+				Recommendations: []string{"message"},
+			},
+			Expected: false,
+		},
+		{
+			Name: "Has warnings",
+			InputEvent: events.Event{
+				Warnings: []string{"message"},
+			},
+			Expected: false,
+		},
+		{
+			Name:        "Different resource",
+			InputConfig: fixFullRecommendationConfig(),
+			InputEvent: events.Event{
+				Resource: "v1/deployments",
+				Type:     config.CreateEvent,
+			},
+			Expected: false,
+		},
+		{
+			Name:        "Different event",
+			InputConfig: fixFullRecommendationConfig(),
+			InputEvent: events.Event{
+				Resource: "v1/pods",
+				Type:     config.UpdateEvent,
+			},
+			Expected: false,
+		},
+		{
+			Name:        "User configured such event",
+			InputConfig: fixFullRecommendationConfig(),
+			InputEvent: events.Event{
+				Resource:  "v1/pods",
+				Namespace: "default",
+				Type:      config.CreateEvent,
+			},
+			InputSourceBindings: []string{"deployments", "pods"},
+			Expected:            false,
+		},
+		{
+			Name:        "User didn't configure such resource",
+			InputConfig: fixFullRecommendationConfig(),
+			InputEvent: events.Event{
+				Resource:  "networking.k8s.io/v1/ingress",
+				Namespace: "default",
+				Type:      config.CreateEvent,
+			},
+			InputSourceBindings: []string{"deployments", "pods"},
+			Expected:            true,
+		},
+		{
+			Name:        "User didn't configure such event - different namespace",
+			InputConfig: fixFullRecommendationConfig(),
+			InputEvent: events.Event{
+				Resource:  "v1/pods",
+				Namespace: "default",
+				Type:      config.CreateEvent,
+			},
+			InputSourceBindings: []string{"deployments", "pods-ns"},
+			Expected:            true,
+		},
+		{
+			Name:        "User didn't configure such event - different events",
+			InputConfig: fixFullRecommendationConfig(),
+			InputEvent: events.Event{
+				Resource:  "v1/pods",
+				Namespace: "default",
+				Type:      config.CreateEvent,
+			},
+			InputSourceBindings: []string{"deployments", "pods-update"},
+			Expected:            true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			// when
+			actual := recommendation.ShouldIgnoreEvent(testCase.InputConfig, sources, testCase.InputSourceBindings, testCase.InputEvent)
+
+			// then
+			assert.Equal(t, testCase.Expected, actual)
+		})
+	}
+}
+
+func fixFullRecommendationConfig() config.Recommendations {
+	return config.Recommendations{
+		Pod: config.PodRecommendations{
+			NoLatestImageTag: ptr.Bool(true),
+			LabelsSet:        ptr.Bool(true),
+		},
+		Ingress: config.IngressRecommendations{
+			BackendServiceValid: ptr.Bool(true),
+			TLSSecretValid:      ptr.Bool(true),
+		},
+	}
+}
+
+func fixSources() map[string]config.Sources {
+	return map[string]config.Sources{
+		"deployments": {
+			Kubernetes: config.KubernetesSource{
+				Resources: []config.Resource{
+					{
+						Name:       "v1/deployments",
+						Namespaces: config.Namespaces{},
+						Events:     []config.EventType{config.AllEvent},
+					},
+				},
+			},
+		},
+		"pods": {
+			Kubernetes: config.KubernetesSource{
+				Resources: []config.Resource{
+					{
+						Name: "v1/pods",
+						Namespaces: config.Namespaces{
+							Include: []string{".*"},
+						},
+						Events: []config.EventType{config.AllEvent},
+					},
+				},
+			},
+		},
+		"pods-ns": {
+			Kubernetes: config.KubernetesSource{
+				Resources: []config.Resource{
+					{
+						Name: "v1/pods",
+						Namespaces: config.Namespaces{
+							Include: []string{"kube-system"},
+						},
+						Events: []config.EventType{config.AllEvent},
+					},
+				},
+			},
+		},
+		"pods-update": {
+			Kubernetes: config.KubernetesSource{
+				Resources: []config.Resource{
+					{
+						Name: "v1/pods",
+						Namespaces: config.Namespaces{
+							Include: []string{".*"},
+						},
+						Events: []config.EventType{config.UpdateEvent},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/recommendation/resource_events_test.go
+++ b/pkg/recommendation/resource_events_test.go
@@ -26,7 +26,7 @@ func TestResourceEventsForConfig(t *testing.T) {
 				},
 			},
 			Expected: map[string]config.EventType{
-				"v1/pods": config.CreateEvent,
+				recommendation.PodResourceName(): config.CreateEvent,
 			},
 		},
 		{
@@ -37,7 +37,7 @@ func TestResourceEventsForConfig(t *testing.T) {
 				},
 			},
 			Expected: map[string]config.EventType{
-				"v1/pods": config.CreateEvent,
+				recommendation.PodResourceName(): config.CreateEvent,
 			},
 		},
 		{
@@ -48,7 +48,7 @@ func TestResourceEventsForConfig(t *testing.T) {
 				},
 			},
 			Expected: map[string]config.EventType{
-				"networking.k8s.io/v1/ingress": config.CreateEvent,
+				recommendation.IngressResourceName(): config.CreateEvent,
 			},
 		},
 		{
@@ -59,7 +59,7 @@ func TestResourceEventsForConfig(t *testing.T) {
 				},
 			},
 			Expected: map[string]config.EventType{
-				"networking.k8s.io/v1/ingress": config.CreateEvent,
+				recommendation.IngressResourceName(): config.CreateEvent,
 			},
 		},
 		{
@@ -73,8 +73,8 @@ func TestResourceEventsForConfig(t *testing.T) {
 				},
 			},
 			Expected: map[string]config.EventType{
-				"v1/pods":                      config.CreateEvent,
-				"networking.k8s.io/v1/ingress": config.CreateEvent,
+				recommendation.PodResourceName():     config.CreateEvent,
+				recommendation.IngressResourceName(): config.CreateEvent,
 			},
 		},
 	}
@@ -127,7 +127,7 @@ func TestShouldIgnoreEvent(t *testing.T) {
 			Name:        "Different event",
 			InputConfig: fixFullRecommendationConfig(),
 			InputEvent: events.Event{
-				Resource: "v1/pods",
+				Resource: recommendation.PodResourceName(),
 				Type:     config.UpdateEvent,
 			},
 			Expected: false,
@@ -136,7 +136,7 @@ func TestShouldIgnoreEvent(t *testing.T) {
 			Name:        "User configured such event",
 			InputConfig: fixFullRecommendationConfig(),
 			InputEvent: events.Event{
-				Resource:  "v1/pods",
+				Resource:  recommendation.PodResourceName(),
 				Namespace: "default",
 				Type:      config.CreateEvent,
 			},
@@ -147,7 +147,7 @@ func TestShouldIgnoreEvent(t *testing.T) {
 			Name:        "User didn't configure such resource",
 			InputConfig: fixFullRecommendationConfig(),
 			InputEvent: events.Event{
-				Resource:  "networking.k8s.io/v1/ingress",
+				Resource:  recommendation.IngressResourceName(),
 				Namespace: "default",
 				Type:      config.CreateEvent,
 			},
@@ -158,7 +158,7 @@ func TestShouldIgnoreEvent(t *testing.T) {
 			Name:        "User didn't configure such event - different namespace",
 			InputConfig: fixFullRecommendationConfig(),
 			InputEvent: events.Event{
-				Resource:  "v1/pods",
+				Resource:  recommendation.PodResourceName(),
 				Namespace: "default",
 				Type:      config.CreateEvent,
 			},
@@ -169,7 +169,7 @@ func TestShouldIgnoreEvent(t *testing.T) {
 			Name:        "User didn't configure such event - different events",
 			InputConfig: fixFullRecommendationConfig(),
 			InputEvent: events.Event{
-				Resource:  "v1/pods",
+				Resource:  recommendation.PodResourceName(),
 				Namespace: "default",
 				Type:      config.CreateEvent,
 			},
@@ -219,7 +219,7 @@ func fixSources() map[string]config.Sources {
 			Kubernetes: config.KubernetesSource{
 				Resources: []config.Resource{
 					{
-						Name: "v1/pods",
+						Name: recommendation.PodResourceName(),
 						Namespaces: config.Namespaces{
 							Include: []string{".*"},
 						},
@@ -232,7 +232,7 @@ func fixSources() map[string]config.Sources {
 			Kubernetes: config.KubernetesSource{
 				Resources: []config.Resource{
 					{
-						Name: "v1/pods",
+						Name: recommendation.PodResourceName(),
 						Namespaces: config.Namespaces{
 							Include: []string{"kube-system"},
 						},
@@ -245,7 +245,7 @@ func fixSources() map[string]config.Sources {
 			Kubernetes: config.KubernetesSource{
 				Resources: []config.Resource{
 					{
-						Name: "v1/pods",
+						Name: recommendation.PodResourceName(),
 						Namespaces: config.Namespaces{
 							Include: []string{".*"},
 						},

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/recommendation"
 )
 
 const eventsResource = "v1/events"
@@ -198,6 +199,14 @@ func mergeResourceEvents(sources config.IndexableMap[config.Sources]) mergedEven
 			for _, e := range flattenEvents(resource.Events) {
 				out[resource.Name][e] = struct{}{}
 			}
+		}
+
+		resForRecomms := recommendation.ResourceEventsForConfig(srcGroupCfg.Kubernetes.Recommendations)
+		for resourceName, eventType := range resForRecomms {
+			if _, ok := out[resourceName]; !ok {
+				out[resourceName] = make(map[config.EventType]struct{})
+			}
+			out[resourceName][eventType] = struct{}{}
 		}
 	}
 	return out

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -201,7 +201,6 @@ func mergeResourceEvents(sources map[string]config.Sources) mergedEvents {
 			}
 		}
 
-		// add resource events related to recommendations
 		resForRecomms := recommendation.ResourceEventsForConfig(srcGroupCfg.Kubernetes.Recommendations)
 		for resourceName, eventType := range resForRecomms {
 			if _, ok := out[resourceName]; !ok {
@@ -246,9 +245,8 @@ func setEventRouteForRecommendationsIfShould(routeMap *map[config.EventType][]ro
 		return
 	}
 
-	eventType, ok := resForRecomms[resourceName]
-	if !ok {
-		// no recommendation for this resource
+	eventType, found := resForRecomms[resourceName]
+	if !found {
 		return
 	}
 

--- a/pkg/sources/sources_test.go
+++ b/pkg/sources/sources_test.go
@@ -1,4 +1,4 @@
-package sources_test
+package sources
 
 import (
 	"testing"
@@ -8,11 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kubeshop/botkube/pkg/config"
-	"github.com/kubeshop/botkube/pkg/sources"
 )
 
 func TestRouter_GetBoundSources_UsesAddedBindings(t *testing.T) {
-	router := sources.NewRouter(nil, nil, nil)
+	router := NewRouter(nil, nil, nil)
 
 	router.AddAnyBindings(config.BotBindings{
 		Sources: []string{"k8s-events"},
@@ -34,14 +33,14 @@ func TestRouter_GetBoundSources_UsesAddedBindings(t *testing.T) {
 		},
 	})
 
-	candidates := config.IndexableMap[config.Sources]{
-		"k8s-events": config.Sources{
+	candidates := map[string]config.Sources{
+		"k8s-events": {
 			Kubernetes: config.KubernetesSource{},
 		},
-		"k8s-other": config.Sources{
+		"k8s-other": {
 			Kubernetes: config.KubernetesSource{},
 		},
-		"k8s-ignored": config.Sources{
+		"k8s-ignored": {
 			Kubernetes: config.KubernetesSource{},
 		},
 	}
@@ -57,14 +56,14 @@ func TestRouter_BuildTable_CreatesRoutesForBoundSources(t *testing.T) {
 	hasRoutes := "apps/v1/deployments"
 	hasNoRoutes := "v1/pods"
 
-	router := sources.NewRouter(nil, nil, logger)
+	router := NewRouter(nil, nil, logger)
 	router.AddAnyBindings(config.BotBindings{
 		Sources: []string{"k8s-events"},
 	})
 
 	cfg := &config.Config{
-		Sources: config.IndexableMap[config.Sources]{
-			"k8s-events": config.Sources{
+		Sources: map[string]config.Sources{
+			"k8s-events": {
 				Kubernetes: config.KubernetesSource{
 					Resources: []config.Resource{
 						{
@@ -86,7 +85,7 @@ func TestRouter_BuildTable_CreatesRoutesForBoundSources(t *testing.T) {
 					},
 				},
 			},
-			"k8s-ignored": config.Sources{
+			"k8s-ignored": {
 				Kubernetes: config.KubernetesSource{
 					Resources: []config.Resource{
 						{
@@ -114,4 +113,80 @@ func TestRouter_BuildTable_CreatesRoutesForBoundSources(t *testing.T) {
 	assert.Len(t, router.GetSourceRoutes(hasRoutes, config.DeleteEvent), 1)
 	assert.Len(t, router.GetSourceRoutes(hasRoutes, config.ErrorEvent), 1)
 	assert.Len(t, router.GetSourceRoutes(hasNoRoutes, config.ErrorEvent), 0)
+}
+
+func TestSetEventRouteForRecommendationsIfShould(t *testing.T) {
+	// given
+	resForRecomms := map[string]config.EventType{
+		"v1/pods":                      config.CreateEvent,
+		"networking.k8s.io/v1/ingress": config.CreateEvent,
+	}
+	resourceName := "v1/pods"
+	srcGroupName := "foo"
+
+	testCases := []struct {
+		Name     string
+		Input    map[config.EventType][]route
+		Expected map[config.EventType][]route
+	}{
+		{
+			Name: "Append",
+			Input: map[config.EventType][]route{
+				config.CreateEvent: {},
+				config.UpdateEvent: {{source: "foo"}, {source: "bar"}},
+			},
+			Expected: map[config.EventType][]route{
+				config.CreateEvent: {{source: "foo", namespaces: config.Namespaces{Include: []string{config.AllNamespaceIndicator}}}},
+				config.UpdateEvent: {{source: "foo"}, {source: "bar"}},
+			},
+		},
+		{
+			Name: "Override",
+			Input: map[config.EventType][]route{
+				config.CreateEvent: {
+					{
+						source: "bar",
+					},
+					{
+						source: "foo",
+						namespaces: config.Namespaces{
+							Include: []string{"foo", "bar"},
+							Exclude: []string{"default"},
+						},
+					},
+					{
+						source: "baz",
+					},
+				},
+				config.UpdateEvent: {{source: "foo"}, {source: "bar"}},
+			},
+			Expected: map[config.EventType][]route{
+				config.CreateEvent: {
+					{
+						source: "bar",
+					},
+					{
+						source: "foo",
+						namespaces: config.Namespaces{
+							Include: []string{config.AllNamespaceIndicator},
+						},
+					},
+					{
+						source: "baz",
+					},
+				},
+				config.UpdateEvent: {{source: "foo"}, {source: "bar"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			// when
+			setEventRouteForRecommendationsIfShould(&tc.Input, resForRecomms, srcGroupName, resourceName)
+
+			// then
+			assert.Equal(t, tc.Expected, tc.Input)
+		})
+	}
 }

--- a/pkg/sources/sources_test.go
+++ b/pkg/sources/sources_test.go
@@ -182,8 +182,10 @@ func TestSetEventRouteForRecommendationsIfShould(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
+			r := &Router{}
+
 			// when
-			setEventRouteForRecommendationsIfShould(&tc.Input, resForRecomms, srcGroupName, resourceName)
+			r.setEventRouteForRecommendationsIfShould(&tc.Input, resForRecomms, srcGroupName, resourceName)
 
 			// then
 			assert.Equal(t, tc.Expected, tc.Input)


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

-  Handle recommendations even if no such resources are configured for notifications

Now the recommendations are passed to all configured

**NOTE:** The recommendations don't have configurable namespaces. If they are enabled, BotKube notifies about Pod/Ingress resources from all namespaces if they contain any warning/recommendation.

## Testing

The changes has been tested in E2E tests as well as unit ones.

You can use sample config:
```yaml
sources:
  'k8s-events':

    kubernetes:

      recommendations:
        pod:
          noLatestImageTag: true
          labelsSet: true
        ingress:
          backendServiceValid: true
          tlsSecretValid: true

      resources: []

  'k8s-events2':

    kubernetes:

      recommendations:
        pod:
          noLatestImageTag: true
          labelsSet: true
        ingress:
          backendServiceValid: true
          tlsSecretValid: true

      resources:
        - name: v1/pods
          namespaces:
            include:
              - ".*"
          events:
            - create
            - delete
            - error

  'k8s-events3':

    kubernetes:

      recommendations:
        pod:
          noLatestImageTag: true
          labelsSet: true
        ingress:
          backendServiceValid: false
          tlsSecretValid: false

      resources:
        - name: v1/pods
          namespaces:
            include:
              - ".*"
          events:
            - delete
            - error
communications:
  'default-group':
    # Settings for Slack
    slack:
      enabled: true
      channels:
        'alias':
          name: 'botkube-test'
          bindings:
            executors:
              - 'kubectl-read-only'
            sources:
              - 'k8s-events'
        'alias2':
          name: 'general'
          bindings:
            executors:
              - 'kubectl-read-only'
            sources:
              - 'k8s-events2'
        'alias3':
          name: 'random'
          bindings:
            executors:
              - 'kubectl-read-only'
            sources:
              - 'k8s-events3'
      token: "{TOKEN}"
      notification:
        type: short
```

Apply recommendations file:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: failing
spec:
  containers:
  - name: nginx
    image: nginx
    command: ["foo"]
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ingress
spec:
  rules:
    - host: "foo"
      http:
        paths:
          - path: "/testpath"
            pathType: Exact
            backend:
              service:
                name: "foo"
                port:
                  number: 3001
```

Create and delete the resources:
```bash
kubectl create -f /tmp/recommendations.yaml
kubectl delete -f /tmp/recommendations.yaml
```
Observe the events.

## Related issue(s)

Resolves #684 
