### PR TITLE
Disable Discord E2E tests temporarily

### DIFF
--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -95,6 +95,9 @@ func TestSlack(t *testing.T) {
 }
 
 func TestDiscord(t *testing.T) {
+	// TODO: Fix it as a part https://github.com/kubeshop/botkube/issues/307
+	t.Skip("Test disabled temporarily as it keeps failing on CI.")
+
 	t.Log("Loading configuration...")
 	var appCfg Config
 	err := envconfig.Init(&appCfg)


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Disable Discord E2E tests temporarily

This test currently keeps failing on CI. Skipping it temporarily to unblock the team until it's fixed.
NOTE: Didn't want to skip it on GH actions level to make sure they can be easily fixed in a follow-up PR and the Ci pipeline will verify if the fix works.

## Related issue(s)

https://github.com/kubeshop/botkube/issues/307

CC @ezodude 