### PR TITLE
Use color scheme in E2E tests

### DIFF
--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -51,19 +51,17 @@ type Config struct {
 type AttachmentStatus = map[config.Level]string
 
 type SlackConfig struct {
-	BotName                  string           `envconfig:"default=botkube"`
-	TesterName               string           `envconfig:"default=tester"`
-	AdditionalContextMessage string           `envconfig:"optional"`
-	AttachmentStatus         AttachmentStatus `envconfig:"optional"`
+	BotName                  string `envconfig:"default=botkube"`
+	TesterName               string `envconfig:"default=tester"`
+	AdditionalContextMessage string `envconfig:"optional"`
 	TesterAppToken           string
 	MessageWaitTimeout       time.Duration `envconfig:"default=30s"`
 }
 
 type DiscordConfig struct {
-	BotName                  string           `envconfig:"default=botkube"`
-	TesterName               string           `envconfig:"default=botkube_tester"`
-	AdditionalContextMessage string           `envconfig:"optional"`
-	AttachmentStatus         AttachmentStatus `envconfig:"optional"`
+	BotName                  string `envconfig:"default=botkube"`
+	TesterName               string `envconfig:"default=botkube_tester"`
+	AdditionalContextMessage string `envconfig:"optional"`
 	GuildID                  string
 	TesterAppToken           string
 	MessageWaitTimeout       time.Duration `envconfig:"default=30s"`
@@ -124,10 +122,8 @@ func TestDiscord(t *testing.T) {
 func newBotDriver(cfg Config, driverType DriverType) (BotDriver, error) {
 	switch driverType {
 	case SlackBot:
-		cfg.Slack.AttachmentStatus = SlackAttachmentColorStatus
 		return newSlackDriver(cfg.Slack)
 	case DiscordBot:
-		cfg.Discord.AttachmentStatus = DiscordAttachmentColorStatus
 		return newDiscordDriver(cfg.Discord)
 	}
 	return nil, nil

--- a/test/e2e/bots_tester_test.go
+++ b/test/e2e/bots_tester_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"github.com/kubeshop/botkube/pkg/config"
 	"regexp"
 	"testing"
 
@@ -64,4 +65,5 @@ type BotDriver interface {
 	TesterUserID() string
 	WaitForInteractiveMessagePostedRecentlyEqual(userID string, channelID string, message interactive.Message) error
 	WaitForLastInteractiveMessagePostedEqual(userID string, channelID string, message interactive.Message) error
+	GetColorByLevel(level config.Level) string
 }

--- a/test/e2e/bots_tester_test.go
+++ b/test/e2e/bots_tester_test.go
@@ -3,13 +3,13 @@
 package e2e
 
 import (
-	"github.com/kubeshop/botkube/pkg/config"
 	"regexp"
 	"testing"
 
 	"github.com/sanity-io/litter"
 
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
+	"github.com/kubeshop/botkube/pkg/config"
 )
 
 const recentMessagesLimit = 6

--- a/test/e2e/discord_driver_test.go
+++ b/test/e2e/discord_driver_test.go
@@ -325,11 +325,7 @@ func (d *discordTester) WaitForLastInteractiveMessagePostedEqual(userID, channel
 }
 
 func (d *discordTester) GetColorByLevel(level config.Level) string {
-	if d.cfg.AttachmentStatus[level] != "" {
-		return d.cfg.AttachmentStatus[level]
-	}
-
-	return ""
+	return DiscordAttachmentColorStatus[level]
 }
 
 func (d *discordTester) findUserID(t *testing.T, name string) string {

--- a/test/e2e/discord_driver_test.go
+++ b/test/e2e/discord_driver_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"errors"
 	"fmt"
+	"github.com/kubeshop/botkube/pkg/config"
 	"strconv"
 	"strings"
 	"testing"
@@ -18,6 +19,14 @@ import (
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
 	"github.com/kubeshop/botkube/pkg/multierror"
 )
+
+var DiscordAttachmentColorStatus = AttachmentStatus{
+	config.Info:     "8311585",
+	config.Debug:    "8311585",
+	config.Warn:     "16312092",
+	config.Error:    "13632027",
+	config.Critical: "13632027",
+}
 
 type DiscordChannel struct {
 	*discordgo.Channel
@@ -313,6 +322,14 @@ func (d *discordTester) WaitForLastInteractiveMessagePostedEqual(userID, channel
 	return d.WaitForMessagePosted(userID, channelID, 1, func(msg string) bool {
 		return strings.EqualFold(markdown, msg)
 	})
+}
+
+func (d *discordTester) GetColorByLevel(level config.Level) string {
+	if d.cfg.AttachmentStatus[level] != "" {
+		return d.cfg.AttachmentStatus[level]
+	}
+
+	return ""
 }
 
 func (d *discordTester) findUserID(t *testing.T, name string) string {

--- a/test/e2e/discord_driver_test.go
+++ b/test/e2e/discord_driver_test.go
@@ -5,7 +5,6 @@ package e2e
 import (
 	"errors"
 	"fmt"
-	"github.com/kubeshop/botkube/pkg/config"
 	"strconv"
 	"strings"
 	"testing"
@@ -17,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
+	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/multierror"
 )
 

--- a/test/e2e/slack_driver_test.go
+++ b/test/e2e/slack_driver_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"errors"
 	"fmt"
+	"github.com/kubeshop/botkube/pkg/config"
 	"strings"
 	"testing"
 
@@ -17,6 +18,14 @@ import (
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
 	"github.com/kubeshop/botkube/pkg/multierror"
 )
+
+var SlackAttachmentColorStatus = AttachmentStatus{
+	config.Info:     "2eb886",
+	config.Debug:    "2eb886",
+	config.Warn:     "daa038",
+	config.Error:    "a30200",
+	config.Critical: "a30200",
+}
 
 type SlackChannel struct {
 	*slack.Channel
@@ -307,6 +316,14 @@ func (s *slackTester) WaitForLastInteractiveMessagePostedEqual(userID, channelID
 	return s.WaitForMessagePosted(userID, channelID, 1, func(msg string) bool {
 		return strings.EqualFold(strings.NewReplacer("<https", "https", ">\n", "\n").Replace(msg), renderedMsg)
 	})
+}
+
+func (s *slackTester) GetColorByLevel(level config.Level) string {
+	if s.cfg.AttachmentStatus[level] != "" {
+		return s.cfg.AttachmentStatus[level]
+	}
+
+	return ""
 }
 
 func (s *slackTester) findUserID(t *testing.T, name string) string {

--- a/test/e2e/slack_driver_test.go
+++ b/test/e2e/slack_driver_test.go
@@ -319,11 +319,7 @@ func (s *slackTester) WaitForLastInteractiveMessagePostedEqual(userID, channelID
 }
 
 func (s *slackTester) GetColorByLevel(level config.Level) string {
-	if s.cfg.AttachmentStatus[level] != "" {
-		return s.cfg.AttachmentStatus[level]
-	}
-
-	return ""
+	return SlackAttachmentColorStatus[level]
 }
 
 func (s *slackTester) findUserID(t *testing.T, name string) string {

--- a/test/e2e/slack_driver_test.go
+++ b/test/e2e/slack_driver_test.go
@@ -5,7 +5,6 @@ package e2e
 import (
 	"errors"
 	"fmt"
-	"github.com/kubeshop/botkube/pkg/config"
 	"strings"
 	"testing"
 
@@ -16,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
+	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/multierror"
 )
 


### PR DESCRIPTION
## Description
Added tests color schema for message attachment (embeded) in Slack & Discord

## Related issue(s)
fix https://github.com/kubeshop/botkube/issues/730

## How to test
Run integration tests (it was added for attachment assertion)