### PR TITLE
Define different k8s source presets, add option to set event list globally

### DIFF
--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -111,54 +111,54 @@ Controller for the BotKube Slack app which helps you monitor your Kubernetes clu
 | [communications.default-group.elasticsearch.indices.default.bindings.sources](./values.yaml#L437) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given index. |
 | [communications.default-group.webhook.enabled](./values.yaml#L444) | bool | `false` | If true, enables Webhook. |
 | [communications.default-group.webhook.url](./values.yaml#L446) | string | `"WEBHOOK_URL"` | The Webhook URL, e.g.: https://example.com:80 |
-| [communications.default-group.webhook.bindings.sources](./values.yaml#L449) | list | `["k8s-err-events"]` | Notification sources configuration for the webhook. |
-| [settings.clusterName](./values.yaml#L455) | string | `"not-configured"` | Cluster name to differentiate incoming messages. |
-| [settings.configWatcher](./values.yaml#L457) | bool | `true` | If true, restarts the BotKube Pod on config changes. |
-| [settings.upgradeNotifier](./values.yaml#L459) | bool | `true` | If true, notifies about new BotKube releases. |
-| [settings.log.level](./values.yaml#L463) | string | `"info"` | Sets one of the log levels. Allowed values: `info`, `warn`, `debug`, `error`, `fatal`, `panic`. |
-| [settings.log.disableColors](./values.yaml#L465) | bool | `false` | If true, disable ANSI colors in logging. |
-| [settings.systemConfigMap](./values.yaml#L468) | object | `{"name":"botkube-system"}` | BotKube's system ConfigMap where internal data is stored. |
-| [ssl.enabled](./values.yaml#L474) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
-| [ssl.existingSecretName](./values.yaml#L480) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
-| [ssl.cert](./values.yaml#L483) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
-| [service](./values.yaml#L486) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
-| [ingress](./values.yaml#L493) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
-| [serviceMonitor](./values.yaml#L504) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
-| [deployment.annotations](./values.yaml#L514) | object | `{}` | Extra annotations to pass to the BotKube Deployment. |
-| [extraAnnotations](./values.yaml#L521) | object | `{}` | Extra annotations to pass to the BotKube Pod. |
-| [extraLabels](./values.yaml#L523) | object | `{}` | Extra labels to pass to the BotKube Pod. |
-| [priorityClassName](./values.yaml#L525) | string | `""` | Priority class name for the BotKube Pod. |
-| [nameOverride](./values.yaml#L528) | string | `""` | Fully override "botkube.name" template. |
-| [fullnameOverride](./values.yaml#L530) | string | `""` | Fully override "botkube.fullname" template. |
-| [resources](./values.yaml#L536) | object | `{}` | The BotKube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
-| [extraEnv](./values.yaml#L548) | list | `[]` | Extra environment variables to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
-| [extraVolumes](./values.yaml#L560) | list | `[]` | Extra volumes to pass to the BotKube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
-| [extraVolumeMounts](./values.yaml#L575) | list | `[]` | Extra volume mounts to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
-| [nodeSelector](./values.yaml#L593) | object | `{}` | Node labels for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
-| [tolerations](./values.yaml#L597) | list | `[]` | Tolerations for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
-| [affinity](./values.yaml#L601) | object | `{}` | Affinity for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
-| [rbac](./values.yaml#L605) | object | `{"create":true,"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["get","watch","list"]}]}` | Role Based Access for BotKube Pod. [Ref doc](https://kubernetes.io/docs/admin/authorization/rbac/). |
-| [serviceAccount.create](./values.yaml#L614) | bool | `true` | If true, a ServiceAccount is automatically created. |
-| [serviceAccount.name](./values.yaml#L617) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
-| [serviceAccount.annotations](./values.yaml#L619) | object | `{}` | Extra annotations for the ServiceAccount. |
-| [extraObjects](./values.yaml#L622) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
-| [analytics.disable](./values.yaml#L650) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://botkube.io/privacy#privacy-policy). |
-| [e2eTest.image.registry](./values.yaml#L656) | string | `"ghcr.io"` | Test runner image registry. |
-| [e2eTest.image.repository](./values.yaml#L658) | string | `"kubeshop/botkube-test"` | Test runner image repository. |
-| [e2eTest.image.pullPolicy](./values.yaml#L660) | string | `"IfNotPresent"` | Test runner image pull policy. |
-| [e2eTest.image.tag](./values.yaml#L662) | string | `"v9.99.9-dev"` | Test runner image tag. Default tag is `appVersion` from Chart.yaml. |
-| [e2eTest.deployment](./values.yaml#L664) | object | `{"waitTimeout":"3m"}` | Configures BotKube Deployment related data. |
-| [e2eTest.slack.botName](./values.yaml#L669) | string | `"botkube"` | Name of the BotKube bot to interact with during the e2e tests. |
-| [e2eTest.slack.testerName](./values.yaml#L671) | string | `"botkube_tester"` | Name of the BotKube Tester bot that sends messages during the e2e tests. |
-| [e2eTest.slack.testerAppToken](./values.yaml#L673) | string | `""` | Slack tester application token that interacts with BotKube bot. |
-| [e2eTest.slack.additionalContextMessage](./values.yaml#L675) | string | `""` | Additional message that is sent by Tester. You can pass e.g. pull request number or source link where these tests are run from. |
-| [e2eTest.slack.messageWaitTimeout](./values.yaml#L677) | string | `"1m"` | Message wait timeout. It defines how long we wait to ensure that notification were not sent when disabled. |
-| [e2eTest.discord.botName](./values.yaml#L680) | string | `"botkube"` | Name of the BotKube bot to interact with during the e2e tests. |
-| [e2eTest.discord.testerName](./values.yaml#L682) | string | `"botkube_tester"` | Name of the BotKube Tester bot that sends messages during the e2e tests. |
-| [e2eTest.discord.guildID](./values.yaml#L684) | string | `""` | Discord Guild ID (discord server ID) used to run e2e tests |
-| [e2eTest.discord.testerAppToken](./values.yaml#L686) | string | `""` | Discord tester application token that interacts with BotKube bot. |
-| [e2eTest.discord.additionalContextMessage](./values.yaml#L688) | string | `""` | Additional message that is sent by Tester. You can pass e.g. pull request number or source link where these tests are run from. |
-| [e2eTest.discord.messageWaitTimeout](./values.yaml#L690) | string | `"1m"` | Message wait timeout. It defines how long we wait to ensure that notification were not sent when disabled. |
+| [communications.default-group.webhook.bindings.sources](./values.yaml#L449) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for the webhook. |
+| [settings.clusterName](./values.yaml#L456) | string | `"not-configured"` | Cluster name to differentiate incoming messages. |
+| [settings.configWatcher](./values.yaml#L458) | bool | `true` | If true, restarts the BotKube Pod on config changes. |
+| [settings.upgradeNotifier](./values.yaml#L460) | bool | `true` | If true, notifies about new BotKube releases. |
+| [settings.log.level](./values.yaml#L464) | string | `"info"` | Sets one of the log levels. Allowed values: `info`, `warn`, `debug`, `error`, `fatal`, `panic`. |
+| [settings.log.disableColors](./values.yaml#L466) | bool | `false` | If true, disable ANSI colors in logging. |
+| [settings.systemConfigMap](./values.yaml#L469) | object | `{"name":"botkube-system"}` | BotKube's system ConfigMap where internal data is stored. |
+| [ssl.enabled](./values.yaml#L475) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
+| [ssl.existingSecretName](./values.yaml#L481) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
+| [ssl.cert](./values.yaml#L484) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
+| [service](./values.yaml#L487) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
+| [ingress](./values.yaml#L494) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
+| [serviceMonitor](./values.yaml#L505) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
+| [deployment.annotations](./values.yaml#L515) | object | `{}` | Extra annotations to pass to the BotKube Deployment. |
+| [extraAnnotations](./values.yaml#L522) | object | `{}` | Extra annotations to pass to the BotKube Pod. |
+| [extraLabels](./values.yaml#L524) | object | `{}` | Extra labels to pass to the BotKube Pod. |
+| [priorityClassName](./values.yaml#L526) | string | `""` | Priority class name for the BotKube Pod. |
+| [nameOverride](./values.yaml#L529) | string | `""` | Fully override "botkube.name" template. |
+| [fullnameOverride](./values.yaml#L531) | string | `""` | Fully override "botkube.fullname" template. |
+| [resources](./values.yaml#L537) | object | `{}` | The BotKube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
+| [extraEnv](./values.yaml#L549) | list | `[]` | Extra environment variables to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
+| [extraVolumes](./values.yaml#L561) | list | `[]` | Extra volumes to pass to the BotKube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
+| [extraVolumeMounts](./values.yaml#L576) | list | `[]` | Extra volume mounts to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
+| [nodeSelector](./values.yaml#L594) | object | `{}` | Node labels for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
+| [tolerations](./values.yaml#L598) | list | `[]` | Tolerations for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
+| [affinity](./values.yaml#L602) | object | `{}` | Affinity for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
+| [rbac](./values.yaml#L606) | object | `{"create":true,"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["get","watch","list"]}]}` | Role Based Access for BotKube Pod. [Ref doc](https://kubernetes.io/docs/admin/authorization/rbac/). |
+| [serviceAccount.create](./values.yaml#L615) | bool | `true` | If true, a ServiceAccount is automatically created. |
+| [serviceAccount.name](./values.yaml#L618) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
+| [serviceAccount.annotations](./values.yaml#L620) | object | `{}` | Extra annotations for the ServiceAccount. |
+| [extraObjects](./values.yaml#L623) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
+| [analytics.disable](./values.yaml#L651) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://botkube.io/privacy#privacy-policy). |
+| [e2eTest.image.registry](./values.yaml#L657) | string | `"ghcr.io"` | Test runner image registry. |
+| [e2eTest.image.repository](./values.yaml#L659) | string | `"kubeshop/botkube-test"` | Test runner image repository. |
+| [e2eTest.image.pullPolicy](./values.yaml#L661) | string | `"IfNotPresent"` | Test runner image pull policy. |
+| [e2eTest.image.tag](./values.yaml#L663) | string | `"v9.99.9-dev"` | Test runner image tag. Default tag is `appVersion` from Chart.yaml. |
+| [e2eTest.deployment](./values.yaml#L665) | object | `{"waitTimeout":"3m"}` | Configures BotKube Deployment related data. |
+| [e2eTest.slack.botName](./values.yaml#L670) | string | `"botkube"` | Name of the BotKube bot to interact with during the e2e tests. |
+| [e2eTest.slack.testerName](./values.yaml#L672) | string | `"botkube_tester"` | Name of the BotKube Tester bot that sends messages during the e2e tests. |
+| [e2eTest.slack.testerAppToken](./values.yaml#L674) | string | `""` | Slack tester application token that interacts with BotKube bot. |
+| [e2eTest.slack.additionalContextMessage](./values.yaml#L676) | string | `""` | Additional message that is sent by Tester. You can pass e.g. pull request number or source link where these tests are run from. |
+| [e2eTest.slack.messageWaitTimeout](./values.yaml#L678) | string | `"1m"` | Message wait timeout. It defines how long we wait to ensure that notification were not sent when disabled. |
+| [e2eTest.discord.botName](./values.yaml#L681) | string | `"botkube"` | Name of the BotKube bot to interact with during the e2e tests. |
+| [e2eTest.discord.testerName](./values.yaml#L683) | string | `"botkube_tester"` | Name of the BotKube Tester bot that sends messages during the e2e tests. |
+| [e2eTest.discord.guildID](./values.yaml#L685) | string | `""` | Discord Guild ID (discord server ID) used to run e2e tests |
+| [e2eTest.discord.testerAppToken](./values.yaml#L687) | string | `""` | Discord tester application token that interacts with BotKube bot. |
+| [e2eTest.discord.additionalContextMessage](./values.yaml#L689) | string | `""` | Additional message that is sent by Tester. You can pass e.g. pull request number or source link where these tests are run from. |
+| [e2eTest.discord.messageWaitTimeout](./values.yaml#L691) | string | `"1m"` | Message wait timeout. It defines how long we wait to ensure that notification were not sent when disabled. |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -31,66 +31,72 @@ Controller for the BotKube Slack app which helps you monitor your Kubernetes clu
 | [kubeconfig.base64Config](./values.yaml#L46) | string | `""` | A base64 encoded kubeconfig that will be stored in a Secret, mounted to the Pod, and specified in the KUBECONFIG environment variable. |
 | [kubeconfig.existingSecret](./values.yaml#L51) | string | `""` | A Secret containing a kubeconfig to use.  |
 | [sources](./values.yaml#L60) | object | See the `values.yaml` file for full object. | Map of sources. Source contains configuration for Kubernetes events and sending recommendations. The property name under `sources` object is an alias for a given configuration. You can define multiple sources configuration with different names. Key name is used as a binding reference.   |
-| [sources.k8s-events.kubernetes](./values.yaml#L64) | object | `{"namespaces":{"include":[".*"]},"recommendations":{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}},"resources":[{"events":["create","delete","error"],"name":"v1/pods"},{"events":["create","delete","error"],"name":"v1/services"},{"events":["create","update","delete","error"],"name":"apps/v1/deployments","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.availableReplicas"],"includeDiff":true}},{"events":["create","update","delete","error"],"name":"apps/v1/statefulsets","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.readyReplicas"],"includeDiff":true}},{"events":["create","delete","error"],"name":"networking.k8s.io/v1/ingresses"},{"events":["create","delete","error"],"name":"v1/nodes"},{"events":["create","delete","error"],"name":"v1/namespaces"},{"events":["create","delete","error"],"name":"v1/persistentvolumes"},{"events":["create","delete","error"],"name":"v1/persistentvolumeclaims"},{"events":["create","delete","error"],"name":"v1/configmaps"},{"events":["create","update","delete","error"],"name":"apps/v1/daemonsets","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.numberReady"],"includeDiff":true}},{"events":["create","update","delete","error"],"name":"batch/v1/jobs","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.conditions[*].type"],"includeDiff":true}},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/roles"},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/rolebindings"},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/clusterrolebindings"},{"events":["create","delete","error"],"name":"rbac.authorization.k8s.io/v1/clusterroles"}]}` | Describes Kubernetes source configuration. |
-| [sources.k8s-events.kubernetes.recommendations](./values.yaml#L66) | object | `{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}}` | Describes configuration for various recommendation insights. |
-| [sources.k8s-events.kubernetes.recommendations.pod](./values.yaml#L68) | object | `{"labelsSet":true,"noLatestImageTag":true}` | Recommendations for Pod Kubernetes resource. |
-| [sources.k8s-events.kubernetes.recommendations.pod.noLatestImageTag](./values.yaml#L70) | bool | `true` | If true, notifies about Pod containers that use `latest` tag for images. |
-| [sources.k8s-events.kubernetes.recommendations.pod.labelsSet](./values.yaml#L72) | bool | `true` | If true, notifies about Pod resources created without labels. |
-| [sources.k8s-events.kubernetes.recommendations.ingress](./values.yaml#L74) | object | `{"backendServiceValid":true,"tlsSecretValid":true}` | Recommendations for Ingress Kubernetes resource. |
-| [sources.k8s-events.kubernetes.recommendations.ingress.backendServiceValid](./values.yaml#L76) | bool | `true` | If true, notifies about Ingress resources with invalid backend service reference. |
-| [sources.k8s-events.kubernetes.recommendations.ingress.tlsSecretValid](./values.yaml#L78) | bool | `true` | If true, notifies about Ingress resources with invalid TLS secret reference. |
-| [sources.k8s-events.kubernetes.namespaces](./values.yaml#L83) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
-| [sources.k8s-events.kubernetes.resources](./values.yaml#L96) | list | Watch all built-in K8s kinds. | Describes the Kubernetes resources you want to watch. |
-| [filters](./values.yaml#L228) | object | See the `values.yaml` file for full object. | Filter settings for various sources. Currently, all filters are globally enabled or disabled. You can enable or disable filters with `@BotKube filters` commands. |
-| [filters.kubernetes.objectAnnotationChecker](./values.yaml#L231) | bool | `true` | If true, enables support for `botkube.io/disable` and `botkube.io/channel` resource annotations. |
-| [filters.kubernetes.nodeEventsChecker](./values.yaml#L233) | bool | `true` | If true, filters out Node-related events that are not important. |
-| [executors](./values.yaml#L241) | object | See the `values.yaml` file for full object. | Map of executors. Executor contains configuration for running `kubectl` commands. The property name under `executors` is an alias for a given configuration. You can define multiple executor configurations with different names. Key name is used as a binding reference.   |
-| [executors.kubectl-read-only.kubectl.namespaces.include](./values.yaml#L249) | list | `[".*"]` | List of allowed Kubernetes Namespaces for command execution. It can also contain a regex expressions:  `- ".*"` - to specify all Namespaces. |
-| [executors.kubectl-read-only.kubectl.namespaces.exclude](./values.yaml#L254) | list | `[]` | List of ignored Kubernetes Namespace. It can also contain a regex expressions:  `- "test-.*"` - to specify all Namespaces. |
-| [executors.kubectl-read-only.kubectl.enabled](./values.yaml#L256) | bool | `false` | If true, enables `kubectl` commands execution. |
-| [executors.kubectl-read-only.kubectl.commands.verbs](./values.yaml#L260) | list | `["api-resources","api-versions","cluster-info","describe","diff","explain","get","logs","top","auth"]` | Configures which `kubectl` methods are allowed. |
-| [executors.kubectl-read-only.kubectl.commands.resources](./values.yaml#L262) | list | `["deployments","pods","namespaces","daemonsets","statefulsets","storageclasses","nodes","configmaps"]` | Configures which K8s resource are allowed. |
-| [executors.kubectl-read-only.kubectl.defaultNamespace](./values.yaml#L264) | string | `"default"` | Configures the default Namespace for executing BotKube `kubectl` commands. If not set, uses the 'default'. |
-| [executors.kubectl-read-only.kubectl.restrictAccess](./values.yaml#L266) | bool | `false` | If true, enables commands execution from configured channel only. |
-| [existingCommunicationsSecretName](./values.yaml#L276) | string | `""` | Configures existing Secret with communication settings. It MUST be in the `botkube` Namespace.  |
-| [communications](./values.yaml#L283) | object | See the `values.yaml` file for full object. | Map of communication groups. Communication group contains settings for multiple communication platforms. The property name under `communications` object is an alias for a given configuration group. You can define multiple communication groups with different names.   |
-| [communications.default-group.slack.enabled](./values.yaml#L288) | bool | `false` | If true, enables Slack bot. |
-| [communications.default-group.slack.channels](./values.yaml#L292) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-events"]},"name":"SLACK_CHANNEL","notification":{"disabled":false}}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
-| [communications.default-group.slack.channels.default.name](./values.yaml#L295) | string | `"SLACK_CHANNEL"` | Slack channel name without '#' prefix where you have added BotKube and want to receive notifications in. |
-| [communications.default-group.slack.channels.default.notification.disabled](./values.yaml#L298) | bool | `false` | If true, the notifications are not sent to the channel. They can be enabled with `@BotKube` command anytime. |
-| [communications.default-group.slack.channels.default.bindings.executors](./values.yaml#L301) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
-| [communications.default-group.slack.channels.default.bindings.sources](./values.yaml#L304) | list | `["k8s-events"]` | Notification sources configuration for a given channel. |
-| [communications.default-group.slack.token](./values.yaml#L307) | string | `""` | Slack token. |
-| [communications.default-group.slack.botToken](./values.yaml#L310) | string | `""` | Slack bot token for your own Slack app. [Ref doc](https://api.slack.com/authentication/token-types). |
-| [communications.default-group.slack.appToken](./values.yaml#L313) | string | `""` | Slack app-level token for your own Slack app. [Ref doc](https://api.slack.com/authentication/token-types). |
-| [communications.default-group.slack.notification.type](./values.yaml#L316) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
-| [communications.default-group.mattermost.enabled](./values.yaml#L321) | bool | `false` | If true, enables Mattermost bot. |
-| [communications.default-group.mattermost.botName](./values.yaml#L323) | string | `"BotKube"` | User in Mattermost which belongs the specified Personal Access token. |
-| [communications.default-group.mattermost.url](./values.yaml#L325) | string | `"MATTERMOST_SERVER_URL"` | The URL (including http/https schema) where Mattermost is running. e.g https://example.com:9243 |
-| [communications.default-group.mattermost.token](./values.yaml#L327) | string | `"MATTERMOST_TOKEN"` | Personal Access token generated by BotKube user. |
-| [communications.default-group.mattermost.team](./values.yaml#L329) | string | `"MATTERMOST_TEAM"` | The Mattermost Team name where BotKube is added. |
-| [communications.default-group.mattermost.channels](./values.yaml#L333) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-events"]},"name":"MATTERMOST_CHANNEL","notification":{"disabled":false}}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
-| [communications.default-group.mattermost.channels.default.name](./values.yaml#L337) | string | `"MATTERMOST_CHANNEL"` | The Mattermost channel name for receiving BotKube alerts. The BotKube user needs to be added to it. |
-| [communications.default-group.mattermost.channels.default.notification.disabled](./values.yaml#L340) | bool | `false` | If true, the notifications are not sent to the channel. They can be enabled with `@BotKube` command anytime. |
-| [communications.default-group.mattermost.channels.default.bindings.executors](./values.yaml#L343) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
-| [communications.default-group.mattermost.channels.default.bindings.sources](./values.yaml#L346) | list | `["k8s-events"]` | Notification sources configuration for a given channel. |
-| [communications.default-group.mattermost.notification.type](./values.yaml#L350) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
-| [communications.default-group.teams.enabled](./values.yaml#L355) | bool | `false` | If true, enables MS Teams bot. |
-| [communications.default-group.teams.botName](./values.yaml#L357) | string | `"BotKube"` | The Bot name set while registering Bot to MS Teams. |
-| [communications.default-group.teams.appID](./values.yaml#L359) | string | `"APPLICATION_ID"` | The BotKube application ID generated while registering Bot to MS Teams. |
-| [communications.default-group.teams.appPassword](./values.yaml#L361) | string | `"APPLICATION_PASSWORD"` | The BotKube application password generated while registering Bot to MS Teams. |
-| [communications.default-group.teams.bindings.executors](./values.yaml#L364) | list | `["kubectl-read-only"]` | Executor bindings apply to all MS Teams channels where BotKube has access to. |
-| [communications.default-group.teams.bindings.sources](./values.yaml#L367) | list | `["k8s-events"]` | Source bindings apply to all channels which have notification turned on with `@BotKube notifier start` command. |
-| [communications.default-group.teams.messagePath](./values.yaml#L370) | string | `"/bots/teams"` | The path in endpoint URL provided while registering BotKube to MS Teams. |
-| [communications.default-group.teams.port](./values.yaml#L372) | int | `3978` | The Service port for bot endpoint on BotKube container. |
-| [communications.default-group.discord.enabled](./values.yaml#L377) | bool | `false` | If true, enables Discord bot. |
-| [communications.default-group.discord.token](./values.yaml#L379) | string | `"DISCORD_TOKEN"` | BotKube Bot Token. |
-| [communications.default-group.discord.botID](./values.yaml#L381) | string | `"DISCORD_BOT_ID"` | BotKube Application Client ID. |
-| [communications.default-group.discord.channels](./values.yaml#L385) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-events"]},"id":"DISCORD_CHANNEL_ID","notification":{"disabled":false}}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
-| [communications.default-group.discord.channels.default.id](./values.yaml#L389) | string | `"DISCORD_CHANNEL_ID"` | Discord channel ID for receiving BotKube alerts. The BotKube user needs to be added to it. |
-| [communications.default-group.discord.channels.default.notification.disabled](./values.yaml#L392) | bool | `false` | If true, the notifications are not sent to the channel. They can be enabled with `@BotKube` command anytime. |
-| [communications.default-group.discord.channels.default.bindings.executors](./values.yaml#L395) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
-| [communications.default-group.discord.channels.default.bindings.sources](./values.yaml#L398) | list | `["k8s-events"]` | Notification sources configuration for a given channel. |
+| [sources.k8s-recommendation-events.kubernetes](./values.yaml#L63) | object | `{"recommendations":{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}}}` | Describes Kubernetes source configuration. |
+| [sources.k8s-recommendation-events.kubernetes.recommendations](./values.yaml#L65) | object | `{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}}` | Describes configuration for various recommendation insights. |
+| [sources.k8s-recommendation-events.kubernetes.recommendations.pod](./values.yaml#L67) | object | `{"labelsSet":true,"noLatestImageTag":true}` | Recommendations for Pod Kubernetes resource. |
+| [sources.k8s-recommendation-events.kubernetes.recommendations.pod.noLatestImageTag](./values.yaml#L69) | bool | `true` | If true, notifies about Pod containers that use `latest` tag for images. |
+| [sources.k8s-recommendation-events.kubernetes.recommendations.pod.labelsSet](./values.yaml#L71) | bool | `true` | If true, notifies about Pod resources created without labels. |
+| [sources.k8s-recommendation-events.kubernetes.recommendations.ingress](./values.yaml#L73) | object | `{"backendServiceValid":true,"tlsSecretValid":true}` | Recommendations for Ingress Kubernetes resource. |
+| [sources.k8s-recommendation-events.kubernetes.recommendations.ingress.backendServiceValid](./values.yaml#L75) | bool | `true` | If true, notifies about Ingress resources with invalid backend service reference. |
+| [sources.k8s-recommendation-events.kubernetes.recommendations.ingress.tlsSecretValid](./values.yaml#L77) | bool | `true` | If true, notifies about Ingress resources with invalid TLS secret reference. |
+| [sources.k8s-all-events.kubernetes](./values.yaml#L81) | object | `{"events":["create","delete","error"],"namespaces":{"include":[".*"]},"resources":[{"name":"v1/pods"},{"name":"v1/services"},{"name":"networking.k8s.io/v1/ingresses"},{"name":"v1/nodes"},{"name":"v1/namespaces"},{"name":"v1/persistentvolumes"},{"name":"v1/persistentvolumeclaims"},{"name":"v1/configmaps"},{"name":"rbac.authorization.k8s.io/v1/roles"},{"name":"rbac.authorization.k8s.io/v1/rolebindings"},{"name":"rbac.authorization.k8s.io/v1/clusterrolebindings"},{"name":"rbac.authorization.k8s.io/v1/clusterroles"},{"events":["create","update","delete","error"],"name":"apps/v1/daemonsets","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.numberReady"],"includeDiff":true}},{"events":["create","update","delete","error"],"name":"batch/v1/jobs","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.conditions[*].type"],"includeDiff":true}},{"events":["create","update","delete","error"],"name":"apps/v1/deployments","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.availableReplicas"],"includeDiff":true}},{"events":["create","update","delete","error"],"name":"apps/v1/statefulsets","updateSetting":{"fields":["spec.template.spec.containers[*].image","status.readyReplicas"],"includeDiff":true}}]}` | Describes Kubernetes source configuration. |
+| [sources.k8s-all-events.kubernetes.namespaces](./values.yaml#L85) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
+| [sources.k8s-all-events.kubernetes.events](./values.yaml#L99) | list | `["create","delete","error"]` | Describes events for every Kubernetes resources you want to watch or exclude. These events are applied to every resource specified in the resources list. However, every specified resource can override this by using its own events object. |
+| [sources.k8s-all-events.kubernetes.resources](./values.yaml#L106) | list | See the `values.yaml` file for full object. | Describes the Kubernetes resources you want to watch. |
+| [sources.k8s-err-events.kubernetes](./values.yaml#L188) | object | `{"events":["error"],"namespaces":{"include":[".*"]},"resources":[{"name":"v1/pods"},{"name":"v1/services"},{"name":"networking.k8s.io/v1/ingresses"},{"name":"v1/nodes"},{"name":"v1/namespaces"},{"name":"v1/persistentvolumes"},{"name":"v1/persistentvolumeclaims"},{"name":"v1/configmaps"},{"name":"rbac.authorization.k8s.io/v1/roles"},{"name":"rbac.authorization.k8s.io/v1/rolebindings"},{"name":"rbac.authorization.k8s.io/v1/clusterrolebindings"},{"name":"rbac.authorization.k8s.io/v1/clusterroles"},{"name":"apps/v1/deployments"},{"name":"apps/v1/statefulsets"},{"name":"apps/v1/daemonsets"},{"name":"batch/v1/jobs"}]}` | Describes Kubernetes source configuration. |
+| [sources.k8s-err-events.kubernetes.namespaces](./values.yaml#L192) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
+| [sources.k8s-err-events.kubernetes.events](./values.yaml#L197) | list | `["error"]` | Describes events for every Kubernetes resources you want to watch or exclude. These events are applied to every resource specified in the resources list. However, every specified resource can override this by using its own events object. |
+| [sources.k8s-err-events.kubernetes.resources](./values.yaml#L202) | list | See the `values.yaml` file for full object. | Describes the Kubernetes resources you want to watch. |
+| [filters](./values.yaml#L224) | object | See the `values.yaml` file for full object. | Filter settings for various sources. Currently, all filters are globally enabled or disabled. You can enable or disable filters with `@BotKube filters` commands. |
+| [filters.kubernetes.objectAnnotationChecker](./values.yaml#L227) | bool | `true` | If true, enables support for `botkube.io/disable` and `botkube.io/channel` resource annotations. |
+| [filters.kubernetes.nodeEventsChecker](./values.yaml#L229) | bool | `true` | If true, filters out Node-related events that are not important. |
+| [executors](./values.yaml#L237) | object | See the `values.yaml` file for full object. | Map of executors. Executor contains configuration for running `kubectl` commands. The property name under `executors` is an alias for a given configuration. You can define multiple executor configurations with different names. Key name is used as a binding reference.   |
+| [executors.kubectl-read-only.kubectl.namespaces.include](./values.yaml#L245) | list | `[".*"]` | List of allowed Kubernetes Namespaces for command execution. It can also contain a regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [executors.kubectl-read-only.kubectl.namespaces.exclude](./values.yaml#L250) | list | `[]` | List of ignored Kubernetes Namespace. It can also contain a regex expressions:  `- "test-.*"` - to specify all Namespaces. |
+| [executors.kubectl-read-only.kubectl.enabled](./values.yaml#L252) | bool | `false` | If true, enables `kubectl` commands execution. |
+| [executors.kubectl-read-only.kubectl.commands.verbs](./values.yaml#L256) | list | `["api-resources","api-versions","cluster-info","describe","diff","explain","get","logs","top","auth"]` | Configures which `kubectl` methods are allowed. |
+| [executors.kubectl-read-only.kubectl.commands.resources](./values.yaml#L258) | list | `["deployments","pods","namespaces","daemonsets","statefulsets","storageclasses","nodes","configmaps"]` | Configures which K8s resource are allowed. |
+| [executors.kubectl-read-only.kubectl.defaultNamespace](./values.yaml#L260) | string | `"default"` | Configures the default Namespace for executing BotKube `kubectl` commands. If not set, uses the 'default'. |
+| [executors.kubectl-read-only.kubectl.restrictAccess](./values.yaml#L262) | bool | `false` | If true, enables commands execution from configured channel only. |
+| [existingCommunicationsSecretName](./values.yaml#L272) | string | `""` | Configures existing Secret with communication settings. It MUST be in the `botkube` Namespace.  |
+| [communications](./values.yaml#L279) | object | See the `values.yaml` file for full object. | Map of communication groups. Communication group contains settings for multiple communication platforms. The property name under `communications` object is an alias for a given configuration group. You can define multiple communication groups with different names.   |
+| [communications.default-group.slack.enabled](./values.yaml#L284) | bool | `false` | If true, enables Slack bot. |
+| [communications.default-group.slack.channels](./values.yaml#L288) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-err-events","k8s-recommendation-events"]},"name":"SLACK_CHANNEL","notification":{"disabled":false}}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
+| [communications.default-group.slack.channels.default.name](./values.yaml#L291) | string | `"SLACK_CHANNEL"` | Slack channel name without '#' prefix where you have added BotKube and want to receive notifications in. |
+| [communications.default-group.slack.channels.default.notification.disabled](./values.yaml#L294) | bool | `false` | If true, the notifications are not sent to the channel. They can be enabled with `@BotKube` command anytime. |
+| [communications.default-group.slack.channels.default.bindings.executors](./values.yaml#L297) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
+| [communications.default-group.slack.channels.default.bindings.sources](./values.yaml#L300) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given channel. |
+| [communications.default-group.slack.token](./values.yaml#L304) | string | `""` | Slack token. |
+| [communications.default-group.slack.botToken](./values.yaml#L307) | string | `""` | Slack bot token for your own Slack app. [Ref doc](https://api.slack.com/authentication/token-types). |
+| [communications.default-group.slack.appToken](./values.yaml#L310) | string | `""` | Slack app-level token for your own Slack app. [Ref doc](https://api.slack.com/authentication/token-types). |
+| [communications.default-group.slack.notification.type](./values.yaml#L313) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
+| [communications.default-group.mattermost.enabled](./values.yaml#L318) | bool | `false` | If true, enables Mattermost bot. |
+| [communications.default-group.mattermost.botName](./values.yaml#L320) | string | `"BotKube"` | User in Mattermost which belongs the specified Personal Access token. |
+| [communications.default-group.mattermost.url](./values.yaml#L322) | string | `"MATTERMOST_SERVER_URL"` | The URL (including http/https schema) where Mattermost is running. e.g https://example.com:9243 |
+| [communications.default-group.mattermost.token](./values.yaml#L324) | string | `"MATTERMOST_TOKEN"` | Personal Access token generated by BotKube user. |
+| [communications.default-group.mattermost.team](./values.yaml#L326) | string | `"MATTERMOST_TEAM"` | The Mattermost Team name where BotKube is added. |
+| [communications.default-group.mattermost.channels](./values.yaml#L330) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-err-events","k8s-recommendation-events"]},"name":"MATTERMOST_CHANNEL","notification":{"disabled":false}}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
+| [communications.default-group.mattermost.channels.default.name](./values.yaml#L334) | string | `"MATTERMOST_CHANNEL"` | The Mattermost channel name for receiving BotKube alerts. The BotKube user needs to be added to it. |
+| [communications.default-group.mattermost.channels.default.notification.disabled](./values.yaml#L337) | bool | `false` | If true, the notifications are not sent to the channel. They can be enabled with `@BotKube` command anytime. |
+| [communications.default-group.mattermost.channels.default.bindings.executors](./values.yaml#L340) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
+| [communications.default-group.mattermost.channels.default.bindings.sources](./values.yaml#L343) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given channel. |
+| [communications.default-group.mattermost.notification.type](./values.yaml#L348) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
+| [communications.default-group.teams.enabled](./values.yaml#L353) | bool | `false` | If true, enables MS Teams bot. |
+| [communications.default-group.teams.botName](./values.yaml#L355) | string | `"BotKube"` | The Bot name set while registering Bot to MS Teams. |
+| [communications.default-group.teams.appID](./values.yaml#L357) | string | `"APPLICATION_ID"` | The BotKube application ID generated while registering Bot to MS Teams. |
+| [communications.default-group.teams.appPassword](./values.yaml#L359) | string | `"APPLICATION_PASSWORD"` | The BotKube application password generated while registering Bot to MS Teams. |
+| [communications.default-group.teams.bindings.executors](./values.yaml#L362) | list | `["kubectl-read-only"]` | Executor bindings apply to all MS Teams channels where BotKube has access to. |
+| [communications.default-group.teams.bindings.sources](./values.yaml#L365) | list | `["k8s-err-events","k8s-recommendation-events"]` | Source bindings apply to all channels which have notification turned on with `@BotKube notifier start` command. |
+| [communications.default-group.teams.messagePath](./values.yaml#L369) | string | `"/bots/teams"` | The path in endpoint URL provided while registering BotKube to MS Teams. |
+| [communications.default-group.teams.port](./values.yaml#L371) | int | `3978` | The Service port for bot endpoint on BotKube container. |
+| [communications.default-group.discord.enabled](./values.yaml#L376) | bool | `false` | If true, enables Discord bot. |
+| [communications.default-group.discord.token](./values.yaml#L378) | string | `"DISCORD_TOKEN"` | BotKube Bot Token. |
+| [communications.default-group.discord.botID](./values.yaml#L380) | string | `"DISCORD_BOT_ID"` | BotKube Application Client ID. |
+| [communications.default-group.discord.channels](./values.yaml#L384) | object | `{"default":{"bindings":{"executors":["kubectl-read-only"],"sources":["k8s-err-events","k8s-recommendation-events"]},"id":"DISCORD_CHANNEL_ID","notification":{"disabled":false}}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
+| [communications.default-group.discord.channels.default.id](./values.yaml#L388) | string | `"DISCORD_CHANNEL_ID"` | Discord channel ID for receiving BotKube alerts. The BotKube user needs to be added to it. |
+| [communications.default-group.discord.channels.default.notification.disabled](./values.yaml#L391) | bool | `false` | If true, the notifications are not sent to the channel. They can be enabled with `@BotKube` command anytime. |
+| [communications.default-group.discord.channels.default.bindings.executors](./values.yaml#L394) | list | `["kubectl-read-only"]` | Executors configuration for a given channel. |
+| [communications.default-group.discord.channels.default.bindings.sources](./values.yaml#L397) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given channel. |
 | [communications.default-group.discord.notification.type](./values.yaml#L402) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
 | [communications.default-group.elasticsearch.enabled](./values.yaml#L407) | bool | `false` | If true, enables Elasticsearch. |
 | [communications.default-group.elasticsearch.awsSigning.enabled](./values.yaml#L411) | bool | `false` | If true, enables awsSigning using IAM for Elasticsearch hosted on AWS. Make sure AWS environment variables are set. [Ref doc](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html). |
@@ -100,59 +106,59 @@ Controller for the BotKube Slack app which helps you monitor your Kubernetes clu
 | [communications.default-group.elasticsearch.username](./values.yaml#L419) | string | `"ELASTICSEARCH_USERNAME"` | Basic Auth username. |
 | [communications.default-group.elasticsearch.password](./values.yaml#L421) | string | `"ELASTICSEARCH_PASSWORD"` | Basic Auth password. |
 | [communications.default-group.elasticsearch.skipTLSVerify](./values.yaml#L424) | bool | `false` | If true, skips the verification of TLS certificate of the Elastic nodes. It's useful for clusters with self-signed certificates. |
-| [communications.default-group.elasticsearch.indices](./values.yaml#L428) | object | `{"default":{"bindings":{"sources":["k8s-events"]},"name":"botkube","replicas":0,"shards":1,"type":"botkube-event"}}` | Map of configured indices. The `indices` property name is an alias for a given configuration.   |
+| [communications.default-group.elasticsearch.indices](./values.yaml#L428) | object | `{"default":{"bindings":{"sources":["k8s-err-events","k8s-recommendation-events"]},"name":"botkube","replicas":0,"shards":1,"type":"botkube-event"}}` | Map of configured indices. The `indices` property name is an alias for a given configuration.   |
 | [communications.default-group.elasticsearch.indices.default.name](./values.yaml#L431) | string | `"botkube"` | Configures Elasticsearch index settings. |
-| [communications.default-group.elasticsearch.indices.default.bindings.sources](./values.yaml#L437) | list | `["k8s-events"]` | Notification sources configuration for a given index. |
-| [communications.default-group.webhook.enabled](./values.yaml#L443) | bool | `false` | If true, enables Webhook. |
-| [communications.default-group.webhook.url](./values.yaml#L445) | string | `"WEBHOOK_URL"` | The Webhook URL, e.g.: https://example.com:80 |
-| [communications.default-group.webhook.bindings.sources](./values.yaml#L448) | list | `["k8s-events"]` | Notification sources configuration for the webhook. |
-| [settings.clusterName](./values.yaml#L454) | string | `"not-configured"` | Cluster name to differentiate incoming messages. |
-| [settings.configWatcher](./values.yaml#L456) | bool | `true` | If true, restarts the BotKube Pod on config changes. |
-| [settings.upgradeNotifier](./values.yaml#L458) | bool | `true` | If true, notifies about new BotKube releases. |
-| [settings.log.level](./values.yaml#L462) | string | `"info"` | Sets one of the log levels. Allowed values: `info`, `warn`, `debug`, `error`, `fatal`, `panic`. |
-| [settings.log.disableColors](./values.yaml#L464) | bool | `false` | If true, disable ANSI colors in logging. |
-| [settings.systemConfigMap](./values.yaml#L467) | object | `{"name":"botkube-system"}` | BotKube's system ConfigMap where internal data is stored. |
-| [ssl.enabled](./values.yaml#L473) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
-| [ssl.existingSecretName](./values.yaml#L479) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
-| [ssl.cert](./values.yaml#L482) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
-| [service](./values.yaml#L485) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
-| [ingress](./values.yaml#L492) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
-| [serviceMonitor](./values.yaml#L503) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
-| [deployment.annotations](./values.yaml#L513) | object | `{}` | Extra annotations to pass to the BotKube Deployment. |
-| [extraAnnotations](./values.yaml#L520) | object | `{}` | Extra annotations to pass to the BotKube Pod. |
-| [extraLabels](./values.yaml#L522) | object | `{}` | Extra labels to pass to the BotKube Pod. |
-| [priorityClassName](./values.yaml#L524) | string | `""` | Priority class name for the BotKube Pod. |
-| [nameOverride](./values.yaml#L527) | string | `""` | Fully override "botkube.name" template. |
-| [fullnameOverride](./values.yaml#L529) | string | `""` | Fully override "botkube.fullname" template. |
-| [resources](./values.yaml#L535) | object | `{}` | The BotKube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
-| [extraEnv](./values.yaml#L547) | list | `[]` | Extra environment variables to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
-| [extraVolumes](./values.yaml#L559) | list | `[]` | Extra volumes to pass to the BotKube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
-| [extraVolumeMounts](./values.yaml#L574) | list | `[]` | Extra volume mounts to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
-| [nodeSelector](./values.yaml#L592) | object | `{}` | Node labels for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
-| [tolerations](./values.yaml#L596) | list | `[]` | Tolerations for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
-| [affinity](./values.yaml#L600) | object | `{}` | Affinity for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
-| [rbac](./values.yaml#L604) | object | `{"create":true,"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["get","watch","list"]}]}` | Role Based Access for BotKube Pod. [Ref doc](https://kubernetes.io/docs/admin/authorization/rbac/). |
-| [serviceAccount.create](./values.yaml#L613) | bool | `true` | If true, a ServiceAccount is automatically created. |
-| [serviceAccount.name](./values.yaml#L616) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
-| [serviceAccount.annotations](./values.yaml#L618) | object | `{}` | Extra annotations for the ServiceAccount. |
-| [extraObjects](./values.yaml#L621) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
-| [analytics.disable](./values.yaml#L649) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://botkube.io/privacy#privacy-policy). |
-| [e2eTest.image.registry](./values.yaml#L655) | string | `"ghcr.io"` | Test runner image registry. |
-| [e2eTest.image.repository](./values.yaml#L657) | string | `"kubeshop/botkube-test"` | Test runner image repository. |
-| [e2eTest.image.pullPolicy](./values.yaml#L659) | string | `"IfNotPresent"` | Test runner image pull policy. |
-| [e2eTest.image.tag](./values.yaml#L661) | string | `"v9.99.9-dev"` | Test runner image tag. Default tag is `appVersion` from Chart.yaml. |
-| [e2eTest.deployment](./values.yaml#L663) | object | `{"waitTimeout":"3m"}` | Configures BotKube Deployment related data. |
-| [e2eTest.slack.botName](./values.yaml#L668) | string | `"botkube"` | Name of the BotKube bot to interact with during the e2e tests. |
-| [e2eTest.slack.testerName](./values.yaml#L670) | string | `"botkube_tester"` | Name of the BotKube Tester bot that sends messages during the e2e tests. |
-| [e2eTest.slack.testerAppToken](./values.yaml#L672) | string | `""` | Slack tester application token that interacts with BotKube bot. |
-| [e2eTest.slack.additionalContextMessage](./values.yaml#L674) | string | `""` | Additional message that is sent by Tester. You can pass e.g. pull request number or source link where these tests are run from. |
-| [e2eTest.slack.messageWaitTimeout](./values.yaml#L676) | string | `"1m"` | Message wait timeout. It defines how long we wait to ensure that notification were not sent when disabled. |
-| [e2eTest.discord.botName](./values.yaml#L679) | string | `"botkube"` | Name of the BotKube bot to interact with during the e2e tests. |
-| [e2eTest.discord.testerName](./values.yaml#L681) | string | `"botkube_tester"` | Name of the BotKube Tester bot that sends messages during the e2e tests. |
-| [e2eTest.discord.guildID](./values.yaml#L683) | string | `""` | Discord Guild ID (discord server ID) used to run e2e tests |
-| [e2eTest.discord.testerAppToken](./values.yaml#L685) | string | `""` | Discord tester application token that interacts with BotKube bot. |
-| [e2eTest.discord.additionalContextMessage](./values.yaml#L687) | string | `""` | Additional message that is sent by Tester. You can pass e.g. pull request number or source link where these tests are run from. |
-| [e2eTest.discord.messageWaitTimeout](./values.yaml#L689) | string | `"1m"` | Message wait timeout. It defines how long we wait to ensure that notification were not sent when disabled. |
+| [communications.default-group.elasticsearch.indices.default.bindings.sources](./values.yaml#L437) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given index. |
+| [communications.default-group.webhook.enabled](./values.yaml#L444) | bool | `false` | If true, enables Webhook. |
+| [communications.default-group.webhook.url](./values.yaml#L446) | string | `"WEBHOOK_URL"` | The Webhook URL, e.g.: https://example.com:80 |
+| [communications.default-group.webhook.bindings.sources](./values.yaml#L449) | list | `["k8s-err-events"]` | Notification sources configuration for the webhook. |
+| [settings.clusterName](./values.yaml#L455) | string | `"not-configured"` | Cluster name to differentiate incoming messages. |
+| [settings.configWatcher](./values.yaml#L457) | bool | `true` | If true, restarts the BotKube Pod on config changes. |
+| [settings.upgradeNotifier](./values.yaml#L459) | bool | `true` | If true, notifies about new BotKube releases. |
+| [settings.log.level](./values.yaml#L463) | string | `"info"` | Sets one of the log levels. Allowed values: `info`, `warn`, `debug`, `error`, `fatal`, `panic`. |
+| [settings.log.disableColors](./values.yaml#L465) | bool | `false` | If true, disable ANSI colors in logging. |
+| [settings.systemConfigMap](./values.yaml#L468) | object | `{"name":"botkube-system"}` | BotKube's system ConfigMap where internal data is stored. |
+| [ssl.enabled](./values.yaml#L474) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
+| [ssl.existingSecretName](./values.yaml#L480) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
+| [ssl.cert](./values.yaml#L483) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
+| [service](./values.yaml#L486) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
+| [ingress](./values.yaml#L493) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
+| [serviceMonitor](./values.yaml#L504) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
+| [deployment.annotations](./values.yaml#L514) | object | `{}` | Extra annotations to pass to the BotKube Deployment. |
+| [extraAnnotations](./values.yaml#L521) | object | `{}` | Extra annotations to pass to the BotKube Pod. |
+| [extraLabels](./values.yaml#L523) | object | `{}` | Extra labels to pass to the BotKube Pod. |
+| [priorityClassName](./values.yaml#L525) | string | `""` | Priority class name for the BotKube Pod. |
+| [nameOverride](./values.yaml#L528) | string | `""` | Fully override "botkube.name" template. |
+| [fullnameOverride](./values.yaml#L530) | string | `""` | Fully override "botkube.fullname" template. |
+| [resources](./values.yaml#L536) | object | `{}` | The BotKube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
+| [extraEnv](./values.yaml#L548) | list | `[]` | Extra environment variables to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
+| [extraVolumes](./values.yaml#L560) | list | `[]` | Extra volumes to pass to the BotKube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
+| [extraVolumeMounts](./values.yaml#L575) | list | `[]` | Extra volume mounts to pass to the BotKube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
+| [nodeSelector](./values.yaml#L593) | object | `{}` | Node labels for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
+| [tolerations](./values.yaml#L597) | list | `[]` | Tolerations for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
+| [affinity](./values.yaml#L601) | object | `{}` | Affinity for BotKube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
+| [rbac](./values.yaml#L605) | object | `{"create":true,"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["get","watch","list"]}]}` | Role Based Access for BotKube Pod. [Ref doc](https://kubernetes.io/docs/admin/authorization/rbac/). |
+| [serviceAccount.create](./values.yaml#L614) | bool | `true` | If true, a ServiceAccount is automatically created. |
+| [serviceAccount.name](./values.yaml#L617) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
+| [serviceAccount.annotations](./values.yaml#L619) | object | `{}` | Extra annotations for the ServiceAccount. |
+| [extraObjects](./values.yaml#L622) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
+| [analytics.disable](./values.yaml#L650) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://botkube.io/privacy#privacy-policy). |
+| [e2eTest.image.registry](./values.yaml#L656) | string | `"ghcr.io"` | Test runner image registry. |
+| [e2eTest.image.repository](./values.yaml#L658) | string | `"kubeshop/botkube-test"` | Test runner image repository. |
+| [e2eTest.image.pullPolicy](./values.yaml#L660) | string | `"IfNotPresent"` | Test runner image pull policy. |
+| [e2eTest.image.tag](./values.yaml#L662) | string | `"v9.99.9-dev"` | Test runner image tag. Default tag is `appVersion` from Chart.yaml. |
+| [e2eTest.deployment](./values.yaml#L664) | object | `{"waitTimeout":"3m"}` | Configures BotKube Deployment related data. |
+| [e2eTest.slack.botName](./values.yaml#L669) | string | `"botkube"` | Name of the BotKube bot to interact with during the e2e tests. |
+| [e2eTest.slack.testerName](./values.yaml#L671) | string | `"botkube_tester"` | Name of the BotKube Tester bot that sends messages during the e2e tests. |
+| [e2eTest.slack.testerAppToken](./values.yaml#L673) | string | `""` | Slack tester application token that interacts with BotKube bot. |
+| [e2eTest.slack.additionalContextMessage](./values.yaml#L675) | string | `""` | Additional message that is sent by Tester. You can pass e.g. pull request number or source link where these tests are run from. |
+| [e2eTest.slack.messageWaitTimeout](./values.yaml#L677) | string | `"1m"` | Message wait timeout. It defines how long we wait to ensure that notification were not sent when disabled. |
+| [e2eTest.discord.botName](./values.yaml#L680) | string | `"botkube"` | Name of the BotKube bot to interact with during the e2e tests. |
+| [e2eTest.discord.testerName](./values.yaml#L682) | string | `"botkube_tester"` | Name of the BotKube Tester bot that sends messages during the e2e tests. |
+| [e2eTest.discord.guildID](./values.yaml#L684) | string | `""` | Discord Guild ID (discord server ID) used to run e2e tests |
+| [e2eTest.discord.testerAppToken](./values.yaml#L686) | string | `""` | Discord tester application token that interacts with BotKube bot. |
+| [e2eTest.discord.additionalContextMessage](./values.yaml#L688) | string | `""` | Additional message that is sent by Tester. You can pass e.g. pull request number or source link where these tests are run from. |
+| [e2eTest.discord.messageWaitTimeout](./values.yaml#L690) | string | `"1m"` | Message wait timeout. It defines how long we wait to ensure that notification were not sent when disabled. |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/e2e-test-values.yaml
+++ b/helm/botkube/e2e-test-values.yaml
@@ -66,23 +66,28 @@ sources:
         ingress:
           backendServiceValid: false
           tlsSecretValid: false
+      events:
+        - create
+        - update
+        - delete
       resources:
         - name: v1/configmaps
-          events:
-            - create
-            - update
-            - delete
+
   'k8s-updates':
     kubernetes:
       namespaces:
         include:
           - default
+      events:
+        - create
+        - update
+        - delete
       resources:
         - name: v1/configmaps
           namespaces:
             include:
               - botkube
-          events:
+          events: # overrides top level `events` entry
             - update
 executors:
   'kubectl-read-only':

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -448,6 +448,7 @@ communications:
         # -- Notification sources configuration for the webhook.
         sources:
           - k8s-err-events
+          - k8s-recommendation-events
 
 ## Global BotKube configuration.
 settings:

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -58,8 +58,7 @@ kubeconfig:
 #
 ## Format: sources.<alias>
 sources:
-  'k8s-events':
-
+  'k8s-recommendation-events':
     # -- Describes Kubernetes source configuration.
     kubernetes:
       # -- Describes configuration for various recommendation insights.
@@ -77,10 +76,13 @@ sources:
           # -- If true, notifies about Ingress resources with invalid TLS secret reference.
           tlsSecretValid: true
 
+  'k8s-all-events':
+    # -- Describes Kubernetes source configuration.
+    kubernetes:
       # -- Describes namespaces for every Kubernetes resources you want to watch or exclude.
       # These namespaces are applied to every resource specified in the resources list.
       # However, every specified resource can override this by using its own namespaces object.
-      namespaces:
+      namespaces: &k8s-events-namespaces
         # Include contains a list of allowed Namespaces.
         # It can also contain a regex expressions:
         #  `- ".*"` - to specify all Namespaces.
@@ -91,8 +93,16 @@ sources:
         #  `- "test-.*"` - to specif all Namespaces with `test-` prefix.
         # exclude: []
 
+      # -- Describes events for every Kubernetes resources you want to watch or exclude.
+      # These events are applied to every resource specified in the resources list.
+      # However, every specified resource can override this by using its own events object.
+      events:
+        - create
+        - delete
+        - error
+
       # -- Describes the Kubernetes resources you want to watch.
-      # @default -- Watch all built-in K8s kinds.
+      # @default -- See the `values.yaml` file for full object.
       resources:
         - name: v1/pods             # Name of the resource. Resource name must be in group/version/resource (G/V/R) format
                                     # resource name should be plural (e.g apps/v1/deployments, v1/pods)
@@ -101,69 +111,19 @@ sources:
         #    include:
         #      - ".*"
         #    exclude: []
-          events:                   # List of lifecycle events you want to receive, e.g create, update, delete, error OR all
-            - create
-            - delete
-            - error
         - name: v1/services
-          events:
-            - create
-            - delete
-            - error
-        - name: apps/v1/deployments
-          events:
-            - create
-            - update
-            - delete
-            - error
-          updateSetting:
-            includeDiff: true
-            fields:
-              - spec.template.spec.containers[*].image
-              - status.availableReplicas
-        - name: apps/v1/statefulsets
-          events:
-            - create
-            - update
-            - delete
-            - error
-          updateSetting:
-            includeDiff: true
-            fields:
-              - spec.template.spec.containers[*].image
-              - status.readyReplicas
         - name: networking.k8s.io/v1/ingresses
-          events:
-            - create
-            - delete
-            - error
         - name: v1/nodes
-          events:
-            - create
-            - delete
-            - error
         - name: v1/namespaces
-          events:
-            - create
-            - delete
-            - error
         - name: v1/persistentvolumes
-          events:
-            - create
-            - delete
-            - error
         - name: v1/persistentvolumeclaims
-          events:
-            - create
-            - delete
-            - error
         - name: v1/configmaps
-          events:
-            - create
-            - delete
-            - error
+        - name: rbac.authorization.k8s.io/v1/roles
+        - name: rbac.authorization.k8s.io/v1/rolebindings
+        - name: rbac.authorization.k8s.io/v1/clusterrolebindings
+        - name: rbac.authorization.k8s.io/v1/clusterroles
         - name: apps/v1/daemonsets
-          events:
+          events: # Overrides 'source'.kubernetes.events
             - create
             - update
             - delete
@@ -174,7 +134,7 @@ sources:
               - spec.template.spec.containers[*].image
               - status.numberReady
         - name: batch/v1/jobs
-          events:
+          events: # Overrides 'source'.kubernetes.events
             - create
             - update
             - delete
@@ -184,26 +144,28 @@ sources:
             fields:
               - spec.template.spec.containers[*].image
               - status.conditions[*].type
-        - name: rbac.authorization.k8s.io/v1/roles
-          events:
+        - name: apps/v1/deployments
+          events: # Overrides 'source'.kubernetes.events
             - create
+            - update
             - delete
             - error
-        - name: rbac.authorization.k8s.io/v1/rolebindings
-          events:
+          updateSetting:
+            includeDiff: true
+            fields:
+              - spec.template.spec.containers[*].image
+              - status.availableReplicas
+        - name: apps/v1/statefulsets
+          events: # Overrides 'source'.kubernetes.events
             - create
+            - update
             - delete
             - error
-        - name: rbac.authorization.k8s.io/v1/clusterrolebindings
-          events:
-            - create
-            - delete
-            - error
-        - name: rbac.authorization.k8s.io/v1/clusterroles
-          events:
-            - create
-            - delete
-            - error
+          updateSetting:
+            includeDiff: true
+            fields:
+              - spec.template.spec.containers[*].image
+              - status.readyReplicas
        ## Custom resource example
        # - name: velero.io/v1/backups
        #   namespaces:
@@ -220,6 +182,40 @@ sources:
        #     includeDiff: true
        #     fields:
        #       - status.phase
+
+  'k8s-err-events':
+    # -- Describes Kubernetes source configuration.
+    kubernetes:
+      # -- Describes namespaces for every Kubernetes resources you want to watch or exclude.
+      # These namespaces are applied to every resource specified in the resources list.
+      # However, every specified resource can override this by using its own namespaces object.
+      namespaces: *k8s-events-namespaces
+
+      # -- Describes events for every Kubernetes resources you want to watch or exclude.
+      # These events are applied to every resource specified in the resources list.
+      # However, every specified resource can override this by using its own events object.
+      events:
+        - error
+
+      # -- Describes the Kubernetes resources you want to watch.
+      # @default -- See the `values.yaml` file for full object.
+      resources:
+        - name: v1/pods
+        - name: v1/services
+        - name: networking.k8s.io/v1/ingresses
+        - name: v1/nodes
+        - name: v1/namespaces
+        - name: v1/persistentvolumes
+        - name: v1/persistentvolumeclaims
+        - name: v1/configmaps
+        - name: rbac.authorization.k8s.io/v1/roles
+        - name: rbac.authorization.k8s.io/v1/rolebindings
+        - name: rbac.authorization.k8s.io/v1/clusterrolebindings
+        - name: rbac.authorization.k8s.io/v1/clusterroles
+        - name: apps/v1/deployments
+        - name: apps/v1/statefulsets
+        - name: apps/v1/daemonsets
+        - name: batch/v1/jobs
 
 # -- Filter settings for various sources.
 # Currently, all filters are globally enabled or disabled.
@@ -302,7 +298,8 @@ communications:
               - kubectl-read-only
             # -- Notification sources configuration for a given channel.
             sources:
-              - k8s-events
+              - k8s-err-events
+              - k8s-recommendation-events
       # -- Slack token.
       token: ''
       # -- Slack bot token for your own Slack app.
@@ -344,7 +341,8 @@ communications:
               - kubectl-read-only
             # -- Notification sources configuration for a given channel.
             sources:
-              - k8s-events
+              - k8s-err-events
+              - k8s-recommendation-events
       notification:
         # -- Configures notification type that are sent. Possible values: `short`, `long`.
         type: short
@@ -365,7 +363,8 @@ communications:
           - kubectl-read-only
         # -- Source bindings apply to all channels which have notification turned on with `@BotKube notifier start` command.
         sources:
-          - k8s-events
+          - k8s-err-events
+          - k8s-recommendation-events
       # -- The path in endpoint URL provided while registering BotKube to MS Teams.
       messagePath: "/bots/teams"
       # -- The Service port for bot endpoint on BotKube container.
@@ -396,7 +395,8 @@ communications:
               - kubectl-read-only
             # -- Notification sources configuration for a given channel.
             sources:
-              - k8s-events
+              - k8s-err-events
+              - k8s-recommendation-events
       notification:
         # -- Configures notification type that are sent. Possible values: `short`, `long`.
         type: short
@@ -435,7 +435,8 @@ communications:
           bindings:
             # -- Notification sources configuration for a given index.
             sources:
-              - k8s-events
+              - k8s-err-events
+              - k8s-recommendation-events
 
     ## Settings for Webhook.
     webhook:
@@ -446,7 +447,7 @@ communications:
       bindings:
         # -- Notification sources configuration for the webhook.
         sources:
-          - k8s-events
+          - k8s-err-events
 
 ## Global BotKube configuration.
 settings:

--- a/pkg/config/testdata/TestLoadConfigSuccess/config-all.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config-all.yaml
@@ -98,23 +98,16 @@ sources:
         ingress:
           backendServiceValid: true
           tlsSecretValid: false
-
-      # TODO: https://github.com/kubeshop/botkube/issues/596
+      events:
+        - create
+        - delete
+        - error
       # New 'namespace' property.
       # It can be overridden in the nested level.
-      # namespace:
-      #   include: [ ".*" ]
+      namespace:
+        include: [ ".*" ]
       resources:
         - name: v1/pods
-          namespaces:
-            include:
-              - ".*"
-            exclude:
-              - # example [x,y,secret-ns-*]
-          events:
-            - create
-            - delete
-            - error
         - name: v1/services
           namespaces:
             include:

--- a/pkg/config/testdata/TestLoadConfigSuccess/config-all.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config-all.yaml
@@ -104,7 +104,7 @@ sources:
         - error
       # New 'namespace' property.
       # It can be overridden in the nested level.
-      namespace:
+      namespaces:
         include: [ ".*" ]
       resources:
         - name: v1/pods

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -8,17 +8,15 @@ sources:
                 pod:
                     noLatestImageTag: false
                     labelsSet: true
+            events:
+                - create
+                - delete
+                - error
             resources:
                 - name: v1/pods
                   namespaces:
-                    include:
-                        - .*
-                    exclude:
-                        - ""
-                  events:
-                    - create
-                    - delete
-                    - error
+                    include: []
+                  events: []
                   updateSetting:
                     fields: []
                     includeDiff: false

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -241,7 +241,8 @@ sources:
                     fields: []
                     includeDiff: false
             namespaces:
-                include: []
+                include:
+                    - .*
 executors:
     kubectl-read-only:
         kubectl:

--- a/pkg/recommendation/resource_events.go
+++ b/pkg/recommendation/resource_events.go
@@ -54,7 +54,7 @@ func ShouldIgnoreEvent(recCfg config.Recommendations, sources map[string]config.
 		}
 
 		// sources are appended, so we need to check the first source that has a given resource with event
-		if source.Kubernetes.Resources.IsAllowed(event.Resource, event.Namespace, event.Type) {
+		if source.Kubernetes.IsAllowed(event.Resource, event.Namespace, event.Type) {
 			return false
 		}
 	}

--- a/pkg/sources/sources_test.go
+++ b/pkg/sources/sources_test.go
@@ -51,6 +51,122 @@ func TestRouter_GetBoundSources_UsesAddedBindings(t *testing.T) {
 	assert.NotContains(t, boundSources, "k8s-ignored")
 }
 
+func TestRouter_BuildTable_CreatesRoutesWithProperEventsList(t *testing.T) {
+	const hasRoutes = "apps/v1/deployments"
+	logger, _ := logtest.NewNullLogger()
+
+	tests := []struct {
+		name     string
+		givenCfg config.Config
+	}{
+		{
+			name: "Events defined on resource level",
+			givenCfg: config.Config{
+				Sources: map[string]config.Sources{
+					"k8s-events": {
+						Kubernetes: config.KubernetesSource{
+							Resources: []config.Resource{
+								{
+									Name: hasRoutes,
+									Namespaces: config.Namespaces{
+										Include: []string{"default"},
+									},
+									Events: []config.EventType{
+										config.CreateEvent,
+										config.DeleteEvent,
+										config.UpdateEvent,
+										config.ErrorEvent,
+									},
+									UpdateSetting: config.UpdateSetting{
+										Fields:      []string{"status.availableReplicas"},
+										IncludeDiff: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Events defined on top-level",
+			givenCfg: config.Config{
+				Sources: map[string]config.Sources{
+					"k8s-events": {
+						Kubernetes: config.KubernetesSource{
+							Events: []config.EventType{
+								config.CreateEvent,
+								config.DeleteEvent,
+								config.UpdateEvent,
+								config.ErrorEvent,
+							},
+							Resources: []config.Resource{
+								{
+									Name: hasRoutes,
+									Namespaces: config.Namespaces{
+										Include: []string{"default"},
+									},
+									UpdateSetting: config.UpdateSetting{
+										Fields:      []string{"status.availableReplicas"},
+										IncludeDiff: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Events defined on top-level but override by resource once",
+			givenCfg: config.Config{
+				Sources: map[string]config.Sources{
+					"k8s-events": {
+						Kubernetes: config.KubernetesSource{
+							Events: []config.EventType{
+								config.CreateEvent,
+								config.ErrorEvent,
+							},
+							Resources: []config.Resource{
+								{
+									Name: hasRoutes,
+									Namespaces: config.Namespaces{
+										Include: []string{"default"},
+									},
+									Events: []config.EventType{
+										config.CreateEvent,
+										config.DeleteEvent,
+										config.UpdateEvent,
+										config.ErrorEvent,
+									},
+									UpdateSetting: config.UpdateSetting{
+										Fields:      []string{"status.availableReplicas"},
+										IncludeDiff: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			router := NewRouter(nil, nil, logger)
+			router.AddAnyBindings(config.BotBindings{
+				Sources: []string{"k8s-events"},
+			})
+
+			router = router.BuildTable(&tc.givenCfg)
+			assert.Len(t, router.getSourceRoutes(hasRoutes, config.CreateEvent), 1)
+			assert.Len(t, router.getSourceRoutes(hasRoutes, config.UpdateEvent), 1)
+			assert.Len(t, router.getSourceRoutes(hasRoutes, config.DeleteEvent), 1)
+			assert.Len(t, router.getSourceRoutes(hasRoutes, config.ErrorEvent), 1)
+		})
+	}
+}
+
 func TestRouter_BuildTable_CreatesRoutesForBoundSources(t *testing.T) {
 	logger, _ := logtest.NewNullLogger()
 	hasRoutes := "apps/v1/deployments"


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add option to set events list globally
- Define different k8s source presets
  - `k8s-recommendation-events` - enables all possible k8s recommendations
  - `k8s-all-events` - is the name of the previous configuration
  - `k8s-err-events` - enables only `error` events for resources that were watched previously

## Related issue(s)

- #710 
