### PR TITLE
Use image registry when building single Docker image

### DIFF
--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -108,7 +108,7 @@ build_single() {
     -e GORELEASER_CURRENT_TAG=${GORELEASER_CURRENT_TAG} \
     -e ANALYTICS_API_KEY="${ANALYTICS_API_KEY}" \
     goreleaser/goreleaser build --single-target --rm-dist --snapshot --id botkube -o "./botkube"
-  docker build -f "$PWD/build/Dockerfile" --platform "${IMAGE_PLATFORM}" -t "${IMAGE_REPOSITORY}:${GORELEASER_CURRENT_TAG}" .
+  docker build -f "$PWD/build/Dockerfile" --platform "${IMAGE_PLATFORM}" -t "${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}:${GORELEASER_CURRENT_TAG}" .
   rm "$PWD/botkube"
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix build single image target


As @madebyrogal noticed, our [contribution guide](https://github.com/kubeshop/botkube/blob/main/CONTRIBUTING.md#build-and-install-on-kubernetes) says:

``````
       ```sh
        IMAGE_PLATFORM=linux/arm64 make container-image-single
        docker tag ghcr.io/kubeshop/botkube:v9.99.9-dev <your_account>/botkube:v9.99.9-dev
        docker push <your_account>/botkube:v9.99.9-dev
        ```
``````

And our `container-image-single` target produces `kubeshop/botkube:v9.99.9-dev` image. This PR fixes it.