### PR TITLE
Filter not supported verbs by interactive `kubectl`, improve telemetry for interactive Slack messages

### DIFF
--- a/internal/analytics/noop_reporter.go
+++ b/internal/analytics/noop_reporter.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 )
 
 var _ Reporter = &NoopReporter{}
@@ -24,7 +25,7 @@ func (n NoopReporter) RegisterCurrentIdentity(_ context.Context, _ kubernetes.In
 }
 
 // ReportCommand reports a new executed command. The command should be anonymized before using this method.
-func (n NoopReporter) ReportCommand(_ config.CommPlatformIntegration, _ string, _ bool) error {
+func (n NoopReporter) ReportCommand(_ config.CommPlatformIntegration, _ string, _ command.Origin) error {
 	return nil
 }
 

--- a/internal/analytics/reporter.go
+++ b/internal/analytics/reporter.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 )
 
 // Reporter defines an analytics reporter implementation.
@@ -14,7 +15,7 @@ type Reporter interface {
 	RegisterCurrentIdentity(ctx context.Context, k8sCli kubernetes.Interface) error
 
 	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(platform config.CommPlatformIntegration, command string, isButtonClickOrigin bool) error
+	ReportCommand(platform config.CommPlatformIntegration, command string, origin command.Origin) error
 
 	// ReportBotEnabled reports an enabled bot.
 	ReportBotEnabled(platform config.CommPlatformIntegration) error

--- a/internal/analytics/segment_reporter.go
+++ b/internal/analytics/segment_reporter.go
@@ -11,19 +11,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 	"github.com/kubeshop/botkube/pkg/version"
 )
 
 const (
 	kubeSystemNSName  = "kube-system"
 	unknownIdentityID = "00000000-0000-0000-0000-000000000000"
-)
-
-type commandOrigin string
-
-const (
-	buttonClickCommandOrigin commandOrigin = "buttonClick"
-	typedCommandOrigin       commandOrigin = "typed"
 )
 
 var (
@@ -66,11 +60,7 @@ func (r *SegmentReporter) RegisterCurrentIdentity(ctx context.Context, k8sCli ku
 
 // ReportCommand reports a new executed command. The command should be anonymized before using this method.
 // The RegisterCurrentIdentity needs to be called first.
-func (r *SegmentReporter) ReportCommand(platform config.CommPlatformIntegration, command string, isButtonClickOrigin bool) error {
-	origin := typedCommandOrigin
-	if isButtonClickOrigin {
-		origin = buttonClickCommandOrigin
-	}
+func (r *SegmentReporter) ReportCommand(platform config.CommPlatformIntegration, command string, origin command.Origin) error {
 	return r.reportEvent("Command executed", map[string]interface{}{
 		"platform": platform,
 		"command":  command,

--- a/internal/analytics/segment_reporter_test.go
+++ b/internal/analytics/segment_reporter_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/kubeshop/botkube/internal/analytics"
 	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 	"github.com/kubeshop/botkube/pkg/version"
 )
 
@@ -65,13 +66,13 @@ func TestSegmentReporter_ReportCommand(t *testing.T) {
 	segmentReporter, segmentCli := fakeSegmentReporterWithIdentity(identity)
 
 	// when
-	err := segmentReporter.ReportCommand(config.DiscordCommPlatformIntegration, "notifier stop", false)
+	err := segmentReporter.ReportCommand(config.DiscordCommPlatformIntegration, "notifier stop", command.TypedOrigin)
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportCommand(config.SlackCommPlatformIntegration, "get", false)
+	err = segmentReporter.ReportCommand(config.SlackCommPlatformIntegration, "get", command.ButtonClickOrigin)
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportCommand(config.TeamsCommPlatformIntegration, "notifier start", true)
+	err = segmentReporter.ReportCommand(config.TeamsCommPlatformIntegration, "notifier start", command.SelectValueChangeOrigin)
 	require.NoError(t, err)
 
 	// then

--- a/internal/analytics/testdata/TestSegmentReporter_ReportCommand.json
+++ b/internal/analytics/testdata/TestSegmentReporter_ReportCommand.json
@@ -19,7 +19,7 @@
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
 			"command": "get",
-			"origin": "typed",
+			"origin": "buttonClick",
 			"platform": "slack"
 		}
 	},
@@ -31,7 +31,7 @@
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
 			"command": "notifier start",
-			"origin": "buttonClick",
+			"origin": "selectValueChange",
 			"platform": "teams"
 		}
 	}

--- a/pkg/bot/discord.go
+++ b/pkg/bot/discord.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/events"
 	"github.com/kubeshop/botkube/pkg/execute"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 	"github.com/kubeshop/botkube/pkg/multierror"
 	"github.com/kubeshop/botkube/pkg/sliceutil"
 )
@@ -245,6 +246,7 @@ func (b *Discord) handleMessage(dm discordMessage) error {
 			ID:               channel.Identifier(),
 			ExecutorBindings: channel.Bindings.Executors,
 			IsAuthenticated:  isAuthChannel,
+			CommandOrigin:    command.TypedOrigin,
 		},
 		Message: req,
 		User:    fmt.Sprintf("<@%s>", dm.Event.Author.ID),

--- a/pkg/bot/mattermost.go
+++ b/pkg/bot/mattermost.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/events"
 	"github.com/kubeshop/botkube/pkg/execute"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 	"github.com/kubeshop/botkube/pkg/multierror"
 	"github.com/kubeshop/botkube/pkg/sliceutil"
 )
@@ -234,6 +235,7 @@ func (mm *mattermostMessage) handleMessage(b *Mattermost) {
 			ID:               channel.Identifier(),
 			ExecutorBindings: channel.Bindings.Executors,
 			IsAuthenticated:  mm.IsAuthChannel,
+			CommandOrigin:    command.TypedOrigin,
 		},
 		Message: mm.Request,
 	})

--- a/pkg/bot/slack.go
+++ b/pkg/bot/slack.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/events"
 	"github.com/kubeshop/botkube/pkg/execute"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 	"github.com/kubeshop/botkube/pkg/multierror"
 	"github.com/kubeshop/botkube/pkg/sliceutil"
 )
@@ -236,6 +237,7 @@ func (b *Slack) handleMessage(msg slackMessage) error {
 			ID:               channel.Identifier(),
 			ExecutorBindings: channel.Bindings.Executors,
 			IsAuthenticated:  isAuthChannel,
+			CommandOrigin:    command.TypedOrigin,
 		},
 		Message: request,
 		User:    fmt.Sprintf("<@%s>", msg.User),

--- a/pkg/bot/teams.go
+++ b/pkg/bot/teams.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/events"
 	"github.com/kubeshop/botkube/pkg/execute"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 	"github.com/kubeshop/botkube/pkg/httpsrv"
 	"github.com/kubeshop/botkube/pkg/multierror"
 	"github.com/kubeshop/botkube/pkg/sliceutil"
@@ -295,6 +296,7 @@ func (b *Teams) processMessage(activity schema.Activity) (int, string) {
 			IsAuthenticated:  true,
 			ID:               ref.ChannelID,
 			ExecutorBindings: b.bindings.Executors,
+			CommandOrigin:    command.TypedOrigin,
 		},
 		Message: trimmedMsg,
 	})

--- a/pkg/execute/command/origin.go
+++ b/pkg/execute/command/origin.go
@@ -1,0 +1,24 @@
+package command
+
+// Origin defines the origin of the command.
+type Origin string
+
+const (
+	// UnknownOrigin is the default value for Origin.
+	UnknownOrigin Origin = "unknown"
+
+	// TypedOrigin is the value for Origin when the command was typed by the user.
+	TypedOrigin Origin = "typed"
+
+	// ButtonClickOrigin is the value for Origin when the command was triggered by a button click.
+	ButtonClickOrigin Origin = "buttonClick"
+
+	// SelectValueChangeOrigin is the value for Origin when the command was triggered by a select value change.
+	SelectValueChangeOrigin Origin = "selectValueChange"
+
+	// MultiSelectValueChangeOrigin is the value for Origin when the command was triggered by a multi-select value change.
+	MultiSelectValueChangeOrigin Origin = "multiSelectValueChange"
+
+	// PlainTextInputOrigin is the value for Origin when the command was triggered by a plain text input.
+	PlainTextInputOrigin Origin = "plainTextInput"
+)

--- a/pkg/execute/edit.go
+++ b/pkg/execute/edit.go
@@ -85,7 +85,7 @@ func (e *EditExecutor) Do(args []string, commGroupName string, platform config.C
 
 	defer func() {
 		cmdToReport := fmt.Sprintf("%s %s", cmdName, cmdVerb)
-		err := e.analyticsReporter.ReportCommand(platform, cmdToReport, conversation.IsButtonClickOrigin)
+		err := e.analyticsReporter.ReportCommand(platform, cmdToReport, conversation.CommandOrigin)
 		if err != nil {
 			e.log.Errorf("while reporting edit command: %s", err.Error())
 		}
@@ -99,7 +99,9 @@ func (e *EditExecutor) Do(args []string, commGroupName string, platform config.C
 
 	msg, err := cmds.SelectAndRun(cmdVerb)
 	if err != nil {
-		cmdVerb = anonymizedInvalidVerb // prevent passing any personal information
+		if err == errUnsupportedCommand {
+			cmdVerb = anonymizedInvalidVerb // prevent passing any personal information
+		}
 		return empty, err
 	}
 	return msg, nil

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
 	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 	"github.com/kubeshop/botkube/pkg/execute/kubectl"
 	"github.com/kubeshop/botkube/pkg/filterengine"
 )
@@ -56,7 +57,7 @@ type ConfigPersistenceManager interface {
 // AnalyticsReporter defines a reporter that collects analytics data.
 type AnalyticsReporter interface {
 	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(platform config.CommPlatformIntegration, command string, isButtonClickOrigin bool) error
+	ReportCommand(platform config.CommPlatformIntegration, command string, origin command.Origin) error
 }
 
 // CommandGuard is an interface that allows to check if a given command is allowed to be executed.
@@ -107,12 +108,12 @@ func NewExecutorFactory(params DefaultExecutorFactoryParams) *DefaultExecutorFac
 
 // Conversation contains details about the conversation.
 type Conversation struct {
-	Alias               string
-	ID                  string
-	ExecutorBindings    []string
-	IsAuthenticated     bool
-	IsButtonClickOrigin bool
-	State               *slack.BlockActionStates
+	Alias            string
+	ID               string
+	ExecutorBindings []string
+	IsAuthenticated  bool
+	CommandOrigin    command.Origin
+	State            *slack.BlockActionStates
 }
 
 // NewDefaultInput an input for NewDefault

--- a/pkg/execute/fake_kc_guard.go
+++ b/pkg/execute/fake_kc_guard.go
@@ -13,6 +13,11 @@ type Resource struct {
 	SlashSeparatedInCommand bool
 }
 
+// FilterSupportedVerbs filters out unsupported verbs by the interactive commands.
+func (f *FakeCommandGuard) FilterSupportedVerbs(allVerbs []string) []string {
+	return allVerbs
+}
+
 // GetAllowedResourcesForVerb returns allowed resources types for a given verb.
 func (f *FakeCommandGuard) GetAllowedResourcesForVerb(selectedVerb string, allConfiguredResources []string) ([]Resource, error) {
 	_, found := resourcelessVerbs[selectedVerb]

--- a/pkg/execute/helper_test.go
+++ b/pkg/execute/helper_test.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 
 	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 )
 
 type fakeAnalyticsReporter struct{}
 
-func (f *fakeAnalyticsReporter) ReportCommand(_ config.CommPlatformIntegration, _ string, _ bool) error {
+func (f *fakeAnalyticsReporter) ReportCommand(_ config.CommPlatformIntegration, _ string, _ command.Origin) error {
 	return nil
 }
 

--- a/pkg/execute/kubectl_cmd_builder.go
+++ b/pkg/execute/kubectl_cmd_builder.go
@@ -124,6 +124,8 @@ func (e *KubectlCmdBuilder) Do(ctx context.Context, args []string, platform conf
 		return e.noVerbsAvailableInChannelMessage()
 	}
 
+	allVerbs = e.commandGuard.FilterSupportedVerbs(allVerbs)
+
 	// if only command name was specified, return initial command builder message
 	if len(args) == 1 {
 		return e.initialMessage(botName, allVerbs)

--- a/pkg/execute/notifier.go
+++ b/pkg/execute/notifier.go
@@ -69,7 +69,7 @@ func (e *NotifierExecutor) Do(ctx context.Context, args []string, commGroupName 
 			cmdVerb = anonymizedInvalidVerb // prevent passing any personal information
 		}
 		cmdToReport := fmt.Sprintf("%s %s", args[0], cmdVerb)
-		err := e.analyticsReporter.ReportCommand(platform, cmdToReport, conversation.IsButtonClickOrigin)
+		err := e.analyticsReporter.ReportCommand(platform, cmdToReport, conversation.CommandOrigin)
 		if err != nil {
 			// TODO: Return error when the DefaultExecutor is refactored as a part of https://github.com/kubeshop/botkube/issues/589
 			e.log.Errorf("while reporting notifier command: %s", err.Error())


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Filter not supported verbs for interactive kubectl (currently it is not used, but @mszostok will switch to actual Command Guard in one of the next PRs)
- Implement telemetry for actionable messages
- Add missing telemetry to `help` and `feedback` typed commands
- Fix "invalid verb" problem for the `edit` command, even if the verb is valid

## Testing

To test against real Segment, contact me 🙂  Alternatively, you can test it with fake reporter with the following instruction:

Check out this PR.
Replace noop_reporter.go `ReportCommand` method with:
```go
// ReportCommand reports a new executed command. The command should be anonymized before using this method.
func (n NoopReporter) ReportCommand(a config.CommPlatformIntegration, b string, c command.Origin) error {
	// TODO: Remove
	fmt.Printf(">>> Reported command: %s/%s/%s\n", a, b, c)
	return nil
}
```

Run Botkube locally:

```bash
export KUBECONFIG=...

export BOTKUBE_SETTINGS_LOG_LEVEL=info
export BOTKUBE_SETTINGS_KUBECONFIG=$KUBECONFIG
export BOTKUBE_CONFIG_PATHS="$(pwd)/resource_config.yaml,$(pwd)/comm_config.yaml"
go run cmd/botkube/main.go
```

Play around with different commands and see what is reported. Test:
- actionable messages (you can use the sample YAML from the testing instruction of the https://github.com/kubeshop/botkube/pull/803 PR)
- interactive kubectl
- edit source bindings
- help command
- feedback command (both button from help and typed command)

## Separate PRs

- [ ] Add delete confirmation for message action
- [ ] Documentation

## Related issue(s)

https://github.com/kubeshop/botkube/issues/786