### PR TITLE
Add analytics to slack interactive buttons

### DIFF
--- a/internal/analytics/noop_reporter.go
+++ b/internal/analytics/noop_reporter.go
@@ -24,7 +24,7 @@ func (n NoopReporter) RegisterCurrentIdentity(_ context.Context, _ kubernetes.In
 }
 
 // ReportCommand reports a new executed command. The command should be anonymized before using this method.
-func (n NoopReporter) ReportCommand(_ config.CommPlatformIntegration, _ string) error {
+func (n NoopReporter) ReportCommand(_ config.CommPlatformIntegration, _ string, _ bool) error {
 	return nil
 }
 

--- a/internal/analytics/reporter.go
+++ b/internal/analytics/reporter.go
@@ -14,7 +14,7 @@ type Reporter interface {
 	RegisterCurrentIdentity(ctx context.Context, k8sCli kubernetes.Interface) error
 
 	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(platform config.CommPlatformIntegration, command string, isInteractiveOrigin bool) error
+	ReportCommand(platform config.CommPlatformIntegration, command string, isButtonClickOrigin bool) error
 
 	// ReportBotEnabled reports an enabled bot.
 	ReportBotEnabled(platform config.CommPlatformIntegration) error

--- a/internal/analytics/reporter.go
+++ b/internal/analytics/reporter.go
@@ -14,7 +14,7 @@ type Reporter interface {
 	RegisterCurrentIdentity(ctx context.Context, k8sCli kubernetes.Interface) error
 
 	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(platform config.CommPlatformIntegration, command string) error
+	ReportCommand(platform config.CommPlatformIntegration, command string, isInteractiveOrigin bool) error
 
 	// ReportBotEnabled reports an enabled bot.
 	ReportBotEnabled(platform config.CommPlatformIntegration) error

--- a/internal/analytics/segment_reporter.go
+++ b/internal/analytics/segment_reporter.go
@@ -17,9 +17,13 @@ import (
 const (
 	kubeSystemNSName  = "kube-system"
 	unknownIdentityID = "00000000-0000-0000-0000-000000000000"
+)
 
-	typedCommand  = "typed"
-	buttonCommand = "buttonClick"
+type commandOrigin string
+
+const (
+	buttonClickCommandOrigin commandOrigin = "buttonClick"
+	typedCommandOrigin       commandOrigin = "typed"
 )
 
 var (
@@ -63,9 +67,9 @@ func (r *SegmentReporter) RegisterCurrentIdentity(ctx context.Context, k8sCli ku
 // ReportCommand reports a new executed command. The command should be anonymized before using this method.
 // The RegisterCurrentIdentity needs to be called first.
 func (r *SegmentReporter) ReportCommand(platform config.CommPlatformIntegration, command string, isInteractiveOrigin bool) error {
-	origin := typedCommand
+	origin := typedCommandOrigin
 	if isInteractiveOrigin {
-		origin = buttonCommand
+		origin = buttonClickCommandOrigin
 	}
 	return r.reportEvent("Command executed", map[string]interface{}{
 		"platform": platform,

--- a/internal/analytics/segment_reporter.go
+++ b/internal/analytics/segment_reporter.go
@@ -19,7 +19,7 @@ const (
 	unknownIdentityID = "00000000-0000-0000-0000-000000000000"
 
 	typedCommand  = "typed"
-	buttonCommand = "button"
+	buttonCommand = "buttonClick"
 )
 
 var (
@@ -62,21 +62,15 @@ func (r *SegmentReporter) RegisterCurrentIdentity(ctx context.Context, k8sCli ku
 
 // ReportCommand reports a new executed command. The command should be anonymized before using this method.
 // The RegisterCurrentIdentity needs to be called first.
-func (r *SegmentReporter) ReportCommand(platform config.CommPlatformIntegration, command string) error {
+func (r *SegmentReporter) ReportCommand(platform config.CommPlatformIntegration, command string, isInteractiveOrigin bool) error {
+	origin := typedCommand
+	if isInteractiveOrigin {
+		origin = buttonCommand
+	}
 	return r.reportEvent("Command executed", map[string]interface{}{
 		"platform": platform,
 		"command":  command,
-		"origin":   typedCommand,
-	})
-}
-
-// ReportButtonCommand reports that user triggered a command using button.
-// The RegisterCurrentIdentity needs to be called first.
-func (r *SegmentReporter) ReportButtonCommand(platform config.CommPlatformIntegration, command string) error {
-	return r.reportEvent("Interactive block", map[string]interface{}{
-		"platform": platform,
-		"command":  command,
-		"origin":   buttonCommand,
+		"origin":   origin,
 	})
 }
 

--- a/internal/analytics/segment_reporter.go
+++ b/internal/analytics/segment_reporter.go
@@ -66,9 +66,9 @@ func (r *SegmentReporter) RegisterCurrentIdentity(ctx context.Context, k8sCli ku
 
 // ReportCommand reports a new executed command. The command should be anonymized before using this method.
 // The RegisterCurrentIdentity needs to be called first.
-func (r *SegmentReporter) ReportCommand(platform config.CommPlatformIntegration, command string, isInteractiveOrigin bool) error {
+func (r *SegmentReporter) ReportCommand(platform config.CommPlatformIntegration, command string, isButtonClickOrigin bool) error {
 	origin := typedCommandOrigin
-	if isInteractiveOrigin {
+	if isButtonClickOrigin {
 		origin = buttonClickCommandOrigin
 	}
 	return r.reportEvent("Command executed", map[string]interface{}{

--- a/internal/analytics/segment_reporter.go
+++ b/internal/analytics/segment_reporter.go
@@ -17,6 +17,9 @@ import (
 const (
 	kubeSystemNSName  = "kube-system"
 	unknownIdentityID = "00000000-0000-0000-0000-000000000000"
+
+	typedCommand  = "typed"
+	buttonCommand = "button"
 )
 
 var (
@@ -63,6 +66,17 @@ func (r *SegmentReporter) ReportCommand(platform config.CommPlatformIntegration,
 	return r.reportEvent("Command executed", map[string]interface{}{
 		"platform": platform,
 		"command":  command,
+		"origin":   typedCommand,
+	})
+}
+
+// ReportButtonCommand reports that user triggered a command using button.
+// The RegisterCurrentIdentity needs to be called first.
+func (r *SegmentReporter) ReportButtonCommand(platform config.CommPlatformIntegration, command string) error {
+	return r.reportEvent("Interactive block", map[string]interface{}{
+		"platform": platform,
+		"command":  command,
+		"origin":   buttonCommand,
 	})
 }
 

--- a/internal/analytics/segment_reporter_test.go
+++ b/internal/analytics/segment_reporter_test.go
@@ -65,13 +65,13 @@ func TestSegmentReporter_ReportCommand(t *testing.T) {
 	segmentReporter, segmentCli := fakeSegmentReporterWithIdentity(identity)
 
 	// when
-	err := segmentReporter.ReportCommand(config.DiscordCommPlatformIntegration, "notifier stop")
+	err := segmentReporter.ReportCommand(config.DiscordCommPlatformIntegration, "notifier stop", false)
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportCommand(config.SlackCommPlatformIntegration, "get")
+	err = segmentReporter.ReportCommand(config.SlackCommPlatformIntegration, "get", false)
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportCommand(config.TeamsCommPlatformIntegration, "notifier start")
+	err = segmentReporter.ReportCommand(config.TeamsCommPlatformIntegration, "notifier start", true)
 	require.NoError(t, err)
 
 	// then

--- a/internal/analytics/testdata/TestSegmentReporter_ReportCommand.json
+++ b/internal/analytics/testdata/TestSegmentReporter_ReportCommand.json
@@ -7,6 +7,7 @@
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
 			"command": "notifier stop",
+			"origin": "typed",
 			"platform": "discord"
 		}
 	},
@@ -18,6 +19,7 @@
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
 			"command": "get",
+			"origin": "typed",
 			"platform": "slack"
 		}
 	},
@@ -29,6 +31,7 @@
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
 			"command": "notifier start",
+			"origin": "buttonClick",
 			"platform": "teams"
 		}
 	}

--- a/pkg/bot/slack_renderer.go
+++ b/pkg/bot/slack_renderer.go
@@ -14,6 +14,11 @@ import (
 	formatx "github.com/kubeshop/botkube/pkg/format"
 )
 
+const (
+	urlButtonActionIDPrefix = "url:"
+	cmdButtonActionIDPrefix = "cmd:"
+)
+
 // SlackRenderer provides functionality to render Slack specific messages from a generic models.
 type SlackRenderer struct {
 	notification config.Notification
@@ -231,9 +236,9 @@ func (b *SlackRenderer) renderButton(btn interactive.Button) slack.BlockElement 
 
 func (b *SlackRenderer) genBtnActionID(btn interactive.Button) string {
 	if btn.Command != "" {
-		return "cmd:" + btn.Command
+		return cmdButtonActionIDPrefix + btn.Command
 	}
-	return "url:" + btn.URL
+	return urlButtonActionIDPrefix + btn.URL
 }
 
 func (*SlackRenderer) mdTextSection(in string, args ...any) *slack.SectionBlock {

--- a/pkg/execute/edit.go
+++ b/pkg/execute/edit.go
@@ -85,7 +85,7 @@ func (e *EditExecutor) Do(args []string, commGroupName string, platform config.C
 
 	defer func() {
 		cmdToReport := fmt.Sprintf("%s %s", cmdName, cmdVerb)
-		err := e.analyticsReporter.ReportCommand(platform, cmdToReport)
+		err := e.analyticsReporter.ReportCommand(platform, cmdToReport, conversation.IsInteractiveOrigin)
 		if err != nil {
 			e.log.Errorf("while reporting edit command: %s", err.Error())
 		}

--- a/pkg/execute/edit.go
+++ b/pkg/execute/edit.go
@@ -85,7 +85,7 @@ func (e *EditExecutor) Do(args []string, commGroupName string, platform config.C
 
 	defer func() {
 		cmdToReport := fmt.Sprintf("%s %s", cmdName, cmdVerb)
-		err := e.analyticsReporter.ReportCommand(platform, cmdToReport, conversation.IsInteractiveOrigin)
+		err := e.analyticsReporter.ReportCommand(platform, cmdToReport, conversation.IsButtonClickOrigin)
 		if err != nil {
 			e.log.Errorf("while reporting edit command: %s", err.Error())
 		}

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -47,22 +47,22 @@ const (
 
 // DefaultExecutor is a default implementations of Executor
 type DefaultExecutor struct {
-	cfg               config.Config
-	filterEngine      filterengine.FilterEngine
-	log               logrus.FieldLogger
-	analyticsReporter AnalyticsReporter
-	cmdRunner         CommandSeparateOutputRunner
-	kubectlExecutor   *Kubectl
-	editExecutor      *EditExecutor
-	notifierExecutor  *NotifierExecutor
-	notifierHandler   NotifierHandler
-	message           string
-	platform          config.CommPlatformIntegration
-	conversation      Conversation
-	merger            *kubectl.Merger
-	cfgManager        ConfigPersistenceManager
-	commGroupName     string
-	user              string
+	cfg                    config.Config
+	filterEngine           filterengine.FilterEngine
+	log                    logrus.FieldLogger
+	reportAnalyticsCommand AnalyticsReportFunc
+	cmdRunner              CommandSeparateOutputRunner
+	kubectlExecutor        *Kubectl
+	editExecutor           *EditExecutor
+	notifierExecutor       *NotifierExecutor
+	notifierHandler        NotifierHandler
+	message                string
+	platform               config.CommPlatformIntegration
+	conversation           Conversation
+	merger                 *kubectl.Merger
+	cfgManager             ConfigPersistenceManager
+	commGroupName          string
+	user                   string
 }
 
 // NotifierAction creates custom type for notifier actions
@@ -242,7 +242,7 @@ func (e *DefaultExecutor) runFilterCommand(ctx context.Context, args []string, c
 	var cmdVerb = args[1]
 	defer func() {
 		cmdToReport := fmt.Sprintf("%s %s", args[0], cmdVerb)
-		err := e.analyticsReporter.ReportCommand(e.platform, cmdToReport)
+		err := e.reportAnalyticsCommand(e.platform, cmdToReport)
 		if err != nil {
 			e.log.Errorf("while reporting filter command: %s", err.Error())
 		}
@@ -302,7 +302,7 @@ func (e *DefaultExecutor) runInfoCommand(args []string) (string, error) {
 		return "", errInvalidCommand
 	}
 
-	err := e.analyticsReporter.ReportCommand(e.platform, strings.Join(args, " "))
+	err := e.reportAnalyticsCommand(e.platform, strings.Join(args, " "))
 	if err != nil {
 		e.log.Errorf("while reporting info command: %s", err.Error())
 	}
@@ -376,7 +376,7 @@ func (e *DefaultExecutor) findBotKubeVersion() (versions string) {
 }
 
 func (e *DefaultExecutor) runVersionCommand(cmd string) string {
-	err := e.analyticsReporter.ReportCommand(e.platform, cmd)
+	err := e.reportAnalyticsCommand(e.platform, cmd)
 	if err != nil {
 		e.log.Errorf("while reporting version command: %s", err.Error())
 	}

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -47,22 +47,22 @@ const (
 
 // DefaultExecutor is a default implementations of Executor
 type DefaultExecutor struct {
-	cfg                    config.Config
-	filterEngine           filterengine.FilterEngine
-	log                    logrus.FieldLogger
-	reportAnalyticsCommand AnalyticsReportFunc
-	cmdRunner              CommandSeparateOutputRunner
-	kubectlExecutor        *Kubectl
-	editExecutor           *EditExecutor
-	notifierExecutor       *NotifierExecutor
-	notifierHandler        NotifierHandler
-	message                string
-	platform               config.CommPlatformIntegration
-	conversation           Conversation
-	merger                 *kubectl.Merger
-	cfgManager             ConfigPersistenceManager
-	commGroupName          string
-	user                   string
+	cfg               config.Config
+	filterEngine      filterengine.FilterEngine
+	log               logrus.FieldLogger
+	analyticsReporter AnalyticsReporter
+	cmdRunner         CommandSeparateOutputRunner
+	kubectlExecutor   *Kubectl
+	editExecutor      *EditExecutor
+	notifierExecutor  *NotifierExecutor
+	notifierHandler   NotifierHandler
+	message           string
+	platform          config.CommPlatformIntegration
+	conversation      Conversation
+	merger            *kubectl.Merger
+	cfgManager        ConfigPersistenceManager
+	commGroupName     string
+	user              string
 }
 
 // NotifierAction creates custom type for notifier actions
@@ -167,7 +167,7 @@ func (e *DefaultExecutor) Execute() interactive.Message {
 
 	if e.kubectlExecutor.CanHandle(e.conversation.ExecutorBindings, args) {
 		cmdPrefix := e.kubectlExecutor.GetCommandPrefix(args)
-		err := e.analyticsReporter.ReportCommand(e.platform, cmdPrefix)
+		err := e.analyticsReporter.ReportCommand(e.platform, cmdPrefix, e.conversation.IsInteractiveOrigin)
 		if err != nil {
 			e.log.Errorf("while reporting executed command: %s", err.Error())
 		}
@@ -242,7 +242,7 @@ func (e *DefaultExecutor) runFilterCommand(ctx context.Context, args []string, c
 	var cmdVerb = args[1]
 	defer func() {
 		cmdToReport := fmt.Sprintf("%s %s", args[0], cmdVerb)
-		err := e.reportAnalyticsCommand(e.platform, cmdToReport)
+		err := e.analyticsReporter.ReportCommand(e.platform, cmdToReport, e.conversation.IsInteractiveOrigin)
 		if err != nil {
 			e.log.Errorf("while reporting filter command: %s", err.Error())
 		}
@@ -302,7 +302,7 @@ func (e *DefaultExecutor) runInfoCommand(args []string) (string, error) {
 		return "", errInvalidCommand
 	}
 
-	err := e.reportAnalyticsCommand(e.platform, strings.Join(args, " "))
+	err := e.analyticsReporter.ReportCommand(e.platform, strings.Join(args, " "), e.conversation.IsInteractiveOrigin)
 	if err != nil {
 		e.log.Errorf("while reporting info command: %s", err.Error())
 	}
@@ -376,7 +376,7 @@ func (e *DefaultExecutor) findBotKubeVersion() (versions string) {
 }
 
 func (e *DefaultExecutor) runVersionCommand(cmd string) string {
-	err := e.reportAnalyticsCommand(e.platform, cmd)
+	err := e.analyticsReporter.ReportCommand(e.platform, cmd, e.conversation.IsInteractiveOrigin)
 	if err != nil {
 		e.log.Errorf("while reporting version command: %s", err.Error())
 	}

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -167,7 +167,7 @@ func (e *DefaultExecutor) Execute() interactive.Message {
 
 	if e.kubectlExecutor.CanHandle(e.conversation.ExecutorBindings, args) {
 		cmdPrefix := e.kubectlExecutor.GetCommandPrefix(args)
-		err := e.analyticsReporter.ReportCommand(e.platform, cmdPrefix, e.conversation.IsInteractiveOrigin)
+		err := e.analyticsReporter.ReportCommand(e.platform, cmdPrefix, e.conversation.IsButtonClickOrigin)
 		if err != nil {
 			e.log.Errorf("while reporting executed command: %s", err.Error())
 		}
@@ -242,7 +242,7 @@ func (e *DefaultExecutor) runFilterCommand(ctx context.Context, args []string, c
 	var cmdVerb = args[1]
 	defer func() {
 		cmdToReport := fmt.Sprintf("%s %s", args[0], cmdVerb)
-		err := e.analyticsReporter.ReportCommand(e.platform, cmdToReport, e.conversation.IsInteractiveOrigin)
+		err := e.analyticsReporter.ReportCommand(e.platform, cmdToReport, e.conversation.IsButtonClickOrigin)
 		if err != nil {
 			e.log.Errorf("while reporting filter command: %s", err.Error())
 		}
@@ -302,7 +302,7 @@ func (e *DefaultExecutor) runInfoCommand(args []string) (string, error) {
 		return "", errInvalidCommand
 	}
 
-	err := e.analyticsReporter.ReportCommand(e.platform, strings.Join(args, " "), e.conversation.IsInteractiveOrigin)
+	err := e.analyticsReporter.ReportCommand(e.platform, strings.Join(args, " "), e.conversation.IsButtonClickOrigin)
 	if err != nil {
 		e.log.Errorf("while reporting info command: %s", err.Error())
 	}
@@ -376,7 +376,7 @@ func (e *DefaultExecutor) findBotKubeVersion() (versions string) {
 }
 
 func (e *DefaultExecutor) runVersionCommand(cmd string) string {
-	err := e.analyticsReporter.ReportCommand(e.platform, cmd, e.conversation.IsInteractiveOrigin)
+	err := e.analyticsReporter.ReportCommand(e.platform, cmd, e.conversation.IsButtonClickOrigin)
 	if err != nil {
 		e.log.Errorf("while reporting version command: %s", err.Error())
 	}

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -52,7 +52,7 @@ type ConfigPersistenceManager interface {
 // AnalyticsReporter defines a reporter that collects analytics data.
 type AnalyticsReporter interface {
 	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(platform config.CommPlatformIntegration, command string, isInteractiveOrigin bool) error
+	ReportCommand(platform config.CommPlatformIntegration, command string, isButtonClickOrigin bool) error
 }
 
 // NewExecutorFactory creates new DefaultExecutorFactory.
@@ -93,7 +93,7 @@ type Conversation struct {
 	ID                  string
 	ExecutorBindings    []string
 	IsAuthenticated     bool
-	IsInteractiveOrigin bool
+	IsButtonClickOrigin bool
 }
 
 // NewDefaultInput an input for NewDefault

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -49,15 +49,10 @@ type ConfigPersistenceManager interface {
 	PersistFilterEnabled(ctx context.Context, name string, enabled bool) error
 }
 
-type AnalyticsReportFunc func(platform config.CommPlatformIntegration, command string) error
-
 // AnalyticsReporter defines a reporter that collects analytics data.
 type AnalyticsReporter interface {
 	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(platform config.CommPlatformIntegration, command string) error
-
-	// ReportButtonCommand reports that user triggered a command using button. The command should be anonymized before using this method.
-	ReportButtonCommand(platform config.CommPlatformIntegration, command string) error
+	ReportCommand(platform config.CommPlatformIntegration, command string, isInteractiveOrigin bool) error
 }
 
 // NewExecutorFactory creates new DefaultExecutorFactory.
@@ -113,27 +108,22 @@ type NewDefaultInput struct {
 
 // NewDefault creates new Default Executor.
 func (f *DefaultExecutorFactory) NewDefault(cfg NewDefaultInput) Executor {
-	var reportFunc AnalyticsReportFunc = f.analyticsReporter.ReportCommand
-	if cfg.Conversation.IsInteractiveOrigin {
-		reportFunc = f.analyticsReporter.ReportButtonCommand
-	}
-
 	return &DefaultExecutor{
-		log:                    f.log,
-		cmdRunner:              f.cmdRunner,
-		cfg:                    f.cfg,
-		reportAnalyticsCommand: reportFunc,
-		kubectlExecutor:        f.kubectlExecutor,
-		notifierExecutor:       f.notifierExecutor,
-		editExecutor:           f.editExecutor,
-		filterEngine:           f.filterEngine,
-		merger:                 f.merger,
-		cfgManager:             f.cfgManager,
-		user:                   cfg.User,
-		notifierHandler:        cfg.NotifierHandler,
-		conversation:           cfg.Conversation,
-		message:                cfg.Message,
-		platform:               cfg.Platform,
-		commGroupName:          cfg.CommGroupName,
+		log:               f.log,
+		cmdRunner:         f.cmdRunner,
+		cfg:               f.cfg,
+		analyticsReporter: f.analyticsReporter,
+		kubectlExecutor:   f.kubectlExecutor,
+		notifierExecutor:  f.notifierExecutor,
+		editExecutor:      f.editExecutor,
+		filterEngine:      f.filterEngine,
+		merger:            f.merger,
+		cfgManager:        f.cfgManager,
+		user:              cfg.User,
+		notifierHandler:   cfg.NotifierHandler,
+		conversation:      cfg.Conversation,
+		message:           cfg.Message,
+		platform:          cfg.Platform,
+		commGroupName:     cfg.CommGroupName,
 	}
 }

--- a/pkg/execute/helper_test.go
+++ b/pkg/execute/helper_test.go
@@ -9,7 +9,7 @@ import (
 
 type fakeAnalyticsReporter struct{}
 
-func (f *fakeAnalyticsReporter) ReportCommand(_ config.CommPlatformIntegration, _ string) error {
+func (f *fakeAnalyticsReporter) ReportCommand(_ config.CommPlatformIntegration, _ string, _ bool) error {
 	return nil
 }
 

--- a/pkg/execute/notifier.go
+++ b/pkg/execute/notifier.go
@@ -69,7 +69,7 @@ func (e *NotifierExecutor) Do(ctx context.Context, args []string, commGroupName 
 			cmdVerb = anonymizedInvalidVerb // prevent passing any personal information
 		}
 		cmdToReport := fmt.Sprintf("%s %s", args[0], cmdVerb)
-		err := e.analyticsReporter.ReportCommand(platform, cmdToReport, conversation.IsInteractiveOrigin)
+		err := e.analyticsReporter.ReportCommand(platform, cmdToReport, conversation.IsButtonClickOrigin)
 		if err != nil {
 			// TODO: Return error when the DefaultExecutor is refactored as a part of https://github.com/kubeshop/botkube/issues/589
 			e.log.Errorf("while reporting notifier command: %s", err.Error())

--- a/pkg/execute/notifier.go
+++ b/pkg/execute/notifier.go
@@ -69,7 +69,7 @@ func (e *NotifierExecutor) Do(ctx context.Context, args []string, commGroupName 
 			cmdVerb = anonymizedInvalidVerb // prevent passing any personal information
 		}
 		cmdToReport := fmt.Sprintf("%s %s", args[0], cmdVerb)
-		err := e.analyticsReporter.ReportCommand(platform, cmdToReport)
+		err := e.analyticsReporter.ReportCommand(platform, cmdToReport, conversation.IsInteractiveOrigin)
 		if err != nil {
 			// TODO: Return error when the DefaultExecutor is refactored as a part of https://github.com/kubeshop/botkube/issues/589
 			e.log.Errorf("while reporting notifier command: %s", err.Error())


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add analytics to slack interactive buttons. IMO that's the simplest implementation.

   I tried to not modify the code where the `ReportCommand` was used and instead pass func there (see: [bd5020d](https://github.com/kubeshop/botkube/pull/770/commits/bd5020da642d7f55afea53c07e918518ed7470b8#diff-6fe247c9584512f88190e551aeeb30dfedf84d5a4de4aa0a35a9ab1ec221b32aR116-R119)) but the problematic part is for instances such as notifier or edit manager where we already pass the `analyticsReporter`. In this case, to avoid reaces we would need to always do `NewEditExecutor`,`NewNotifierExecutor`, each time we construct executor. IMO this is not worth it. 

We don't need to update our privacy policy as we still only work in "command" area.

## Testing

To test that you need to build the image manually with embedded API key:
```bash
env ANALYTICS_API_KEY="" goreleaser release --rm-dist --snapshot --skip-publish
```

Later you can import that image into your cluster: `k3d image import ghcr.io/kubeshop/botkube:v9.99.9-dev` (if you use k3d).

Then access segment.io, and run `@BotKube help` and then click button to run some  command. You should see two events:
- help command with `"origin": "typed"`
- your command but with `"origin": "buttonClick"`

## Related issue(s)

Fix #756 
