### PR TITLE
Interactive output filtering

### DIFF
--- a/pkg/bot/interactive/message.go
+++ b/pkg/bot/interactive/message.go
@@ -45,10 +45,11 @@ const (
 type Message struct {
 	Type MessageType
 	Base
-	Sections          []Section
-	Inputs            []Input
-	OnlyVisibleForYou bool
-	ReplaceOriginal   bool
+	Sections               []Section
+	Inputs                 []Input
+	OnlyVisibleForYou      bool
+	ReplaceOriginal        bool
+	IgnoreOriginalResponse bool
 }
 
 // HasSections returns true if message has interactive sections.

--- a/pkg/bot/interactive/message.go
+++ b/pkg/bot/interactive/message.go
@@ -50,11 +50,10 @@ const (
 type Message struct {
 	Type MessageType
 	Base
-	Sections               []Section
-	Inputs                 []Input
-	OnlyVisibleForYou      bool
-	ReplaceOriginal        bool
-	IgnoreOriginalResponse bool
+	Sections          []Section
+	Inputs            []Input
+	OnlyVisibleForYou bool
+	ReplaceOriginal   bool
 }
 
 // HasSections returns true if message has interactive sections.
@@ -131,6 +130,7 @@ type Selects struct {
 
 // Input is used to create input elements to use in slack messages.
 type Input struct {
+	ID               string
 	DispatchedAction bool
 	Element          InputElement
 	Label            InputLabel

--- a/pkg/bot/interactive/message.go
+++ b/pkg/bot/interactive/message.go
@@ -33,11 +33,22 @@ const (
 	Popup MessageType = "form"
 )
 
+type InputType string
+type PlainTextType string
+type PlainTextInputType string
+
+const (
+	InputText      InputType          = "input"
+	PlainText      PlainTextType      = "plain_text"
+	PlainTextInput PlainTextInputType = "plain_text_input"
+)
+
 // Message represents a generic message with interactive buttons.
 type Message struct {
 	Type MessageType
 	Base
 	Sections          []Section
+	Inputs            []Input
 	OnlyVisibleForYou bool
 	ReplaceOriginal   bool
 }
@@ -45,6 +56,11 @@ type Message struct {
 // HasSections returns true if message has interactive sections.
 func (msg *Message) HasSections() bool {
 	return len(msg.Sections) != 0
+}
+
+// HasInputs returns true if message has interactive inputs.
+func (msg *Message) HasInputs() bool {
+	return len(msg.Inputs) != 0
 }
 
 // Select holds data related to the select drop-down.
@@ -107,6 +123,22 @@ type Selects struct {
 	// ID allows to identify a given block when we do the updated.
 	ID    string
 	Items []Select
+}
+
+type Input struct {
+	Type             InputType
+	DispatchedAction bool
+	Element          InputElement
+	Label            InputLabel
+}
+
+type InputElement struct {
+	Type PlainTextInputType
+}
+
+type InputLabel struct {
+	Type PlainTextType
+	Text string
 }
 
 // AreOptionsDefined returns true if some options are available.

--- a/pkg/bot/interactive/message.go
+++ b/pkg/bot/interactive/message.go
@@ -33,11 +33,16 @@ const (
 	Popup MessageType = "form"
 )
 
+// PlainTextType defines the label as plain_text
 type PlainTextType string
+
+// PlainTextInputType defines the element as plain_text_input
 type PlainTextInputType string
 
 const (
-	PlainText      PlainTextType      = "plain_text"
+	// PlainText refers to plain_text
+	PlainText PlainTextType = "plain_text"
+	// PlainTextInput refers to plain_text for elements
 	PlainTextInput PlainTextInputType = "plain_text_input"
 )
 
@@ -124,16 +129,19 @@ type Selects struct {
 	Items []Select
 }
 
+// Input is used to create input elements to use in slack messages.
 type Input struct {
 	DispatchedAction bool
 	Element          InputElement
 	Label            InputLabel
 }
 
+// InputElement is one of the components of Input. This component is mostly used to hold elements like input text, etc...
 type InputElement struct {
 	Type PlainTextInputType
 }
 
+// InputLabel refers to label of input element
 type InputLabel struct {
 	Type PlainTextType
 	Text string

--- a/pkg/bot/interactive/message.go
+++ b/pkg/bot/interactive/message.go
@@ -33,12 +33,10 @@ const (
 	Popup MessageType = "form"
 )
 
-type InputType string
 type PlainTextType string
 type PlainTextInputType string
 
 const (
-	InputText      InputType          = "input"
 	PlainText      PlainTextType      = "plain_text"
 	PlainTextInput PlainTextInputType = "plain_text_input"
 )
@@ -126,7 +124,6 @@ type Selects struct {
 }
 
 type Input struct {
-	Type             InputType
 	DispatchedAction bool
 	Element          InputElement
 	Label            InputLabel

--- a/pkg/bot/slack.go
+++ b/pkg/bot/slack.go
@@ -259,8 +259,6 @@ func (b *Slack) send(msg slackMessage, req string, resp interactive.Message, onl
 		return fmt.Errorf("while reading Slack response: empty response for request %q", req)
 	}
 
-	var options = []slack.MsgOption{slack.MsgOptionText(markdown, false), slack.MsgOptionAsUser(true)}
-
 	// Upload message as a file if too long
 	if len(markdown) >= slackMaxMessageSize {
 		_, err := uploadFileToSlack(msg.Channel, resp, b.client)
@@ -269,6 +267,8 @@ func (b *Slack) send(msg slackMessage, req string, resp interactive.Message, onl
 		}
 		return nil
 	}
+
+	var options = []slack.MsgOption{slack.MsgOptionText(markdown, false), slack.MsgOptionAsUser(true)}
 
 	//if the message is from thread then add an option to return the response to the thread
 	if msg.ThreadTimeStamp != "" {

--- a/pkg/bot/slack_renderer.go
+++ b/pkg/bot/slack_renderer.go
@@ -98,7 +98,7 @@ func (b *SlackRenderer) RenderModal(msg interactive.Message) slack.ModalViewRequ
 
 // RenderInteractiveMessage returns Slack message based on the input msg.
 func (b *SlackRenderer) RenderInteractiveMessage(msg interactive.Message) slack.MsgOption {
-	if msg.HasSections() {
+	if msg.HasSections() || msg.HasInputs() {
 		blocks := b.RenderAsSlackBlocks(msg)
 		return slack.MsgOptionBlocks(blocks...)
 	}
@@ -130,6 +130,10 @@ func (b *SlackRenderer) RenderAsSlackBlocks(msg interactive.Message) []slack.Blo
 		if !(idx == all-1) { // if not the last one, append divider
 			blocks = append(blocks, slack.NewDividerBlock())
 		}
+	}
+
+	for _, i := range msg.Inputs {
+		blocks = append(blocks, b.renderInput(i)...)
 	}
 
 	return blocks
@@ -248,6 +252,17 @@ func (b *SlackRenderer) renderTextFields(in interactive.TextFields) slack.Block 
 		textBlockObjs,
 		nil,
 	)
+}
+
+func (b *SlackRenderer) renderInput(in interactive.Input) []slack.Block {
+	var out []slack.Block
+	out = append(out, slack.InputBlock{
+		Type:           slack.MessageBlockType(in.Type),
+		Label:          b.plainTextBlock(in.Label.Text),
+		Element:        slack.PlainTextInputBlockElement{Type: slack.MessageElementType(in.Element.Type)},
+		DispatchAction: in.DispatchedAction,
+	})
+	return out
 }
 
 func (b *SlackRenderer) renderContext(in []interactive.ContextItem) []slack.Block {

--- a/pkg/bot/slack_renderer.go
+++ b/pkg/bot/slack_renderer.go
@@ -108,36 +108,32 @@ func (b *SlackRenderer) RenderInteractiveMessage(msg interactive.Message) slack.
 // RenderAsSlackBlocks returns the Slack message blocks for a given input message.
 func (b *SlackRenderer) RenderAsSlackBlocks(msg interactive.Message) []slack.Block {
 	var blocks []slack.Block
-	if !msg.IgnoreOriginalResponse {
-		// Input actions are rendered once the message size is big. For this case,
-		// we shouldn't render basic fields, only input field is ok.
-		if msg.Header != "" {
-			blocks = append(blocks, b.mdTextSection("*%s*", msg.Header))
-		}
+	if msg.Header != "" {
+		blocks = append(blocks, b.mdTextSection("*%s*", msg.Header))
+	}
 
-		if msg.Description != "" {
-			blocks = append(blocks, b.mdTextSection(msg.Description))
-		}
+	if msg.Description != "" {
+		blocks = append(blocks, b.mdTextSection(msg.Description))
+	}
 
-		if msg.Body.Plaintext != "" {
-			blocks = append(blocks, b.mdTextSection(msg.Body.Plaintext))
-		}
+	if msg.Body.Plaintext != "" {
+		blocks = append(blocks, b.mdTextSection(msg.Body.Plaintext))
+	}
 
-		if msg.Body.CodeBlock != "" {
-			blocks = append(blocks, b.mdTextSection(formatx.AdaptiveCodeBlock(msg.Body.CodeBlock)))
-		}
+	if msg.Body.CodeBlock != "" {
+		blocks = append(blocks, b.mdTextSection(formatx.AdaptiveCodeBlock(msg.Body.CodeBlock)))
+	}
 
-		all := len(msg.Sections)
-		for idx, s := range msg.Sections {
-			blocks = append(blocks, b.renderSection(s)...)
-			if !(idx == all-1) { // if not the last one, append divider
-				blocks = append(blocks, slack.NewDividerBlock())
-			}
+	all := len(msg.Sections)
+	for idx, s := range msg.Sections {
+		blocks = append(blocks, b.renderSection(s)...)
+		if !(idx == all-1) { // if not the last one, append divider
+			blocks = append(blocks, slack.NewDividerBlock())
 		}
 	}
 
 	for _, i := range msg.Inputs {
-		blocks = append(blocks, b.renderInput(i, msg.Description)...)
+		blocks = append(blocks, b.renderInput(i)...)
 	}
 
 	return blocks
@@ -258,14 +254,14 @@ func (b *SlackRenderer) renderTextFields(in interactive.TextFields) slack.Block 
 	)
 }
 
-func (b *SlackRenderer) renderInput(in interactive.Input, blockID string) []slack.Block {
+func (b *SlackRenderer) renderInput(in interactive.Input) []slack.Block {
 	return []slack.Block{
 		slack.InputBlock{
 			Type:           slack.MBTInput,
 			Label:          b.plainTextBlock(in.Label.Text),
 			Element:        slack.PlainTextInputBlockElement{Type: slack.MessageElementType(in.Element.Type)},
 			DispatchAction: in.DispatchedAction,
-			BlockID:        blockID,
+			BlockID:        in.ID,
 		},
 	}
 }

--- a/pkg/bot/slack_renderer.go
+++ b/pkg/bot/slack_renderer.go
@@ -257,7 +257,7 @@ func (b *SlackRenderer) renderTextFields(in interactive.TextFields) slack.Block 
 func (b *SlackRenderer) renderInput(in interactive.Input) []slack.Block {
 	var out []slack.Block
 	out = append(out, slack.InputBlock{
-		Type:           slack.MessageBlockType(in.Type),
+		Type:           slack.MBTInput,
 		Label:          b.plainTextBlock(in.Label.Text),
 		Element:        slack.PlainTextInputBlockElement{Type: slack.MessageElementType(in.Element.Type)},
 		DispatchAction: in.DispatchedAction,

--- a/pkg/bot/slack_renderer.go
+++ b/pkg/bot/slack_renderer.go
@@ -108,29 +108,31 @@ func (b *SlackRenderer) RenderInteractiveMessage(msg interactive.Message) slack.
 // RenderAsSlackBlocks returns the Slack message blocks for a given input message.
 func (b *SlackRenderer) RenderAsSlackBlocks(msg interactive.Message) []slack.Block {
 	var blocks []slack.Block
-	// Input actions are rendered once the message size is big. For this case,
-	// we shouldn't render basic fields, only input field is ok.
-	if msg.Header != "" && !msg.HasInputs() {
-		blocks = append(blocks, b.mdTextSection("*%s*", msg.Header))
-	}
+	if !msg.IgnoreOriginalResponse {
+		// Input actions are rendered once the message size is big. For this case,
+		// we shouldn't render basic fields, only input field is ok.
+		if msg.Header != "" {
+			blocks = append(blocks, b.mdTextSection("*%s*", msg.Header))
+		}
 
-	if msg.Description != "" && !msg.HasInputs() {
-		blocks = append(blocks, b.mdTextSection(msg.Description))
-	}
+		if msg.Description != "" {
+			blocks = append(blocks, b.mdTextSection(msg.Description))
+		}
 
-	if msg.Body.Plaintext != "" && !msg.HasInputs() {
-		blocks = append(blocks, b.mdTextSection(msg.Body.Plaintext))
-	}
+		if msg.Body.Plaintext != "" {
+			blocks = append(blocks, b.mdTextSection(msg.Body.Plaintext))
+		}
 
-	if msg.Body.CodeBlock != "" && !msg.HasInputs() {
-		blocks = append(blocks, b.mdTextSection(formatx.AdaptiveCodeBlock(msg.Body.CodeBlock)))
-	}
+		if msg.Body.CodeBlock != "" {
+			blocks = append(blocks, b.mdTextSection(formatx.AdaptiveCodeBlock(msg.Body.CodeBlock)))
+		}
 
-	all := len(msg.Sections)
-	for idx, s := range msg.Sections {
-		blocks = append(blocks, b.renderSection(s)...)
-		if !(idx == all-1) { // if not the last one, append divider
-			blocks = append(blocks, slack.NewDividerBlock())
+		all := len(msg.Sections)
+		for idx, s := range msg.Sections {
+			blocks = append(blocks, b.renderSection(s)...)
+			if !(idx == all-1) { // if not the last one, append divider
+				blocks = append(blocks, slack.NewDividerBlock())
+			}
 		}
 	}
 

--- a/pkg/bot/socketslack.go
+++ b/pkg/bot/socketslack.go
@@ -378,7 +378,6 @@ func (b *SocketSlack) send(event socketSlackMessage, req string, resp interactiv
 				break
 			}
 		}
-
 	}
 
 	if resp.ReplaceOriginal && event.ResponseURL != "" {

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -163,18 +163,7 @@ func (e *DefaultExecutor) Execute() interactive.Message {
 		}
 		// Show Filter Input if command response is more than `lineLimitToShowFilter`
 		if len(strings.SplitN(msg, "\n", lineLimitToShowFilter)) == lineLimitToShowFilter {
-			message.Inputs = []interactive.Input{
-				{
-					DispatchedAction: true,
-					Element: interactive.InputElement{
-						Type: interactive.PlainTextInput,
-					},
-					Label: interactive.InputLabel{
-						Type: interactive.PlainText,
-						Text: "Filter Output",
-					},
-				},
-			}
+			message.Inputs = append(message.Inputs, e.filterInput(command, botName))
 		}
 		return message
 	}
@@ -452,4 +441,18 @@ func (e *DefaultExecutor) appendByUserOnlyIfNeeded(cmd string) string {
 		return cmd
 	}
 	return fmt.Sprintf("%s by %s", cmd, e.user)
+}
+
+func (e *DefaultExecutor) filterInput(id, botName string) interactive.Input {
+	return interactive.Input{
+		ID:               fmt.Sprintf("%s %s --filter=", botName, id),
+		DispatchedAction: true,
+		Element: interactive.InputElement{
+			Type: interactive.PlainTextInput,
+		},
+		Label: interactive.InputLabel{
+			Type: interactive.PlainText,
+			Text: "Filter Output",
+		},
+	}
 }

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -153,12 +153,28 @@ func (e *DefaultExecutor) Execute() interactive.Message {
 		}
 
 		header := fmt.Sprintf("%s on `%s`", cmd, clusterName)
-		return interactive.Message{
+		message := interactive.Message{
 			Base: interactive.Base{
 				Description: e.appendByUserOnlyIfNeeded(header),
 				Body:        msgBody,
 			},
 		}
+		if len(strings.SplitN(msg, "\n", 16)) == 16 {
+			message.Inputs = []interactive.Input{
+				{
+					Type:             interactive.InputText,
+					DispatchedAction: true,
+					Element: interactive.InputElement{
+						Type: interactive.PlainTextInput,
+					},
+					Label: interactive.InputLabel{
+						Type: interactive.PlainText,
+						Text: "Filter Output",
+					},
+				},
+			}
+		}
+		return message
 	}
 
 	if inClusterName != "" && inClusterName != clusterName {

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -40,6 +40,8 @@ const (
 	// Currently we support only `kubectl, so we
 	// override the message to human-readable command name.
 	humanReadableCommandListName = "Available kubectl commands"
+
+	lineLimitToShowFilter = 16
 )
 
 // DefaultExecutor is a default implementations of Executor
@@ -159,10 +161,10 @@ func (e *DefaultExecutor) Execute() interactive.Message {
 				Body:        msgBody,
 			},
 		}
-		if len(strings.SplitN(msg, "\n", 16)) == 16 {
+		// Show Filter Input if command response is more than `lineLimitToShowFilter`
+		if len(strings.SplitN(msg, "\n", lineLimitToShowFilter)) == lineLimitToShowFilter {
 			message.Inputs = []interactive.Input{
 				{
-					Type:             interactive.InputText,
 					DispatchedAction: true,
 					Element: interactive.InputElement{
 						Type: interactive.PlainTextInput,


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Introduced "Filter Output" feature to message responses that has > 16 lines
- Supports both markdown responses and file uploads due to slack message size limit.

## Testing

- Checkout BotKube to your local computer
```bash
gh pr checkout 805 --repo=https://github.com/kubeshop/botkube
```
- Prepare `comm_config.yaml` with containing slack credentials as follows
<details>
<summary>Show</summary>

```yaml
communications:
  'default-group':
    # Settings for Slack
    socketSlack:
      enabled: true
      appToken: "xapp-1..."
      botToken: "xoxb-..."
      notification:
        type: "long"
      channels:
        'default':
          name: botkube-demo
          bindings:
            executors:
              - kubectl-backend
            sources:
              - k8s-all-events
              - k8s-recommendation-events

settings:
  clusterName: gke-playground
  configWatcher: true
  lifecycleServer:
    deployment:
      name: botkube
      namespace: botkube
    port: "2113"

configWatcher:
  enabled: false
  initialSyncTimeout: 0

executors:
  'kubectl-backend':
    kubectl:
      namespaces:
        include:
          - ".*"
      enabled: true
      commands:
        verbs: [ "run", "api-resources", "api-versions", "cluster-info", "describe", "diff", "explain", "get", "logs", "top", "auth", "delete" ]
        resources: [ "deployments", "pods", "namespaces", "daemonsets", "ingresses", "statefulsets", "storageclasses", "nodes", "configmaps", "services" ]
      defaultNamespace: backend
      restrictAccess: false

rbac:
  create: true
  rules:
    - apiGroups: ["*"]
      resources: ["*"]
      verbs: ["get", "watch", "list"]
    - apiGroups: [""]
      resources: ["pods"]
      verbs: ["delete", "create"]

analytics:
  disable: true

# -- Map of sources. Source contains configuration for Kubernetes events and sending recommendations.
# The property name under `sources` object is an alias for a given configuration. You can define multiple sources configuration with different names.
# Key name is used as a binding reference.
# @default -- See the `values.yaml` file for full object.
#
## Format: sources.<alias>
sources:
  'k8s-recommendation-events':
    displayName: "Kubernetes Recommendations"
    # -- Describes Kubernetes source configuration.
    kubernetes:
      # -- Describes configuration for various recommendation insights.
      recommendations:
        # -- Recommendations for Pod Kubernetes resource.
        pod:
          # -- If true, notifies about Pod containers that use `latest` tag for images.
          noLatestImageTag: true
          # -- If true, notifies about Pod resources created without labels.
          labelsSet: true
        # -- Recommendations for Ingress Kubernetes resource.
        ingress:
          # -- If true, notifies about Ingress resources with invalid backend service reference.
          backendServiceValid: true
          # -- If true, notifies about Ingress resources with invalid TLS secret reference.
          tlsSecretValid: true

  'k8s-all-events':
    displayName: "Kubernetes Info"
    # -- Describes Kubernetes source configuration.
    kubernetes:
      # -- Describes namespaces for every Kubernetes resources you want to watch or exclude.
      # These namespaces are applied to every resource specified in the resources list.
      # However, every specified resource can override this by using its own namespaces object.
      namespaces: &k8s-events-namespaces
        # Include contains a list of allowed Namespaces.
        # It can also contain a regex expressions:
        #  `- ".*"` - to specify all Namespaces.
        include:
          - ".*"
        # Exclude contains a list of Namespaces to be ignored even if allowed by Include.
        # It can also contain a regex expressions:
        #  `- "test-.*"` - to specif all Namespaces with `test-` prefix.
        # exclude: []

      # -- Describes events for every Kubernetes resources you want to watch or exclude.
      # These events are applied to every resource specified in the resources list.
      # However, every specified resource can override this by using its own events object.
      events:
        - create
        - delete
        - error

      # -- Describes the Kubernetes resources you want to watch.
      # @default -- See the `values.yaml` file for full object.
      resources:
        - name: v1/pods             # Name of the resource. Resource name must be in group/version/resource (G/V/R) format
          # resource name should be plural (e.g apps/v1/deployments, v1/pods)

        #  namespaces:             # Overrides 'source'.kubernetes.namespaces
        #    include:
        #      - ".*"
        #    exclude: []
        - name: v1/services
        - name: networking.k8s.io/v1/ingresses
        - name: v1/nodes
        - name: v1/namespaces
        - name: v1/persistentvolumes
        - name: v1/persistentvolumeclaims
        - name: v1/configmaps
        - name: rbac.authorization.k8s.io/v1/roles
        - name: rbac.authorization.k8s.io/v1/rolebindings
        - name: rbac.authorization.k8s.io/v1/clusterrolebindings
        - name: rbac.authorization.k8s.io/v1/clusterroles
        - name: apps/v1/daemonsets
          events: # Overrides 'source'.kubernetes.events
            - create
            - update
            - delete
            - error
          updateSetting:
            includeDiff: true
            fields:
              - spec.template.spec.containers[*].image
              - status.numberReady
        - name: batch/v1/jobs
          events: # Overrides 'source'.kubernetes.events
            - create
            - update
            - delete
            - error
          updateSetting:
            includeDiff: true
            fields:
              - spec.template.spec.containers[*].image
              - status.conditions[*].type
        - name: apps/v1/deployments
          events: # Overrides 'source'.kubernetes.events
            - create
            - update
            - delete
            - error
          updateSetting:
            includeDiff: true
            fields:
              - spec.template.spec.containers[*].image
              - status.availableReplicas
        - name: apps/v1/statefulsets
          events: # Overrides 'source'.kubernetes.events
            - create
            - update
            - delete
            - error
          updateSetting:
            includeDiff: true
            fields:
              - spec.template.spec.containers[*].image
              - status.readyReplicas
        ## Custom resource example
        # - name: velero.io/v1/backups
        #   namespaces:
        #     include:
        #       - ".*"
        #     exclude:
        #       -
        #   events:
        #     - create
        #     - update
        #     - delete
        #     - error
        #   updateSetting:
        #     includeDiff: true
        #     fields:
        #       - status.phase

  'k8s-err-events':
    displayName: "Kubernetes Errors"

    # -- Describes Kubernetes source configuration.
    kubernetes:
      # -- Describes namespaces for every Kubernetes resources you want to watch or exclude.
      # These namespaces are applied to every resource specified in the resources list.
      # However, every specified resource can override this by using its own namespaces object.
      namespaces: *k8s-events-namespaces

      # -- Describes events for every Kubernetes resources you want to watch or exclude.
      # These events are applied to every resource specified in the resources list.
      # However, every specified resource can override this by using its own events object.
      events:
        - error

      # -- Describes the Kubernetes resources you want to watch.
      # @default -- See the `values.yaml` file for full object.
      resources:
        - name: v1/pods
        - name: v1/services
        - name: networking.k8s.io/v1/ingresses
        - name: v1/nodes
        - name: v1/namespaces
        - name: v1/persistentvolumes
        - name: v1/persistentvolumeclaims
        - name: v1/configmaps
        - name: rbac.authorization.k8s.io/v1/roles
        - name: rbac.authorization.k8s.io/v1/rolebindings
        - name: rbac.authorization.k8s.io/v1/clusterrolebindings
        - name: rbac.authorization.k8s.io/v1/clusterroles
        - name: apps/v1/deployments
        - name: apps/v1/statefulsets
        - name: apps/v1/daemonsets
        - name: batch/v1/jobs
```

</details>

- Export required variables
```bash
export BOTKUBE_SETTINGS_KUBECONFIG=$KUBE_CONFIG_PATH
export BOTKUBE_CONFIG_PATHS="$(pwd)/comm_config.yaml"
```

- Run BotKube
```bash
go run cmd/botkube/main.go
```

## Screenshots
![Screen Shot 2022-10-12 at 17 20 30](https://user-images.githubusercontent.com/1237982/195368464-65d4ceab-e3fa-4833-8a0a-57ce13130140.png)
![Screen Shot 2022-10-12 at 17 20 55](https://user-images.githubusercontent.com/1237982/195368492-213b0c49-ec35-42db-9f79-6bf2059efb4a.png)

## Related issue(s)

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
