### PR TITLE
Ignore resource object when marshalling event to JSON

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -33,7 +33,7 @@ type Event struct {
 	Action    string
 	Skip      bool `json:",omitempty"`
 	Resource  string
-	Object    interface{}
+	Object    interface{} `json:"-"`
 
 	Recommendations []string
 	Warnings        []string


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Ignore resource object when marshalling event to JSON

During 0.13 RC1 testing @ezodude found an issue with sending events to Elasticsearch. This PR fixes the issue.

Elasticsearch sink has the following line of code:

```go
	_, err = e.client.Index().Index(indexName).Type(indexCfg.Type).BodyJson(event).Do(ctx)
```

So we need to make sure the resource object is ignored.