### PR TITLE
Print diff between expected and actual messages in e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/mattermost/mattermost-server/v6 v6.7.2
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/olivere/elastic v6.2.37+incompatible
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.12.2
 	github.com/sanity-io/litter v1.5.5
 	github.com/segmentio/analytics-go v3.1.0+incompatible
@@ -118,7 +119,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.33.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -314,9 +314,9 @@ func runBotTest(t *testing.T,
 	t.Run("Executor", func(t *testing.T) {
 		t.Run("Get Deployment", func(t *testing.T) {
 			command := fmt.Sprintf("get deploy -n %s %s", appCfg.Deployment.Namespace, appCfg.Deployment.Name)
-			assertionFn := func(msg string) bool {
+			assertionFn := func(msg string) (bool, int, string) {
 				return strings.Contains(msg, heredoc.Doc(fmt.Sprintf("`%s` on `%s`", command, appCfg.ClusterName))) &&
-					strings.Contains(msg, "botkube")
+					strings.Contains(msg, "botkube"), 0, ""
 			}
 
 			botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)
@@ -326,10 +326,10 @@ func runBotTest(t *testing.T,
 
 		t.Run("Get Configmap", func(t *testing.T) {
 			command := fmt.Sprintf("get configmap -n %s", appCfg.Deployment.Namespace)
-			assertionFn := func(msg string) bool {
+			assertionFn := func(msg string) (bool, int, string) {
 				return strings.Contains(msg, heredoc.Doc(fmt.Sprintf("`%s` on `%s`", command, appCfg.ClusterName))) &&
 					strings.Contains(msg, "kube-root-ca.crt") &&
-					strings.Contains(msg, "botkube-global-config")
+					strings.Contains(msg, "botkube-global-config"), 0, ""
 			}
 
 			botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)
@@ -346,8 +346,8 @@ func runBotTest(t *testing.T,
 			err = botDriver.WaitForMessagePostedWithFileUpload(botDriver.BotUserID(), botDriver.Channel().ID(), fileUploadAssertionFn)
 			assert.NoError(t, err)
 
-			assertionFn := func(msg string) bool {
-				return strings.Contains(msg, heredoc.Doc(fmt.Sprintf("`%s` on `%s`", command, appCfg.ClusterName)))
+			assertionFn := func(msg string) (bool, int, string) {
+				return strings.Contains(msg, heredoc.Doc(fmt.Sprintf("`%s` on `%s`", command, appCfg.ClusterName))), 0, ""
 			}
 			err = botDriver.WaitForMessagePosted(botDriver.BotUserID(), botDriver.Channel().ID(), 1, assertionFn)
 		})
@@ -395,9 +395,9 @@ func runBotTest(t *testing.T,
 		t.Run("Based on other bindings", func(t *testing.T) {
 			t.Run("Wait for Deployment (the 2st binding)", func(t *testing.T) {
 				command := fmt.Sprintf("wait deployment -n %s %s --for condition=Available=True", appCfg.Deployment.Namespace, appCfg.Deployment.Name)
-				assertionFn := func(msg string) bool {
+				assertionFn := func(msg string) (bool, int, string) {
 					return strings.Contains(msg, heredoc.Doc(fmt.Sprintf("`%s` on `%s`", command, appCfg.ClusterName))) &&
-						strings.Contains(msg, "deployment.apps/botkube condition met")
+						strings.Contains(msg, "deployment.apps/botkube condition met"), 0, ""
 				}
 
 				botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)
@@ -427,11 +427,11 @@ func runBotTest(t *testing.T,
 
 			t.Run("Get all Deployments (the 4th binding)", func(t *testing.T) {
 				command := "get deploy -A"
-				assertionFn := func(msg string) bool {
+				assertionFn := func(msg string) (bool, int, string) {
 					return strings.Contains(msg, heredoc.Doc(fmt.Sprintf("`%s` on `%s`", command, appCfg.ClusterName))) &&
 						strings.Contains(msg, "local-path-provisioner") &&
 						strings.Contains(msg, "coredns") &&
-						strings.Contains(msg, "botkube")
+						strings.Contains(msg, "botkube"), 0, ""
 				}
 
 				botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)
@@ -444,7 +444,7 @@ func runBotTest(t *testing.T,
 		for _, prefix := range k8sPrefixTests {
 			t.Run(fmt.Sprintf("Get Pods with k8s prefix %s", prefix), func(t *testing.T) {
 				command := fmt.Sprintf("%s get pods --namespace %s", prefix, appCfg.Deployment.Namespace)
-				assertionFn := func(msg string) bool {
+				assertionFn := func(msg string) (bool, int, string) {
 					headerColumnNames := []string{"NAME", "READY", "STATUS", "RESTART", "AGE"}
 					containAllColumn := true
 					for _, cn := range headerColumnNames {
@@ -453,7 +453,7 @@ func runBotTest(t *testing.T,
 						}
 					}
 					return strings.Contains(msg, heredoc.Doc(fmt.Sprintf("`%s` on `%s`", command, appCfg.ClusterName))) &&
-						containAllColumn
+						containAllColumn, 0, ""
 				}
 
 				botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)

--- a/test/e2e/bots_tester_test.go
+++ b/test/e2e/bots_tester_test.go
@@ -23,7 +23,7 @@ var structDumper = litter.Options{
 	Separator:         " ",
 }
 
-type MessageAssertion func(content string) bool
+type MessageAssertion func(content string) (bool, int, string)
 type AttachmentAssertion func(title, color, msg string) bool
 type FileUploadAssertion func(title, mimetype string) bool
 

--- a/test/e2e/bots_tester_test.go
+++ b/test/e2e/bots_tester_test.go
@@ -24,7 +24,7 @@ var structDumper = litter.Options{
 }
 
 type MessageAssertion func(content string) (bool, int, string)
-type AttachmentAssertion func(title, color, msg string) bool
+type AttachmentAssertion func(title, color, msg string) (bool, int, string)
 type FileUploadAssertion func(title, mimetype string) bool
 
 type Channel interface {

--- a/test/e2e/diff_helpers_test.go
+++ b/test/e2e/diff_helpers_test.go
@@ -1,0 +1,38 @@
+//go:build integration
+
+package e2e
+
+import (
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// Original source: https://github.com/stretchr/testify/blob/181cea6eab8b2de7071383eca4be32a424db38dd/assert/assertions.go#L1685-L1695
+// Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors. Licensed under MIT License.
+// return diff string is expect and actual are different, otherwise return empty string
+func diff(expect string, actual string) string {
+	if expect == actual {
+		return ""
+	}
+	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(expect),
+		B:        difflib.SplitLines(actual),
+		FromFile: "Expected",
+		FromDate: "",
+		ToFile:   "Actual",
+		ToDate:   "",
+		Context:  1,
+	})
+
+	return "\n\nDiff:\n" + diff
+}
+
+// countMatchBlock count the number of lines matched between two strings
+func countMatchBlock(expect string, actual string) int {
+	matcher := difflib.NewMatcher(difflib.SplitLines(expect), difflib.SplitLines(actual))
+	matches := matcher.GetMatchingBlocks()
+	count := 0
+	for _, match := range matches {
+		count += match.Size
+	}
+	return count
+}

--- a/test/e2e/discord_driver_test.go
+++ b/test/e2e/discord_driver_test.go
@@ -274,8 +274,8 @@ func (d *discordTester) WaitForMessagePostedWithAttachment(userID, channelID str
 
 	var fetchedMessages []*discordgo.Message
 	var lastErr error
-	var common int
 	var diffMessage string
+	common := -1
 
 	err := wait.Poll(pollInterval, d.cfg.MessageWaitTimeout, func() (done bool, err error) {
 		messages, err := d.cli.ChannelMessages(channelID, 1, "", "", "")

--- a/test/e2e/discord_driver_test.go
+++ b/test/e2e/discord_driver_test.go
@@ -167,7 +167,10 @@ func (d *discordTester) WaitForMessagePosted(userID, channelID string, limitMess
 
 	var fetchedMessages []*discordgo.Message
 	var lastErr error
-	var common int
+	var highestCommonBlockCount int
+	if limitMessages == 1 {
+		highestCommonBlockCount = -1 // a single message is fetched, always print diff
+	}
 	var diffMessage string
 
 	err := wait.Poll(pollInterval, d.cfg.MessageWaitTimeout, func() (done bool, err error) {
@@ -185,9 +188,9 @@ func (d *discordTester) WaitForMessagePosted(userID, channelID string, limitMess
 
 			equal, commonCount, diffStr := assertFn(msg.Content)
 			if !equal {
-				// different message; update the diff if it's more similar than the previous one (or initial 0)
-				if commonCount > common {
-					common = commonCount
+				// different message; update the diff if it's more similar than the previous one or initial value
+				if commonCount > highestCommonBlockCount {
+					highestCommonBlockCount = commonCount
 					diffMessage = diffStr
 				}
 				continue
@@ -275,7 +278,7 @@ func (d *discordTester) WaitForMessagePostedWithAttachment(userID, channelID str
 	var fetchedMessages []*discordgo.Message
 	var lastErr error
 	var diffMessage string
-	common := -1
+	highestCommonBlockCount := -1 // a single message is fetched, always print diff
 
 	err := wait.Poll(pollInterval, d.cfg.MessageWaitTimeout, func() (done bool, err error) {
 		messages, err := d.cli.ChannelMessages(channelID, 1, "", "", "")
@@ -299,9 +302,9 @@ func (d *discordTester) WaitForMessagePostedWithAttachment(userID, channelID str
 
 			equal, commonCount, diffStr := assertFn(embed.Title, strconv.Itoa(embed.Color), embed.Description)
 			if !equal {
-				// different message; update the diff if it's more similar than the previous one (or initial 0)
-				if commonCount > common {
-					common = commonCount
+				// different message; update the diff if it's more similar than the previous one or initial value
+				if commonCount > highestCommonBlockCount {
+					highestCommonBlockCount = commonCount
 					diffMessage = diffStr
 				}
 				continue

--- a/test/e2e/k8s_helpers_test.go
+++ b/test/e2e/k8s_helpers_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pmezard/go-difflib/difflib"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -171,35 +170,4 @@ func updateEnv(existing []v1.EnvVar, env []v1.EnvVar, remove []string) []v1.EnvV
 		out = append(out, e)
 	}
 	return out
-}
-
-// Original source: https://github.com/stretchr/testify/blob/181cea6eab8b2de7071383eca4be32a424db38dd/assert/assertions.go#L1685-L1695
-// Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors. Licensed under MIT License.
-// return diff string is expect and actual are different, otherwise return empty string
-func diff(expect string, actual string) string {
-	if expect == actual {
-		return ""
-	}
-	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-		A:        difflib.SplitLines(expect),
-		B:        difflib.SplitLines(actual),
-		FromFile: "Expected",
-		FromDate: "",
-		ToFile:   "Actual",
-		ToDate:   "",
-		Context:  1,
-	})
-
-	return "\n\nDiff:\n" + diff
-}
-
-// countMatchBlock count the number of lines matched between two strings
-func countMatchBlock(expect string, actual string) int {
-	matcher := difflib.NewMatcher(difflib.SplitLines(expect), difflib.SplitLines(actual))
-	matches := matcher.GetMatchingBlocks()
-	count := 0
-	for _, match := range matches {
-		count += match.Size
-	}
-	return count
 }

--- a/test/e2e/k8s_helpers_test.go
+++ b/test/e2e/k8s_helpers_test.go
@@ -173,7 +173,7 @@ func updateEnv(existing []v1.EnvVar, env []v1.EnvVar, remove []string) []v1.EnvV
 	return out
 }
 
-// Original source: https://github.com/stretchr/testify/blob/master/assert/assertions.go#L1685-L1695
+// Original source: https://github.com/stretchr/testify/blob/181cea6eab8b2de7071383eca4be32a424db38dd/assert/assertions.go#L1685-L1695
 // Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors. Licensed under MIT License.
 // return diff string is expect and actual are different, otherwise return empty string
 func diff(expect string, actual string) string {

--- a/test/e2e/k8s_helpers_test.go
+++ b/test/e2e/k8s_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -170,4 +171,35 @@ func updateEnv(existing []v1.EnvVar, env []v1.EnvVar, remove []string) []v1.EnvV
 		out = append(out, e)
 	}
 	return out
+}
+
+// Original source: https://github.com/stretchr/testify/blob/master/assert/assertions.go#L1685-L1695
+// Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors. Licensed under MIT License.
+// return diff string is expect and actual are different, otherwise return empty string
+func diff(expect string, actual string) string {
+	if expect == actual {
+		return ""
+	}
+	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(expect),
+		B:        difflib.SplitLines(actual),
+		FromFile: "Expected",
+		FromDate: "",
+		ToFile:   "Actual",
+		ToDate:   "",
+		Context:  1,
+	})
+
+	return "\n\nDiff:\n" + diff
+}
+
+// countMatchBlock count the number of lines matched between two strings
+func countMatchBlock(expect string, actual string) int {
+	matcher := difflib.NewMatcher(difflib.SplitLines(expect), difflib.SplitLines(actual))
+	matches := matcher.GetMatchingBlocks()
+	count := 0
+	for _, match := range matches {
+		count += match.Size
+	}
+	return count
 }

--- a/test/e2e/slack_driver_test.go
+++ b/test/e2e/slack_driver_test.go
@@ -186,7 +186,7 @@ func (s *slackTester) WaitForMessagePosted(userID, channelID string, limitMessag
 			}
 			equal, commonCount, diffStr := assertFn(msg.Text)
 			if !equal {
-				// different message
+				// different message; update the diff if it's more similar than the previous one (or initial 0)
 				if commonCount > common {
 					common = commonCount
 					diffMessage = diffStr

--- a/test/e2e/slack_driver_test.go
+++ b/test/e2e/slack_driver_test.go
@@ -189,7 +189,7 @@ func (s *slackTester) WaitForMessagePosted(userID, channelID string, limitMessag
 			}
 			equal, commonCount, diffStr := assertFn(msg.Text)
 			if !equal {
-				// different message; update the diff if it's more similar than the previous one (or initial 0)
+				// different message; update the diff if it's more similar than the previous one or initial value
 				if commonCount > highestCommonBlockCount {
 					highestCommonBlockCount = commonCount
 					diffMessage = diffStr
@@ -297,7 +297,7 @@ func (s *slackTester) WaitForMessagePostedWithAttachment(userID, channelID strin
 
 			equal, commonCount, diffStr := assertFn(attachment.Title, attachment.Color, attachment.Fields[0].Value)
 			if !equal {
-				// different message; update the diff if it's more similar than the previous one (or initial 0)
+				// different message; update the diff if it's more similar than the previous one or initial value
 				if commonCount > highestCommonBlockCount {
 					highestCommonBlockCount = commonCount
 					diffMessage = diffStr

--- a/test/e2e/slack_driver_test.go
+++ b/test/e2e/slack_driver_test.go
@@ -265,8 +265,8 @@ func (s *slackTester) WaitForMessagePostedWithFileUpload(userID, channelID strin
 func (s *slackTester) WaitForMessagePostedWithAttachment(userID, channelID string, assertFn AttachmentAssertion) error {
 	var fetchedMessages []slack.Message
 	var lastErr error
-	var common int
 	var diffMessage string
+	common := -1
 
 	err := wait.Poll(pollInterval, s.cfg.MessageWaitTimeout, func() (done bool, err error) {
 		historyRes, err := s.cli.GetConversationHistory(&slack.GetConversationHistoryParameters{


### PR DESCRIPTION
## Description
The return type of function MessageAssertion is updated from `bool` to `(bool, int, string)`.
Other corresponding changes are made base on this change. 
- The returned `int` value indicates the number of matched blocks between expect message and actual got message.
- The returned `string` value is the diff between expect message and actual got message.

This PR compares number of matched blocks and print the diff corresponding to the maximum
value of number of matched blocks.

## Related issue
Resolves: #772
