### PR TITLE
Support kubectl aliases

### DIFF
--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -166,15 +166,14 @@ func (e *DefaultExecutor) Execute() interactive.Message {
 	}
 
 	if e.kubectlExecutor.CanHandle(e.conversation.ExecutorBindings, args) {
-		// Currently the verb is always at the first place of `args`, and, in a result, `finalArgs`.
-		// The length of the slice was already checked before
-		// See the DefaultExecutor.Execute() logic.
-		verb := args[0]
+		verb := e.kubectlExecutor.GetVerb(args)
+		message := e.kubectlExecutor.GetCommandWithoutAlias(e.message)
+		//TODO When we deprecate using executor without alias then we should add to analytics the executor name
 		err := e.analyticsReporter.ReportCommand(e.platform, verb)
 		if err != nil {
 			e.log.Errorf("while reporting executed command: %s", err.Error())
 		}
-		out, err := e.kubectlExecutor.Execute(e.conversation.ExecutorBindings, e.message, e.conversation.IsAuthenticated)
+		out, err := e.kubectlExecutor.Execute(e.conversation.ExecutorBindings, message, e.conversation.IsAuthenticated)
 		if err != nil {
 			// TODO: Return error when the DefaultExecutor is refactored as a part of https://github.com/kubeshop/botkube/issues/589
 			e.log.Errorf("while executing kubectl: %s", err.Error())

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -166,14 +166,12 @@ func (e *DefaultExecutor) Execute() interactive.Message {
 	}
 
 	if e.kubectlExecutor.CanHandle(e.conversation.ExecutorBindings, args) {
-		verb := e.kubectlExecutor.GetVerb(args)
-		message := e.kubectlExecutor.GetCommandWithoutAlias(e.message)
-		//TODO When we deprecate using executor without alias then we should add to analytics the executor name
-		err := e.analyticsReporter.ReportCommand(e.platform, verb)
+		cmdPrefix := e.kubectlExecutor.GetCommandPrefix(args)
+		err := e.analyticsReporter.ReportCommand(e.platform, cmdPrefix)
 		if err != nil {
 			e.log.Errorf("while reporting executed command: %s", err.Error())
 		}
-		out, err := e.kubectlExecutor.Execute(e.conversation.ExecutorBindings, message, e.conversation.IsAuthenticated)
+		out, err := e.kubectlExecutor.Execute(e.conversation.ExecutorBindings, e.message, e.conversation.IsAuthenticated)
 		if err != nil {
 			// TODO: Return error when the DefaultExecutor is refactored as a part of https://github.com/kubeshop/botkube/issues/589
 			e.log.Errorf("while executing kubectl: %s", err.Error())

--- a/pkg/execute/kubectl.go
+++ b/pkg/execute/kubectl.go
@@ -102,7 +102,7 @@ func (e *Kubectl) GetCommandPrefix(args []string) string {
 	}
 
 	if len(args) >= 2 && slices.Contains(e.alias, args[0]) {
-		return fmt.Sprintf("{%s} %s", args[0], args[1])
+		return fmt.Sprintf("%s %s", args[0], args[1])
 	}
 
 	return args[0]

--- a/pkg/execute/kubectl_test.go
+++ b/pkg/execute/kubectl_test.go
@@ -527,17 +527,17 @@ func TestKubectlGetCommandPrefix(t *testing.T) {
 		{
 			name:     "Should get proper command with k8s prefix kubectl",
 			command:  "kubectl get pods --cluster-name test",
-			expected: "{kubectl} get",
+			expected: "kubectl get",
 		},
 		{
 			name:     "Should get proper command with k8s prefix kc",
 			command:  "kc get pods --cluster-name test",
-			expected: "{kc} get",
+			expected: "kc get",
 		},
 		{
 			name:     "Should get proper command with k8s prefix k",
 			command:  "k get pods --cluster-name test",
-			expected: "{k} get",
+			expected: "k get",
 		},
 	}
 	logger, _ := logtest.NewNullLogger()

--- a/pkg/execute/kubectl_test.go
+++ b/pkg/execute/kubectl_test.go
@@ -567,7 +567,7 @@ func TestKubectlGetCommandPrefix(t *testing.T) {
 	}
 }
 
-func TestKubectlGetCommandWithoutAlias(t *testing.T) {
+func TestKubectlGetArgsWithoutAlias(t *testing.T) {
 	tests := []struct {
 		name     string
 		command  string
@@ -613,9 +613,9 @@ func TestKubectlGetCommandWithoutAlias(t *testing.T) {
 			kcChecker := kubectl.NewChecker(nil)
 			executor := NewKubectl(logger, config.Config{}, merger, kcChecker, nil)
 
-			verb := executor.GetCommandWithoutAlias(tc.command)
+			verb := executor.getArgsWithoutAlias(tc.command)
 
-			assert.Equal(t, tc.expected, verb)
+			assert.Equal(t, tc.expected, strings.Join(verb, " "))
 		})
 	}
 }

--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -420,7 +420,7 @@ func runBotTest(t *testing.T,
 		k8sPrefixTests := []string{"kubectl", "kc", "k"}
 		for _, prefix := range k8sPrefixTests {
 			t.Run(fmt.Sprintf("Get Pods with k8s prefix %s", prefix), func(t *testing.T) {
-				command := fmt.Sprintf("%s get pods", prefix)
+				command := fmt.Sprintf("%s get pods --namespace %s", prefix, appCfg.Deployment.Namespace)
 				assertionFn := func(msg string) bool {
 					headerColumnNames := []string{"NAME", "READY", "STATUS", "RESTART", "AGE"}
 					containAllColumn := true


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- Support kubectl commands both on root and with prefix, e.g. `@BotKube get po` and `@BotKube kubectl get po`
- Possible aliasses: `kubectl`, `kc`, `k`

## Related issue(s)
#728

## Related PR in botkube-docs
https://github.com/kubeshop/botkube-docs/pull/150

## Tests
Run combination of commands:
- `@BotKube get pods`
- `@BotKube kubectl get pods`
- `@BotKube kc get pods`
- `@BotKube k get pods`
