### PR TITLE
Merge persistent config ConfigMaps between Helm upgrades

### DIFF
--- a/helm/botkube/templates/persistent-config.yaml
+++ b/helm/botkube/templates/persistent-config.yaml
@@ -1,7 +1,8 @@
+{{- $runtimeStateCfgMap := .Values.settings.persistentConfig.runtime.configMap.name -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.settings.persistentConfig.runtime.configMap.name }}
+  name: {{ $runtimeStateCfgMap }}
   annotations:
 {{- if .Values.settings.persistentConfig.runtime.configMap.annotations }}
 {{ toYaml .Values.settings.persistentConfig.runtime.configMap.annotations | indent 4 }}
@@ -12,10 +13,13 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
+  {{- $prevRuntimeCfgMap := lookup "v1" "ConfigMap" .Release.Namespace $runtimeStateCfgMap | default dict }}
+  {{- $prevRuntimeFile := index ( $prevRuntimeCfgMap.data | default dict ) .Values.settings.persistentConfig.runtime.fileName | default "" | fromYaml -}}
+  {{- $mergedRuntimeCommunications := mustMergeOverwrite (mustDeepCopy (default (dict) $prevRuntimeFile.communications )) (mustDeepCopy .Values.communications) }}
   # This file has a special prefix to load it as the last config file during BotKube startup.
   {{ .Values.settings.persistentConfig.runtime.fileName }}: |
     communications:
-    {{- range $commGroupName,$commGroup := .Values.communications }}
+    {{- range $commGroupName,$commGroup := $mergedRuntimeCommunications }}
       {{$commGroupName}}:
       {{- range $commPlatformName,$commPlatform := $commGroup }}
         {{- /* Bots */ -}}
@@ -48,10 +52,11 @@ data:
       {{- end }}
     {{- end }}
 ---
+{{- $startupStateCfgMap := .Values.settings.persistentConfig.startup.configMap.name -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.settings.persistentConfig.startup.configMap.name }}
+  name: {{ $startupStateCfgMap }}
   annotations:
 {{- if .Values.settings.persistentConfig.startup.configMap.annotations }}
 {{ toYaml .Values.settings.persistentConfig.startup.configMap.annotations | indent 4 }}
@@ -62,12 +67,15 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
+  {{- $prevStartupCfgMap := lookup "v1" "ConfigMap" .Release.Namespace $startupStateCfgMap | default dict }}
+  {{- $prevStartupFile := index ( $prevStartupCfgMap.data | default dict ) .Values.settings.persistentConfig.startup.fileName | default "" | fromYaml -}}
+  {{- $mergedStartupCommunications := mustMergeOverwrite (mustDeepCopy (default (dict) $prevStartupFile.communications )) (mustDeepCopy .Values.communications) }}
   # This file has a special prefix to:
   # - load it as the last config file during BotKube startup,
   # - ignore it by Config Watcher.
   {{ .Values.settings.persistentConfig.startup.fileName }}: |
     communications:
-    {{- range $commGroupName,$commGroup := .Values.communications }}
+    {{- range $commGroupName,$commGroup := $mergedStartupCommunications }}
       {{$commGroupName}}:
       {{- range $commPlatformName,$commPlatform := $commGroup -}}
         {{- if $commPlatform.channels }}

--- a/helm/botkube/templates/persistent-config.yaml
+++ b/helm/botkube/templates/persistent-config.yaml
@@ -52,7 +52,7 @@ data:
       {{- end }}
     {{- end }}
 ---
-{{- $startupStateCfgMap := .Values.settings.persistentConfig.startup.configMap.name -}}
+{{ $startupStateCfgMap := .Values.settings.persistentConfig.startup.configMap.name -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -70,6 +70,7 @@ data:
   {{- $prevStartupCfgMap := lookup "v1" "ConfigMap" .Release.Namespace $startupStateCfgMap | default dict }}
   {{- $prevStartupFile := index ( $prevStartupCfgMap.data | default dict ) .Values.settings.persistentConfig.startup.fileName | default "" | fromYaml -}}
   {{- $mergedStartupCommunications := mustMergeOverwrite (mustDeepCopy (default (dict) $prevStartupFile.communications )) (mustDeepCopy .Values.communications) }}
+  {{- $mergedStartupFilters := mustMergeOverwrite (mustDeepCopy (default (dict) $prevStartupFile.filters )) (mustDeepCopy (default (dict) .Values.filters)) }}
   # This file has a special prefix to:
   # - load it as the last config file during BotKube startup,
   # - ignore it by Config Watcher.
@@ -92,5 +93,5 @@ data:
       {{- end }}
     {{- end }}
     filters:
-      {{- .Values.filters | toYaml | nindent 6 }}
-{{/*  {{ end }}*/}}
+      {{- $mergedStartupFilters | toYaml | nindent 6 }}
+


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Merge persistent config ConfigMaps between Helm upgrades

## Testing

Checkout this PR and export the following envs:

```bash
export WS_SLACK_BOT_TOKEN=""
export WS_SLACK_APP_TOKEN=""
```

Install BotKube:

```bash
cat > /tmp/values.yaml << ENDOFFILE
communications:
  'default-group':
    socketSlack:
      enabled: true
      botToken: "${WS_SLACK_BOT_TOKEN}"
      appToken: "${WS_SLACK_APP_TOKEN}"
      channels:
        'default':
          name: botkube-test
          notification:
            disabled: true
          bindings:
            executors:
              - kubectl-read-only
            sources:
              - k8s-events
        'second':
          name: botkube-demo
          bindings:
            executors:
              - kubectl-read-only
            sources:
              - k8s-events

settings:
  clusterName: dev
executors:
  'kubectl-read-only':
    kubectl:
      enabled: true
analytics:
  disable: true
image:
  repository: kubeshop/pr/botkube
  tag: '762-PR'
  pullPolicy: Always  
ENDOFFILE
helm install botkube ./helm/botkube -n botkube --create-namespace  -f /tmp/values.yaml
```

Get ConfigMaps:

```bash
kubectl get cm -n botkube botkube-runtime-config -oyaml
kubectl get cm -n botkube botkube-startup-config -oyaml
```

Run commands on `botkube-test` channel on Slack:

```
@BotKube filters disable NodeEventsChecker
```

```
@BotKube notifier start
```

Also, edit SourceBindings on the same channel:

```yaml
@BotKube edit SourceBindings
```

Wait for app restart.

Same for `botkube-demo channel:

```yaml
@BotKube edit SourceBindings
```

Wait for app restart.

See the ConfigMaps:

```bash
kubectl get cm -n botkube botkube-runtime-config -oyaml
kubectl get cm -n botkube botkube-startup-config -oyaml
```

Upgrade the installation:

```yaml
cat > /tmp/values-upgrade.yaml << ENDOFFILE
communications:
  'default-group':
    socketSlack:
      enabled: true
      botToken: "${WS_SLACK_BOT_TOKEN}"
      appToken: "${WS_SLACK_APP_TOKEN}"
      channels:
        'default':
          name: botkube-test
          notification: null # explicitly not use defaults from Helm chart
          bindings:
            executors: []
            sources: null # explicitly not use defaults from Helm chart
        'second':
          name: botkube-demo
          notification:
            disabled: true
          bindings:
            executors:
              - kubectl-read-only
            sources:
              - k8s-events
              - k8s-err-events

settings:
  clusterName: dev
executors:
  'kubectl-read-only':
    kubectl:
      enabled: true
analytics:
  disable: true
filters: null # explicitly not use defaults from Helm chart
image:
  repository: kubeshop/pr/botkube
  tag: '746-PR'
  pullPolicy: Always  
ENDOFFILE
helm upgrade botkube ./helm/botkube --namespace botkube -f /tmp/values-upgrade.yaml --wait
```

See the ConfigMaps again:

```bash
kubectl get cm -n botkube botkube-runtime-config -oyaml
kubectl get cm -n botkube botkube-startup-config -oyaml
```

You can also run rollback:

```bash
helm rollback -n botkube botkube
```

And the values will be restored to the ones from previous Helm release (changes to state set by commands will be gone).

## Related issue(s)

See #704 
