### PR TITLE
Support Kubernetes event namespace filtering by another property for kubernetes source.

### DIFF
--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -31,113 +31,114 @@ Controller for the BotKube Slack app which helps you monitor your Kubernetes clu
 | [kubeconfig.base64Config](./values.yaml#L46) | string | `""` | A base64 encoded kubeconfig that will be stored in a Secret, mounted to the Pod, and specified in the KUBECONFIG environment variable. |
 | [kubeconfig.existingSecret](./values.yaml#L51) | string | `""` | A Secret containing a kubeconfig to use.  |
 | [sources](./values.yaml#L60) | object | See the `values.yaml` file for full object. | Map of sources. Source contains configuration for Kubernetes events and sending recommendations. The property name under `sources` object is an alias for a given configuration. You can define multiple sources configuration with different names. Key name is used as a binding reference.   |
-| [sources.k8s-events.kubernetes](./values.yaml#L64) | object | `{"recommendations":{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}},"resources":[{"events":["create","delete","error"],"name":"v1/pods","namespaces":{"include":[".*"]}},{"events":["create","delete","error"],"name":"v1/services","namespaces":{"include":[".*"]}},{"events":["create","update","delete","error"],"name":"apps/v1/deployments","namespaces":{"include":[".*"]},"updateSetting":{"fields":["spec.template.spec.containers[*].image","status.availableReplicas"],"includeDiff":true}},{"events":["create","update","delete","error"],"name":"apps/v1/statefulsets","namespaces":{"include":[".*"]},"updateSetting":{"fields":["spec.template.spec.containers[*].image","status.readyReplicas"],"includeDiff":true}},{"events":["create","delete","error"],"name":"networking.k8s.io/v1/ingresses","namespaces":{"include":[".*"]}},{"events":["create","delete","error"],"name":"v1/nodes","namespaces":{"include":[".*"]}},{"events":["create","delete","error"],"name":"v1/namespaces","namespaces":{"exclude":[null],"include":[".*"]}},{"events":["create","delete","error"],"name":"v1/persistentvolumes","namespaces":{"include":[".*"]}},{"events":["create","delete","error"],"name":"v1/persistentvolumeclaims","namespaces":{"include":[".*"]}},{"events":["create","delete","error"],"name":"v1/configmaps","namespaces":{"include":[".*"]}},{"events":["create","update","delete","error"],"name":"apps/v1/daemonsets","namespaces":{"include":[".*"]},"updateSetting":{"fields":["spec.template.spec.containers[*].image","status.numberReady"],"includeDiff":true}},{"events":["create","update","delete","error"],"name":"batch/v1/jobs","namespaces":{"include":[".*"]},"updateSetting":{"fields":["spec.template.spec.containers[*].image","status.conditions[*].type"],"includeDiff":true}},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/roles","namespaces":{"include":[".*"]}},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/rolebindings","namespaces":{"exclude":[null],"include":[".*"]}},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/clusterrolebindings","namespaces":{"include":[".*"]}},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/clusterroles","namespaces":{"include":[".*"]}}]}` | Describes Kubernetes source configuration. |
-| [sources.k8s-events.kubernetes.recommendations](./values.yaml#L67) | object | `{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}}` | Describes configuration for various recommendation insights. |
-| [sources.k8s-events.kubernetes.recommendations.pod](./values.yaml#L69) | object | `{"labelsSet":true,"noLatestImageTag":true}` | Recommendations for Pod Kubernetes resource. |
-| [sources.k8s-events.kubernetes.recommendations.pod.noLatestImageTag](./values.yaml#L71) | bool | `true` | If true, notifies about Pod containers that use `latest` tag for images. |
-| [sources.k8s-events.kubernetes.recommendations.pod.labelsSet](./values.yaml#L73) | bool | `true` | If true, notifies about Pod resources created without labels. |
-| [sources.k8s-events.kubernetes.recommendations.ingress](./values.yaml#L75) | object | `{"backendServiceValid":true,"tlsSecretValid":true}` | Recommendations for Ingress Kubernetes resource. |
-| [sources.k8s-events.kubernetes.recommendations.ingress.backendServiceValid](./values.yaml#L77) | bool | `true` | If true, notifies about Ingress resources with invalid backend service reference. |
-| [sources.k8s-events.kubernetes.recommendations.ingress.tlsSecretValid](./values.yaml#L79) | bool | `true` | If true, notifies about Ingress resources with invalid TLS secret reference. |
-| [sources.k8s-events.kubernetes.resources](./values.yaml#L83) | list | Watch all built-in K8s kinds. | Describes the Kubernetes resources you want to watch. |
-| [executors](./values.yaml#L271) | object | See the `values.yaml` file for full object. | Map of executors. Executor contains configuration for running `kubectl` commands. The property name under `executors` is an alias for a given configuration. You can define multiple executor configurations with different names. Key name is used as a binding reference.   |
-| [executors.kubectl-read-only.kubectl.namespaces.include](./values.yaml#L279) | list | `[".*"]` | List of allowed Kubernetes Namespaces for command execution. It can also contain a regex expressions:  `- ".*"` - to specify all Namespaces. |
-| [executors.kubectl-read-only.kubectl.namespaces.exclude](./values.yaml#L284) | list | `[]` | List of ignored Kubernetes Namespace. It can also contain a regex expressions:  `- "test-.*"` - to specify all Namespaces. |
-| [executors.kubectl-read-only.kubectl.enabled](./values.yaml#L286) | bool | `false` | If true, enables `kubectl` commands execution. |
-| [executors.kubectl-read-only.kubectl.commands.verbs](./values.yaml#L290) | list | `["api-resources","api-versions","cluster-info","describe","diff","explain","get","logs","top","auth"]` | Configures which `kubectl` methods are allowed. |
-| [executors.kubectl-read-only.kubectl.commands.resources](./values.yaml#L292) | list | `["deployments","pods","namespaces","daemonsets","statefulsets","storageclasses","nodes","configmaps"]` | Configures which K8s resource are allowed. |
-| [executors.kubectl-read-only.kubectl.defaultNamespace](./values.yaml#L294) | string | `"default"` | Configures the default Namespace for executing BotKube `kubectl` commands. If not set, uses the 'default'. |
-| [executors.kubectl-read-only.kubectl.restrictAccess](./values.yaml#L296) | bool | `false` | If true, enables commands execution from configured channel only. |
-| [existingCommunicationsSecretName](./values.yaml#L306) | string | `""` | Configures existing Secret with communication settings. It MUST be in the `botkube` Namespace.  |
-| [communications](./values.yaml#L313) | object | See the `values.yaml` file for full object. | Map of communication groups. Communication group contains settings for multiple communication platforms. The property name under `communications` object is an alias for a given configuration group. You can define multiple communication groups with different names.   |
-| [communications.default-group.slack.enabled](./values.yaml#L318) | bool | `false` | If true, enables Slack bot. |
-| [communications.default-group.slack.channels](./values.yaml#L322) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-events"]},"name":"SLACK_CHANNEL"}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
-| [communications.default-group.slack.channels.default.name](./values.yaml#L325) | string | `"SLACK_CHANNEL"` | Slack channel name without '#' prefix where you have added BotKube and want to receive notifications in. |
-| [communications.default-group.slack.channels.default.bindings.executors](./values.yaml#L328) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
-| [communications.default-group.slack.channels.default.bindings.sources](./values.yaml#L331) | list | `["k8s-events"]` | Notification sources configuration for a given channel. |
-| [communications.default-group.slack.token](./values.yaml#L334) | string | `"SLACK_API_TOKEN"` | Slack token. |
-| [communications.default-group.slack.notification.type](./values.yaml#L337) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
-| [communications.default-group.mattermost.enabled](./values.yaml#L342) | bool | `false` | If true, enables Mattermost bot. |
-| [communications.default-group.mattermost.botName](./values.yaml#L344) | string | `"BotKube"` | User in Mattermost which belongs the specified Personal Access token. |
-| [communications.default-group.mattermost.url](./values.yaml#L346) | string | `"MATTERMOST_SERVER_URL"` | The URL (including http/https schema) where Mattermost is running. e.g https://example.com:9243 |
-| [communications.default-group.mattermost.token](./values.yaml#L348) | string | `"MATTERMOST_TOKEN"` | Personal Access token generated by BotKube user. |
-| [communications.default-group.mattermost.team](./values.yaml#L350) | string | `"MATTERMOST_TEAM"` | The Mattermost Team name where BotKube is added. |
-| [communications.default-group.mattermost.channels](./values.yaml#L354) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-events"]},"name":"MATTERMOST_CHANNEL"}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
-| [communications.default-group.mattermost.channels.default.name](./values.yaml#L358) | string | `"MATTERMOST_CHANNEL"` | The Mattermost channel name for receiving BotKube alerts. The BotKube user needs to be added to it. |
-| [communications.default-group.mattermost.channels.default.bindings.executors](./values.yaml#L361) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
-| [communications.default-group.mattermost.channels.default.bindings.sources](./values.yaml#L364) | list | `["k8s-events"]` | Notification sources configuration for a given channel. |
-| [communications.default-group.mattermost.notification.type](./values.yaml#L368) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
-| [communications.default-group.teams.enabled](./values.yaml#L373) | bool | `false` | If true, enables MS Teams bot. |
-| [communications.default-group.teams.botName](./values.yaml#L375) | string | `"BotKube"` | The Bot name set while registering Bot to MS Teams. |
-| [communications.default-group.teams.appID](./values.yaml#L377) | string | `"APPLICATION_ID"` | The BotKube application ID generated while registering Bot to MS Teams. |
-| [communications.default-group.teams.appPassword](./values.yaml#L379) | string | `"APPLICATION_PASSWORD"` | The BotKube application password generated while registering Bot to MS Teams. |
-| [communications.default-group.teams.bindings.executors](./values.yaml#L382) | list | `["kubectl-read-only"]` | Executor bindings apply to all MS Teams channels where BotKube has access to. |
-| [communications.default-group.teams.bindings.sources](./values.yaml#L385) | list | `["k8s-events"]` | Source bindings apply to all channels which have notification turned on with `@BotKube notifier start` command. |
-| [communications.default-group.teams.messagePath](./values.yaml#L388) | string | `"/bots/teams"` | The path in endpoint URL provided while registering BotKube to MS Teams. |
-| [communications.default-group.teams.notification.type](./values.yaml#L391) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
-| [communications.default-group.teams.port](./values.yaml#L393) | int | `3978` | The Service port for bot endpoint on BotKube container. |
-| [communications.default-group.discord.enabled](./values.yaml#L398) | bool | `false` | If true, enables Discord bot. |
-| [communications.default-group.discord.token](./values.yaml#L400) | string | `"DISCORD_TOKEN"` | BotKube Bot Token. |
-| [communications.default-group.discord.botID](./values.yaml#L402) | string | `"DISCORD_BOT_ID"` | BotKube Application Client ID. |
-| [communications.default-group.discord.channels](./values.yaml#L406) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-events"]},"id":"DISCORD_CHANNEL_ID"}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
-| [communications.default-group.discord.channels.default.id](./values.yaml#L410) | string | `"DISCORD_CHANNEL_ID"` | Discord channel ID for receiving BotKube alerts. The BotKube user needs to be added to it. |
-| [communications.default-group.discord.channels.default.bindings.executors](./values.yaml#L413) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
-| [communications.default-group.discord.channels.default.bindings.sources](./values.yaml#L416) | list | `["k8s-events"]` | Notification sources configuration for a given channel. |
-| [communications.default-group.discord.notification.type](./values.yaml#L420) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
-| [communications.default-group.elasticsearch.enabled](./values.yaml#L425) | bool | `false` | If true, enables Elasticsearch. |
-| [communications.default-group.elasticsearch.awsSigning.enabled](./values.yaml#L429) | bool | `false` | If true, enables awsSigning using IAM for Elasticsearch hosted on AWS. Make sure AWS environment variables are set. [Ref doc](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html). |
-| [communications.default-group.elasticsearch.awsSigning.awsRegion](./values.yaml#L431) | string | `"us-east-1"` | AWS region where Elasticsearch is deployed. |
-| [communications.default-group.elasticsearch.awsSigning.roleArn](./values.yaml#L433) | string | `""` | AWS IAM Role arn to assume for credentials, use this only if you don't want to use the EC2 instance role or not running on AWS instance. |
-| [communications.default-group.elasticsearch.server](./values.yaml#L435) | string | `"ELASTICSEARCH_ADDRESS"` | The server URL, e.g https://example.com:9243 |
-| [communications.default-group.elasticsearch.username](./values.yaml#L437) | string | `"ELASTICSEARCH_USERNAME"` | Basic Auth username. |
-| [communications.default-group.elasticsearch.password](./values.yaml#L439) | string | `"ELASTICSEARCH_PASSWORD"` | Basic Auth password. |
-| [communications.default-group.elasticsearch.skipTLSVerify](./values.yaml#L442) | bool | `false` | If true, skips the verification of TLS certificate of the Elastic nodes. It's useful for clusters with self-signed certificates. |
-| [communications.default-group.elasticsearch.indices](./values.yaml#L446) | object | `{"default":{"bindings":{"sources":["k8s-events"]},"name":"botkube","replicas":0,"shards":1,"type":"botkube-event"}}` | Map of configured indices. The `indices` property name is an alias for a given configuration.   |
-| [communications.default-group.elasticsearch.indices.default.name](./values.yaml#L449) | string | `"botkube"` | Configures Elasticsearch index settings. |
-| [communications.default-group.elasticsearch.indices.default.bindings.sources](./values.yaml#L455) | list | `["k8s-events"]` | Notification sources configuration for a given index. |
-| [communications.default-group.webhook.enabled](./values.yaml#L461) | bool | `false` | If true, enables Webhook. |
-| [communications.default-group.webhook.url](./values.yaml#L463) | string | `"WEBHOOK_URL"` | The Webhook URL, e.g.: https://example.com:80 |
-| [communications.default-group.webhook.bindings.sources](./values.yaml#L466) | list | `["k8s-events"]` | Notification sources configuration for the webhook. |
-| [settings.clusterName](./values.yaml#L472) | string | `"not-configured"` | Cluster name to differentiate incoming messages. |
-| [settings.configWatcher](./values.yaml#L474) | bool | `true` | If true, restarts the BotKube Pod on config changes. |
-| [settings.upgradeNotifier](./values.yaml#L476) | bool | `true` | If true, notifies about new BotKube releases. |
-| [settings.log.level](./values.yaml#L480) | string | `"info"` | Sets one of the log levels. Allowed values: `info`, `warn`, `debug`, `error`, `fatal`, `panic`. |
-| [settings.log.disableColors](./values.yaml#L482) | bool | `false` | If true, disable ANSI colors in logging. |
-| [ssl.enabled](./values.yaml#L487) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
-| [ssl.existingSecretName](./values.yaml#L493) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
-| [ssl.cert](./values.yaml#L496) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
-| [service](./values.yaml#L499) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
-| [ingress](./values.yaml#L506) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
-| [serviceMonitor](./values.yaml#L517) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
-| [deployment.annotations](./values.yaml#L527) | object | `{}` | Extra annotations to pass to the BotKube Deployment. |
-| [extraAnnotations](./values.yaml#L534) | object | `{}` | Extra annotations to pass to the BotKube Pod. |
-| [extraLabels](./values.yaml#L536) | object | `{}` | Extra labels to pass to the BotKube Pod. |
-| [priorityClassName](./values.yaml#L538) | string | `""` | Priority class name for the BotKube Pod. |
-| [nameOverride](./values.yaml#L541) | string | `""` | Fully override "botkube.name" template. |
-| [fullnameOverride](./values.yaml#L543) | string | `""` | Fully override "botkube.fullname" template. |
-| [resources](./values.yaml#L549) | object | `{}` | The BotKube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
-| [extraEnv](./values.yaml#L561) | list | `[]` | Extra environment variables to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
-| [extraVolumes](./values.yaml#L573) | list | `[]` | Extra volumes to pass to the BotKube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
-| [extraVolumeMounts](./values.yaml#L588) | list | `[]` | Extra volume mounts to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
-| [nodeSelector](./values.yaml#L606) | object | `{}` | Node labels for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
-| [tolerations](./values.yaml#L610) | list | `[]` | Tolerations for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
-| [affinity](./values.yaml#L614) | object | `{}` | Affinity for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
-| [rbac](./values.yaml#L618) | object | `{"create":true,"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["get","watch","list"]}]}` | Role Based Access for BotKube Pod. [Ref doc](https://kubernetes.io/docs/admin/authorization/rbac/). |
-| [serviceAccount.create](./values.yaml#L627) | bool | `true` | If true, a ServiceAccount is automatically created. |
-| [serviceAccount.name](./values.yaml#L630) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
-| [serviceAccount.annotations](./values.yaml#L632) | object | `{}` | Extra annotations for the ServiceAccount. |
-| [extraObjects](./values.yaml#L635) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
-| [analytics.disable](./values.yaml#L663) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://botkube.io/privacy#privacy-policy). |
-| [e2eTest.image.registry](./values.yaml#L669) | string | `"ghcr.io"` | Test runner image registry. |
-| [e2eTest.image.repository](./values.yaml#L671) | string | `"kubeshop/botkube-test"` | Test runner image repository. |
-| [e2eTest.image.pullPolicy](./values.yaml#L673) | string | `"IfNotPresent"` | Test runner image pull policy. |
-| [e2eTest.image.tag](./values.yaml#L675) | string | `"v9.99.9-dev"` | Test runner image tag. Default tag is `appVersion` from Chart.yaml. |
-| [e2eTest.deployment](./values.yaml#L677) | object | `{"waitTimeout":"3m"}` | Configures BotKube Deployment related data. |
-| [e2eTest.slack.botName](./values.yaml#L682) | string | `"botkube"` | Name of the BotKube bot to interact with during the e2e tests. |
-| [e2eTest.slack.testerName](./values.yaml#L684) | string | `"botkube_tester"` | Name of the BotKube Tester bot that sends messages during the e2e tests. |
-| [e2eTest.slack.testerAppToken](./values.yaml#L686) | string | `""` | Slack tester application token that interacts with BotKube bot. |
-| [e2eTest.slack.additionalContextMessage](./values.yaml#L688) | string | `""` | Additional message that is sent by Tester. You can pass e.g. pull request number or source link where these tests are run from. |
-| [e2eTest.slack.messageWaitTimeout](./values.yaml#L690) | string | `"1m"` | Message wait timeout. It defines how long we wait to ensure that notification were not sent when disabled. |
+| [sources.k8s-events.kubernetes](./values.yaml#L64) | object | `{"namespaces":{"include":[".*"]},"recommendations":{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}},"resources":[{"events":["create","delete","error"],"name":"v1/pods"},{"events":["create","delete","error"],"name":"v1/services"},{"events":["create","update","delete","error"],"name":"apps/v1/deployments","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.availableReplicas"],"includeDiff":true}},{"events":["create","update","delete","error"],"name":"apps/v1/statefulsets","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.readyReplicas"],"includeDiff":true}},{"events":["create","delete","error"],"name":"networking.k8s.io/v1/ingresses"},{"events":["create","delete","error"],"name":"v1/nodes"},{"events":["create","delete","error"],"name":"v1/namespaces"},{"events":["create","delete","error"],"name":"v1/persistentvolumes"},{"events":["create","delete","error"],"name":"v1/persistentvolumeclaims"},{"events":["create","delete","error"],"name":"v1/configmaps"},{"events":["create","update","delete","error"],"name":"apps/v1/daemonsets","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.numberReady"],"includeDiff":true}},{"events":["create","update","delete","error"],"name":"batch/v1/jobs","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.conditions[*].type"],"includeDiff":true}},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/roles"},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/rolebindings"},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/clusterrolebindings"},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/clusterroles"}]}` | Describes Kubernetes source configuration. |
+| [sources.k8s-events.kubernetes.recommendations](./values.yaml#L66) | object | `{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}}` | Describes configuration for various recommendation insights. |
+| [sources.k8s-events.kubernetes.recommendations.pod](./values.yaml#L68) | object | `{"labelsSet":true,"noLatestImageTag":true}` | Recommendations for Pod Kubernetes resource. |
+| [sources.k8s-events.kubernetes.recommendations.pod.noLatestImageTag](./values.yaml#L70) | bool | `true` | If true, notifies about Pod containers that use `latest` tag for images. |
+| [sources.k8s-events.kubernetes.recommendations.pod.labelsSet](./values.yaml#L72) | bool | `true` | If true, notifies about Pod resources created without labels. |
+| [sources.k8s-events.kubernetes.recommendations.ingress](./values.yaml#L74) | object | `{"backendServiceValid":true,"tlsSecretValid":true}` | Recommendations for Ingress Kubernetes resource. |
+| [sources.k8s-events.kubernetes.recommendations.ingress.backendServiceValid](./values.yaml#L76) | bool | `true` | If true, notifies about Ingress resources with invalid backend service reference. |
+| [sources.k8s-events.kubernetes.recommendations.ingress.tlsSecretValid](./values.yaml#L78) | bool | `true` | If true, notifies about Ingress resources with invalid TLS secret reference. |
+| [sources.k8s-events.kubernetes.namespaces](./values.yaml#L83) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
+| [sources.k8s-events.kubernetes.resources](./values.yaml#L97) | list | Watch all built-in K8s kinds. | Describes the Kubernetes resources you want to watch. |
+| [executors](./values.yaml#L231) | object | See the `values.yaml` file for full object. | Map of executors. Executor contains configuration for running `kubectl` commands. The property name under `executors` is an alias for a given configuration. You can define multiple executor configurations with different names. Key name is used as a binding reference.   |
+| [executors.kubectl-read-only.kubectl.namespaces.include](./values.yaml#L239) | list | `[".*"]` | List of allowed Kubernetes Namespaces for command execution. It can also contain a regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [executors.kubectl-read-only.kubectl.namespaces.exclude](./values.yaml#L244) | list | `[]` | List of ignored Kubernetes Namespace. It can also contain a regex expressions:  `- "test-.*"` - to specify all Namespaces. |
+| [executors.kubectl-read-only.kubectl.enabled](./values.yaml#L246) | bool | `false` | If true, enables `kubectl` commands execution. |
+| [executors.kubectl-read-only.kubectl.commands.verbs](./values.yaml#L250) | list | `["api-resources","api-versions","cluster-info","describe","diff","explain","get","logs","top","auth"]` | Configures which `kubectl` methods are allowed. |
+| [executors.kubectl-read-only.kubectl.commands.resources](./values.yaml#L252) | list | `["deployments","pods","namespaces","daemonsets","statefulsets","storageclasses","nodes","configmaps"]` | Configures which K8s resource are allowed. |
+| [executors.kubectl-read-only.kubectl.defaultNamespace](./values.yaml#L254) | string | `"default"` | Configures the default Namespace for executing BotKube `kubectl` commands. If not set, uses the 'default'. |
+| [executors.kubectl-read-only.kubectl.restrictAccess](./values.yaml#L256) | bool | `false` | If true, enables commands execution from configured channel only. |
+| [existingCommunicationsSecretName](./values.yaml#L266) | string | `""` | Configures existing Secret with communication settings. It MUST be in the `botkube` Namespace.  |
+| [communications](./values.yaml#L273) | object | See the `values.yaml` file for full object. | Map of communication groups. Communication group contains settings for multiple communication platforms. The property name under `communications` object is an alias for a given configuration group. You can define multiple communication groups with different names.   |
+| [communications.default-group.slack.enabled](./values.yaml#L278) | bool | `false` | If true, enables Slack bot. |
+| [communications.default-group.slack.channels](./values.yaml#L282) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-events"]},"name":"SLACK_CHANNEL"}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
+| [communications.default-group.slack.channels.default.name](./values.yaml#L285) | string | `"SLACK_CHANNEL"` | Slack channel name without '#' prefix where you have added BotKube and want to receive notifications in. |
+| [communications.default-group.slack.channels.default.bindings.executors](./values.yaml#L288) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
+| [communications.default-group.slack.channels.default.bindings.sources](./values.yaml#L291) | list | `["k8s-events"]` | Notification sources configuration for a given channel. |
+| [communications.default-group.slack.token](./values.yaml#L294) | string | `"SLACK_API_TOKEN"` | Slack token. |
+| [communications.default-group.slack.notification.type](./values.yaml#L297) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
+| [communications.default-group.mattermost.enabled](./values.yaml#L302) | bool | `false` | If true, enables Mattermost bot. |
+| [communications.default-group.mattermost.botName](./values.yaml#L304) | string | `"BotKube"` | User in Mattermost which belongs the specified Personal Access token. |
+| [communications.default-group.mattermost.url](./values.yaml#L306) | string | `"MATTERMOST_SERVER_URL"` | The URL (including http/https schema) where Mattermost is running. e.g https://example.com:9243 |
+| [communications.default-group.mattermost.token](./values.yaml#L308) | string | `"MATTERMOST_TOKEN"` | Personal Access token generated by BotKube user. |
+| [communications.default-group.mattermost.team](./values.yaml#L310) | string | `"MATTERMOST_TEAM"` | The Mattermost Team name where BotKube is added. |
+| [communications.default-group.mattermost.channels](./values.yaml#L314) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-events"]},"name":"MATTERMOST_CHANNEL"}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
+| [communications.default-group.mattermost.channels.default.name](./values.yaml#L318) | string | `"MATTERMOST_CHANNEL"` | The Mattermost channel name for receiving BotKube alerts. The BotKube user needs to be added to it. |
+| [communications.default-group.mattermost.channels.default.bindings.executors](./values.yaml#L321) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
+| [communications.default-group.mattermost.channels.default.bindings.sources](./values.yaml#L324) | list | `["k8s-events"]` | Notification sources configuration for a given channel. |
+| [communications.default-group.mattermost.notification.type](./values.yaml#L328) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
+| [communications.default-group.teams.enabled](./values.yaml#L333) | bool | `false` | If true, enables MS Teams bot. |
+| [communications.default-group.teams.botName](./values.yaml#L335) | string | `"BotKube"` | The Bot name set while registering Bot to MS Teams. |
+| [communications.default-group.teams.appID](./values.yaml#L337) | string | `"APPLICATION_ID"` | The BotKube application ID generated while registering Bot to MS Teams. |
+| [communications.default-group.teams.appPassword](./values.yaml#L339) | string | `"APPLICATION_PASSWORD"` | The BotKube application password generated while registering Bot to MS Teams. |
+| [communications.default-group.teams.bindings.executors](./values.yaml#L342) | list | `["kubectl-read-only"]` | Executor bindings apply to all MS Teams channels where BotKube has access to. |
+| [communications.default-group.teams.bindings.sources](./values.yaml#L345) | list | `["k8s-events"]` | Source bindings apply to all channels which have notification turned on with `@BotKube notifier start` command. |
+| [communications.default-group.teams.messagePath](./values.yaml#L348) | string | `"/bots/teams"` | The path in endpoint URL provided while registering BotKube to MS Teams. |
+| [communications.default-group.teams.notification.type](./values.yaml#L351) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
+| [communications.default-group.teams.port](./values.yaml#L353) | int | `3978` | The Service port for bot endpoint on BotKube container. |
+| [communications.default-group.discord.enabled](./values.yaml#L358) | bool | `false` | If true, enables Discord bot. |
+| [communications.default-group.discord.token](./values.yaml#L360) | string | `"DISCORD_TOKEN"` | BotKube Bot Token. |
+| [communications.default-group.discord.botID](./values.yaml#L362) | string | `"DISCORD_BOT_ID"` | BotKube Application Client ID. |
+| [communications.default-group.discord.channels](./values.yaml#L366) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-events"]},"id":"DISCORD_CHANNEL_ID"}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
+| [communications.default-group.discord.channels.default.id](./values.yaml#L370) | string | `"DISCORD_CHANNEL_ID"` | Discord channel ID for receiving BotKube alerts. The BotKube user needs to be added to it. |
+| [communications.default-group.discord.channels.default.bindings.executors](./values.yaml#L373) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
+| [communications.default-group.discord.channels.default.bindings.sources](./values.yaml#L376) | list | `["k8s-events"]` | Notification sources configuration for a given channel. |
+| [communications.default-group.discord.notification.type](./values.yaml#L380) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
+| [communications.default-group.elasticsearch.enabled](./values.yaml#L385) | bool | `false` | If true, enables Elasticsearch. |
+| [communications.default-group.elasticsearch.awsSigning.enabled](./values.yaml#L389) | bool | `false` | If true, enables awsSigning using IAM for Elasticsearch hosted on AWS. Make sure AWS environment variables are set. [Ref doc](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html). |
+| [communications.default-group.elasticsearch.awsSigning.awsRegion](./values.yaml#L391) | string | `"us-east-1"` | AWS region where Elasticsearch is deployed. |
+| [communications.default-group.elasticsearch.awsSigning.roleArn](./values.yaml#L393) | string | `""` | AWS IAM Role arn to assume for credentials, use this only if you don't want to use the EC2 instance role or not running on AWS instance. |
+| [communications.default-group.elasticsearch.server](./values.yaml#L395) | string | `"ELASTICSEARCH_ADDRESS"` | The server URL, e.g https://example.com:9243 |
+| [communications.default-group.elasticsearch.username](./values.yaml#L397) | string | `"ELASTICSEARCH_USERNAME"` | Basic Auth username. |
+| [communications.default-group.elasticsearch.password](./values.yaml#L399) | string | `"ELASTICSEARCH_PASSWORD"` | Basic Auth password. |
+| [communications.default-group.elasticsearch.skipTLSVerify](./values.yaml#L402) | bool | `false` | If true, skips the verification of TLS certificate of the Elastic nodes. It's useful for clusters with self-signed certificates. |
+| [communications.default-group.elasticsearch.indices](./values.yaml#L406) | object | `{"default":{"bindings":{"sources":["k8s-events"]},"name":"botkube","replicas":0,"shards":1,"type":"botkube-event"}}` | Map of configured indices. The `indices` property name is an alias for a given configuration.   |
+| [communications.default-group.elasticsearch.indices.default.name](./values.yaml#L409) | string | `"botkube"` | Configures Elasticsearch index settings. |
+| [communications.default-group.elasticsearch.indices.default.bindings.sources](./values.yaml#L415) | list | `["k8s-events"]` | Notification sources configuration for a given index. |
+| [communications.default-group.webhook.enabled](./values.yaml#L421) | bool | `false` | If true, enables Webhook. |
+| [communications.default-group.webhook.url](./values.yaml#L423) | string | `"WEBHOOK_URL"` | The Webhook URL, e.g.: https://example.com:80 |
+| [communications.default-group.webhook.bindings.sources](./values.yaml#L426) | list | `["k8s-events"]` | Notification sources configuration for the webhook. |
+| [settings.clusterName](./values.yaml#L432) | string | `"not-configured"` | Cluster name to differentiate incoming messages. |
+| [settings.configWatcher](./values.yaml#L434) | bool | `true` | If true, restarts the BotKube Pod on config changes. |
+| [settings.upgradeNotifier](./values.yaml#L436) | bool | `true` | If true, notifies about new BotKube releases. |
+| [settings.log.level](./values.yaml#L440) | string | `"info"` | Sets one of the log levels. Allowed values: `info`, `warn`, `debug`, `error`, `fatal`, `panic`. |
+| [settings.log.disableColors](./values.yaml#L442) | bool | `false` | If true, disable ANSI colors in logging. |
+| [ssl.enabled](./values.yaml#L447) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
+| [ssl.existingSecretName](./values.yaml#L453) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
+| [ssl.cert](./values.yaml#L456) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
+| [service](./values.yaml#L459) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
+| [ingress](./values.yaml#L466) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
+| [serviceMonitor](./values.yaml#L477) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
+| [deployment.annotations](./values.yaml#L487) | object | `{}` | Extra annotations to pass to the BotKube Deployment. |
+| [extraAnnotations](./values.yaml#L494) | object | `{}` | Extra annotations to pass to the BotKube Pod. |
+| [extraLabels](./values.yaml#L496) | object | `{}` | Extra labels to pass to the BotKube Pod. |
+| [priorityClassName](./values.yaml#L498) | string | `""` | Priority class name for the BotKube Pod. |
+| [nameOverride](./values.yaml#L501) | string | `""` | Fully override "botkube.name" template. |
+| [fullnameOverride](./values.yaml#L503) | string | `""` | Fully override "botkube.fullname" template. |
+| [resources](./values.yaml#L509) | object | `{}` | The BotKube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
+| [extraEnv](./values.yaml#L521) | list | `[]` | Extra environment variables to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
+| [extraVolumes](./values.yaml#L533) | list | `[]` | Extra volumes to pass to the BotKube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
+| [extraVolumeMounts](./values.yaml#L548) | list | `[]` | Extra volume mounts to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
+| [nodeSelector](./values.yaml#L566) | object | `{}` | Node labels for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
+| [tolerations](./values.yaml#L570) | list | `[]` | Tolerations for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
+| [affinity](./values.yaml#L574) | object | `{}` | Affinity for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
+| [rbac](./values.yaml#L578) | object | `{"create":true,"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["get","watch","list"]}]}` | Role Based Access for BotKube Pod. [Ref doc](https://kubernetes.io/docs/admin/authorization/rbac/). |
+| [serviceAccount.create](./values.yaml#L587) | bool | `true` | If true, a ServiceAccount is automatically created. |
+| [serviceAccount.name](./values.yaml#L590) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
+| [serviceAccount.annotations](./values.yaml#L592) | object | `{}` | Extra annotations for the ServiceAccount. |
+| [extraObjects](./values.yaml#L595) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
+| [analytics.disable](./values.yaml#L623) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://botkube.io/privacy#privacy-policy). |
+| [e2eTest.image.registry](./values.yaml#L629) | string | `"ghcr.io"` | Test runner image registry. |
+| [e2eTest.image.repository](./values.yaml#L631) | string | `"kubeshop/botkube-test"` | Test runner image repository. |
+| [e2eTest.image.pullPolicy](./values.yaml#L633) | string | `"IfNotPresent"` | Test runner image pull policy. |
+| [e2eTest.image.tag](./values.yaml#L635) | string | `"v9.99.9-dev"` | Test runner image tag. Default tag is `appVersion` from Chart.yaml. |
+| [e2eTest.deployment](./values.yaml#L637) | object | `{"waitTimeout":"3m"}` | Configures BotKube Deployment related data. |
+| [e2eTest.slack.botName](./values.yaml#L642) | string | `"botkube"` | Name of the BotKube bot to interact with during the e2e tests. |
+| [e2eTest.slack.testerName](./values.yaml#L644) | string | `"botkube_tester"` | Name of the BotKube Tester bot that sends messages during the e2e tests. |
+| [e2eTest.slack.testerAppToken](./values.yaml#L646) | string | `""` | Slack tester application token that interacts with BotKube bot. |
+| [e2eTest.slack.additionalContextMessage](./values.yaml#L648) | string | `""` | Additional message that is sent by Tester. You can pass e.g. pull request number or source link where these tests are run from. |
+| [e2eTest.slack.messageWaitTimeout](./values.yaml#L650) | string | `"1m"` | Message wait timeout. It defines how long we wait to ensure that notification were not sent when disabled. |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/e2e-test-values.yaml
+++ b/helm/botkube/e2e-test-values.yaml
@@ -25,6 +25,9 @@ communications:
 sources:
   'k8s-events':
     kubernetes:
+      namespaces:
+        include:
+          - botkube
       recommendations:
         pod:
           noLatestImageTag: true
@@ -34,15 +37,15 @@ sources:
           tlsSecretValid: false
       resources:
         - name: v1/configmaps
-          namespaces:
-            include:
-              - botkube
           events:
             - create
             - update
             - delete
   'k8s-updates':
     kubernetes:
+      namespaces:
+        include:
+          - default
       resources:
         - name: v1/configmaps
           namespaces:

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -62,7 +62,6 @@ sources:
 
     # -- Describes Kubernetes source configuration.
     kubernetes:
-
       # -- Describes configuration for various recommendation insights.
       recommendations:
         # -- Recommendations for Pod Kubernetes resource.
@@ -78,37 +77,41 @@ sources:
           # -- If true, notifies about Ingress resources with invalid TLS secret reference.
           tlsSecretValid: true
 
+      # -- Describes namespaces for every Kubernetes resources you want to watch or exclude.
+      # These namespaces are applied to every resource specified in the resources list.
+      # However, every specified resource can override this by using its own namespaces object.
+      namespaces:
+        # Include contains a list of allowed Namespaces.
+        # It can also contain a regex expressions:
+        #  `- ".*"` - to specify all Namespaces.
+        include:
+          - ".*"
+        # Exclude contains a list of Namespaces to be ignored even if allowed by Include.
+        # It can also contain a regex expressions:
+        #  `- "test-.*"` - to specif all Namespaces with `test-` prefix.
+        # exclude: []
+
+
       # -- Describes the Kubernetes resources you want to watch.
       # @default -- Watch all built-in K8s kinds.
       resources:
         - name: v1/pods             # Name of the resource. Resource name must be in group/version/resource (G/V/R) format
                                     # resource name should be plural (e.g apps/v1/deployments, v1/pods)
-          namespaces:
-            # Include contains a list of allowed Namespaces.
-            # It can also contain a regex expressions:
-            #  `- ".*"` - to specify all Namespaces.
-            include:
-              - ".*"
-            # Exclude contains a list of Namespaces to be ignored even if allowed by Include.
-            # It can also contain a regex expressions:
-            #  `- "test-.*"` - to specif all Namespaces with `test-` prefix.
+
+        #  namespaces:             # Overrides 'source'.kubernetes.namespaces
+        #    include:
+        #      - ".*"
             # exclude: []
           events:                   # List of lifecycle events you want to receive, e.g create, update, delete, error OR all
             - create
             - delete
             - error
         - name: v1/services
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - delete
             - error
         - name: apps/v1/deployments
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - update
@@ -120,9 +123,6 @@ sources:
               - spec.template.spec.containers[*].image
               - status.availableReplicas
         - name: apps/v1/statefulsets
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - update
@@ -134,59 +134,36 @@ sources:
               - spec.template.spec.containers[*].image
               - status.readyReplicas
         - name: networking.k8s.io/v1/ingresses
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - delete
             - error
         - name: v1/nodes
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - delete
             - error
         - name: v1/namespaces
-          namespaces:
-            include:
-              - ".*"
-            exclude:
-              -
           events:
             - create
             - delete
             - error
         - name: v1/persistentvolumes
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - delete
             - error
         - name: v1/persistentvolumeclaims
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - delete
             - error
         - name: v1/configmaps
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - delete
             - error
         - name: apps/v1/daemonsets
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - update
@@ -198,9 +175,6 @@ sources:
               - spec.template.spec.containers[*].image
               - status.numberReady
         - name: batch/v1/jobs
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - update
@@ -212,35 +186,21 @@ sources:
               - spec.template.spec.containers[*].image
               - status.conditions[*].type
         - name: rbac.authorization.k8s.io/v1/roles
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - delete
             - error
         - name: rbac.authorization.k8s.io/v1/rolebindings
-          namespaces:
-            include:
-              - ".*"
-            exclude:
-              -
           events:
             - create
             - delete
             - error
         - name: rbac.authorization.k8s.io/v1/clusterrolebindings
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - delete
             - error
         - name: rbac.authorization.k8s.io/v1/clusterroles
-          namespaces:
-            include:
-              - ".*"
           events:
             - create
             - delete

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -170,6 +170,7 @@ type Sources struct {
 type KubernetesSource struct {
 	Recommendations Recommendations     `yaml:"recommendations"`
 	Resources       KubernetesResources `yaml:"resources" validate:"dive"`
+	Namespaces      Namespaces          `yaml:"namespaces"`
 }
 
 // KubernetesResources contains configuration for Kubernetes resources.
@@ -275,6 +276,11 @@ type Namespaces struct {
 	// It can also contain a regex expressions:
 	//  - "test-.*" - to specif all Namespaces with `test-` prefix.
 	Exclude []string `yaml:"exclude,omitempty"`
+}
+
+// IsConfigured checks whether the Namespace has any Include/Exclude configuration.
+func (n *Namespaces) IsConfigured() bool {
+	return len(n.Include) > 0 || len(n.Exclude) > 0
 }
 
 // IsAllowed checks if a given Namespace is allowed based on the config.

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -242,6 +242,8 @@ sources:
                   updateSetting:
                     fields: []
                     includeDiff: false
+            namespaces:
+                include: []
 executors:
     kubectl-read-only:
         kubectl:

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -58,34 +58,38 @@ func NewRouter(mapper meta.RESTMapper, dynamicCli dynamic.Interface, log logrus.
 
 // AddAnyBindingsByName adds source binding names
 // to dictate which source bindings the router should use.
-func (r *Router) AddAnyBindingsByName(c config.IdentifiableMap[config.ChannelBindingsByName]) {
+func (r *Router) AddAnyBindingsByName(c config.IdentifiableMap[config.ChannelBindingsByName]) *Router {
 	for _, byName := range c {
 		r.AddAnyBindings(byName.Bindings)
 	}
+	return r
 }
 
 // AddAnyBindingsByID adds source binding names
 // to dictate which source bindings the router should use.
-func (r *Router) AddAnyBindingsByID(c config.IdentifiableMap[config.ChannelBindingsByID]) {
+func (r *Router) AddAnyBindingsByID(c config.IdentifiableMap[config.ChannelBindingsByID]) *Router {
 	for _, byID := range c {
 		r.AddAnyBindings(byID.Bindings)
 	}
+	return r
 }
 
 // AddAnyBindings adds source binding names
 // to dictate which source bindings the router should use.
-func (r *Router) AddAnyBindings(b config.BotBindings) {
+func (r *Router) AddAnyBindings(b config.BotBindings) *Router {
 	for _, source := range b.Sources {
 		r.bindings[source] = struct{}{}
 	}
+	return r
 }
 
 // AddAnySinkBindings adds source bindings names
 // to dictate which source bindings the router should use.
-func (r *Router) AddAnySinkBindings(b config.SinkBindings) {
+func (r *Router) AddAnySinkBindings(b config.SinkBindings) *Router {
 	for _, source := range b.Sources {
 		r.bindings[source] = struct{}{}
 	}
+	return r
 }
 
 // GetBoundSources returns the Sources the router uses
@@ -221,7 +225,7 @@ func (r *Router) mergeEventRoutes(resource string, sources map[string]config.Sou
 					continue
 				}
 
-				namespaces := determineNamespaces(srcGroupCfg.Kubernetes.Namespaces, r.Namespaces)
+				namespaces := sourceOrResourceNamespaces(srcGroupCfg.Kubernetes.Namespaces, r.Namespaces)
 				route := route{source: srcGroupName, namespaces: namespaces}
 				if e == config.UpdateEvent {
 					route.updateSetting = config.UpdateSetting{
@@ -328,7 +332,9 @@ func flattenEvents(events []config.EventType) []config.EventType {
 	return out
 }
 
-func determineNamespaces(sourceNs, resourceNs config.Namespaces) config.Namespaces {
+// sourceOrResourceNamespaces returns the kubernetes source namespaces
+// unless the resource namespaces are configured.
+func sourceOrResourceNamespaces(sourceNs, resourceNs config.Namespaces) config.Namespaces {
 	if resourceNs.IsConfigured() {
 		return resourceNs
 	}

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -221,7 +221,8 @@ func (r *Router) mergeEventRoutes(resource string, sources map[string]config.Sou
 					continue
 				}
 
-				route := route{source: srcGroupName, namespaces: r.Namespaces}
+				namespaces := determineNamespaces(srcGroupCfg.Kubernetes.Namespaces, r.Namespaces)
+				route := route{source: srcGroupName, namespaces: namespaces}
 				if e == config.UpdateEvent {
 					route.updateSetting = config.UpdateSetting{
 						Fields:      r.UpdateSetting.Fields,
@@ -325,4 +326,11 @@ func flattenEvents(events []config.EventType) []config.EventType {
 		}
 	}
 	return out
+}
+
+func determineNamespaces(sourceNs, resourceNs config.Namespaces) config.Namespaces {
+	if resourceNs.IsConfigured() {
+		return resourceNs
+	}
+	return sourceNs
 }

--- a/pkg/sources/sources_test.go
+++ b/pkg/sources/sources_test.go
@@ -117,37 +117,81 @@ func TestRouter_BuildTable_CreatesRoutesForBoundSources(t *testing.T) {
 
 func TestRouter_BuildTable_CreatesRoutesWithNamespacesPresetFromKubernetesSource(t *testing.T) {
 	logger, _ := logtest.NewNullLogger()
-	router := NewRouter(nil, nil, logger)
-	router.AddAnyBindings(config.BotBindings{
-		Sources: []string{"k8s-events"},
-	})
 
-	cfg := &config.Config{
-		Sources: map[string]config.Sources{
-			"k8s-events": {
-				Kubernetes: config.KubernetesSource{
-					Namespaces: config.Namespaces{
-						Include: []string{"botkube"},
-						Exclude: []string{"default"},
-					},
-					Resources: []config.Resource{
-						{
-							Name: "apps/v1/deployments",
-							Events: []config.EventType{
-								config.CreateEvent,
+	testCases := []struct {
+		Name     string
+		Input    *config.Config
+		Expected config.Namespaces
+	}{
+		{
+			Name: "Use sources Namespaces",
+			Input: &config.Config{
+				Sources: map[string]config.Sources{
+					"k8s-events": {
+						Kubernetes: config.KubernetesSource{
+							Namespaces: config.Namespaces{
+								Include: []string{"botkube"},
+								Exclude: []string{"default"},
+							},
+							Resources: []config.Resource{
+								{
+									Name: "apps/v1/deployments",
+									Events: []config.EventType{
+										config.CreateEvent,
+									},
+								},
 							},
 						},
 					},
 				},
 			},
+			Expected: config.Namespaces{
+				Include: []string{"botkube"},
+				Exclude: []string{"default"},
+			},
+		},
+		{
+			Name: "Override sources Namespaces",
+			Input: &config.Config{
+				Sources: map[string]config.Sources{
+					"k8s-events": {
+						Kubernetes: config.KubernetesSource{
+							Namespaces: config.Namespaces{
+								Include: []string{"botkube"},
+								Exclude: []string{"default"},
+							},
+							Resources: []config.Resource{
+								{
+									Name: "apps/v1/deployments",
+									Namespaces: config.Namespaces{
+										Include: []string{".*"},
+									},
+									Events: []config.EventType{
+										config.CreateEvent,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Expected: config.Namespaces{
+				Include: []string{".*"},
+			},
 		},
 	}
 
-	router = router.BuildTable(cfg)
-	createRoutes := router.GetSourceRoutes("apps/v1/deployments", config.CreateEvent)
-	assert.Len(t, createRoutes, 1)
-	assert.ElementsMatch(t, []string{"botkube"}, createRoutes[0].namespaces.Include)
-	assert.ElementsMatch(t, []string{"default"}, createRoutes[0].namespaces.Exclude)
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			routes := NewRouter(nil, nil, logger).
+				AddAnyBindings(config.BotBindings{Sources: []string{"k8s-events"}}).
+				BuildTable(tc.Input).
+				GetSourceRoutes("apps/v1/deployments", config.CreateEvent)
+
+			assert.Len(t, routes, 1)
+			assert.Equal(t, tc.Expected, routes[0].namespaces)
+		})
+	}
 }
 
 func TestSetEventRouteForRecommendationsIfShould(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add new namespace.include/exclude property in the sources.'group-name'.kubernetes according to the proposal.
- Updates E2E config to simulate both global use and override behaviour.
- Updates Helm Chart values and README.

### Testing it out

Run BotKube with these settings (e.g. loaded from `/tmp/values.yaml`).

```yaml
analytics:
  disable: true

sources:
  'k8s-events':
    kubernetes:
      namespaces: 
        include:
          - botkube
        ignore:
          -
      resources:
        - name: apps/v1/deployments
          updateSetting:
            includeDiff: true
            fields:
              - status.availableReplicas
          events:
            - create
            - delete

  'k8s-other':
    kubernetes:
      namespaces: 
        include:
          - botkube
        ignore:
          -
      resources:
        - name: apps/v1/deployments
           namespaces:
             include:
               - default
             ignore:
               - 
           updateSetting:
             includeDiff: false
             fields:
               - status.availableReplicas
          events: 
            - create
            - delete

communications:
  'default-group':
    slack:
      enabled: true
      channels:
        'default':
          name: general
          bindings:
            sources:
              - k8s-events
        'random':
          name: random
          bindings:
            sources:
              - k8s-other
      token: {slack-token}
      notification:
        type: short
```

Deployment manifest.

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: working-nginx
  labels:
    app: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
```

- Applying `kubectl -n botkube apply -f /tmp/nginx-deploy.yaml`:
  Should trigger notifications on the `general` channel using the  `sources.'group-name'.kubernetes.namespaces`.

- Applying `kubectl -n default apply -f /tmp/nginx-deploy.yaml`: 
  Should trigger notifications on the `random` channel to showcase the override behaviour using the `apps/v1/deployments` namespaces config in the `k8s-other` source.

## Related issue(s)

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->

Resolves #697 