### PR TITLE
Make more robust getting the k8s version

### DIFF
--- a/cmd/botkube/main.go
+++ b/cmd/botkube/main.go
@@ -141,7 +141,7 @@ func run() error {
 	// Create executor factor
 	executorFactory := execute.NewExecutorFactory(
 		logger.WithField(componentLogFieldKey, "Executor"),
-		execute.DefaultCommandRunnerFunc,
+		&execute.OSCommand{},
 		*conf,
 		filterEngine,
 		kubectl.NewChecker(resourceNameNormalizerFunc),

--- a/pkg/execute/default_runner.go
+++ b/pkg/execute/default_runner.go
@@ -2,10 +2,46 @@ package execute
 
 import (
 	"os/exec"
+	"strings"
 )
 
-// DefaultCommandRunnerFunc is a wrapper for exec.Command
-func DefaultCommandRunnerFunc(command string, args []string) (string, error) {
+// CommandRunner provides functionality to run arbitrary commands.
+type CommandRunner interface {
+	CommandCombinedOutputRunner
+	CommandSeparateOutputRunner
+}
+
+// CommandCombinedOutputRunner provides functionality to run arbitrary commands.
+type CommandCombinedOutputRunner interface {
+	RunCombinedOutput(command string, args []string) (string, error)
+}
+
+// CommandSeparateOutputRunner provides functionality to run arbitrary commands.
+type CommandSeparateOutputRunner interface {
+	RunSeparateOutput(command string, args []string) (string, string, error)
+}
+
+// OSCommand provides syntax sugar for working with exec.Command
+type OSCommand struct{}
+
+// RunSeparateOutput runs a given command and returns separately its standard output and standard error.
+func (*OSCommand) RunSeparateOutput(command string, args []string) (string, string, error) {
+	var (
+		out    strings.Builder
+		outErr strings.Builder
+	)
+
+	// #nosec G204
+	cmd := exec.Command(command, args...)
+	cmd.Stdout = &out
+	cmd.Stderr = &outErr
+	err := cmd.Run()
+
+	return out.String(), outErr.String(), err
+}
+
+// RunCombinedOutput runs a given command and returns its combined standard output and standard error.
+func (*OSCommand) RunCombinedOutput(command string, args []string) (string, error) {
 	// #nosec G204
 	cmd := exec.Command(command, args...)
 	out, err := cmd.CombinedOutput()

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -11,7 +11,7 @@ import (
 // DefaultExecutorFactory facilitates creation of the Executor instances.
 type DefaultExecutorFactory struct {
 	log               logrus.FieldLogger
-	runCmdFn          CommandRunnerFunc
+	cmdRunner         CommandSeparateOutputRunner
 	cfg               config.Config
 	filterEngine      filterengine.FilterEngine
 	analyticsReporter AnalyticsReporter
@@ -32,10 +32,10 @@ type AnalyticsReporter interface {
 }
 
 // NewExecutorFactory creates new DefaultExecutorFactory.
-func NewExecutorFactory(log logrus.FieldLogger, runCmdFn CommandRunnerFunc, cfg config.Config, filterEngine filterengine.FilterEngine, kcChecker *kubectl.Checker, merger *kubectl.Merger, analyticsReporter AnalyticsReporter) *DefaultExecutorFactory {
+func NewExecutorFactory(log logrus.FieldLogger, cmdRunner CommandRunner, cfg config.Config, filterEngine filterengine.FilterEngine, kcChecker *kubectl.Checker, merger *kubectl.Merger, analyticsReporter AnalyticsReporter) *DefaultExecutorFactory {
 	return &DefaultExecutorFactory{
 		log:               log,
-		runCmdFn:          runCmdFn,
+		cmdRunner:         cmdRunner,
 		cfg:               cfg,
 		filterEngine:      filterEngine,
 		analyticsReporter: analyticsReporter,
@@ -50,7 +50,7 @@ func NewExecutorFactory(log logrus.FieldLogger, runCmdFn CommandRunnerFunc, cfg 
 			cfg,
 			merger,
 			kcChecker,
-			runCmdFn,
+			cmdRunner,
 		),
 	}
 }
@@ -59,7 +59,7 @@ func NewExecutorFactory(log logrus.FieldLogger, runCmdFn CommandRunnerFunc, cfg 
 func (f *DefaultExecutorFactory) NewDefault(platform config.CommPlatformIntegration, notifierHandler NotifierHandler, isAuthChannel bool, conversationID string, bindings []string, message string) Executor {
 	return &DefaultExecutor{
 		log:               f.log,
-		runCmdFn:          f.runCmdFn,
+		cmdRunner:         f.cmdRunner,
 		cfg:               f.cfg,
 		analyticsReporter: f.analyticsReporter,
 		kubectlExecutor:   f.kubectlExecutor,

--- a/pkg/execute/kubectl.go
+++ b/pkg/execute/kubectl.go
@@ -29,18 +29,18 @@ type Kubectl struct {
 	cfg config.Config
 
 	kcChecker *kubectl.Checker
-	runCmdFn  CommandRunnerFunc
+	cmdRunner CommandCombinedOutputRunner
 	merger    *kubectl.Merger
 }
 
 // NewKubectl creates a new instance of Kubectl.
-func NewKubectl(log logrus.FieldLogger, cfg config.Config, merger *kubectl.Merger, kcChecker *kubectl.Checker, fn CommandRunnerFunc) *Kubectl {
+func NewKubectl(log logrus.FieldLogger, cfg config.Config, merger *kubectl.Merger, kcChecker *kubectl.Checker, fn CommandCombinedOutputRunner) *Kubectl {
 	return &Kubectl{
 		log:       log,
 		cfg:       cfg,
 		merger:    merger,
 		kcChecker: kcChecker,
-		runCmdFn:  fn,
+		cmdRunner: fn,
 	}
 }
 
@@ -121,7 +121,7 @@ func (e *Kubectl) Execute(bindings []string, command string, isAuthChannel bool)
 	}
 
 	finalArgs := e.getFinalArgs(args)
-	out, err := e.runCmdFn(kubectlBinary, finalArgs)
+	out, err := e.cmdRunner.RunCombinedOutput(kubectlBinary, finalArgs)
 	if err != nil {
 		return fmt.Sprintf("Cluster: %s\n%s%s", clusterName, out, err.Error()), nil
 	}

--- a/pkg/execute/kubectl_test.go
+++ b/pkg/execute/kubectl_test.go
@@ -364,10 +364,10 @@ func TestKubectlExecute(t *testing.T) {
 
 			wasKubectlExecuted := false
 
-			executor := NewKubectl(logger, cfg, merger, kcChecker, func(command string, args []string) (string, error) {
+			executor := NewKubectl(logger, cfg, merger, kcChecker, cmdCombinedFunc(func(command string, args []string) (string, error) {
 				wasKubectlExecuted = true
 				return "kubectl executed", nil
-			})
+			}))
 
 			// when
 			canHandle := executor.CanHandle(fixBindingsNames, strings.Fields(strings.TrimSpace(tc.command)))
@@ -458,4 +458,11 @@ func fixCfgWithKubectlExecutor(t *testing.T, executor config.Kubectl) config.Con
 			},
 		},
 	}
+}
+
+// cmdCombinedFunc type is an adapter to allow the use of ordinary functions as command handlers.
+type cmdCombinedFunc func(command string, args []string) (string, error)
+
+func (f cmdCombinedFunc) RunCombinedOutput(command string, args []string) (string, error) {
+	return f(command, args)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description
Previously the deprecated `--short` flag was used to get the k8s version. 

Changes proposed in this pull request:

- Use the `json` format to get the k8s version

## Testing

 
1. Create cluster
    ```bash
    k3d cluster create labs --image rancher/k3s:v1.24.4-k3s1
    ```
2. Install `botkube`

    ```bash
    export SLACK_BOT_TOKEN="xoxb-" # WARNING: It is token for BotKube Slack bot, not the Tester!
    
    helm upgrade botkube --namespace botkube --install --create-namespace \
    --set communications.default-group.slack.enabled=true \
    --set communications.default-group.slack.channels.default.name=random \
    --set communications.default-group.slack.token="${SLACK_BOT_TOKEN}" \
    --set settings.clusterName=slack \
    --set executors.kubectl-read-only.kubectl.enabled=true \
    --set image.repository=kubeshop/pr/botkube \
    --set image.tag=706-PR \
    --set image.pullPolicy="Always" \
    ./helm/botkube
    ```
3. Run 
    ```
    @Botkube ping
    ```
    ![Screen Shot 2022-08-29 at 10 55 27](https://user-images.githubusercontent.com/17568639/187164038-98f53963-43f4-413b-9c74-201417cd8f1a.png)

To test the warning message, create cluster with k8s in ver 1.22:
`k3d cluster create labs --image rancher/k3s:v1.22.13-k3s1`
    
![Screen Shot 2022-08-29 at 10 55 53](https://user-images.githubusercontent.com/17568639/187164066-cf8d25ad-f889-4e80-b8a3-14db99dac04f.png)

## Related issue(s)

- https://github.com/kubeshop/botkube/issues/595