### PR TITLE
Add namespace label to default keyword, change filter placeholder

### DIFF
--- a/pkg/execute/kubectl_cmd_builder.go
+++ b/pkg/execute/kubectl_cmd_builder.go
@@ -321,10 +321,10 @@ func (e *KubectlCmdBuilder) tryToGetNamespaceSelect(ctx context.Context, botName
 	var (
 		kc        = e.merger.MergeAllEnabled(bindings)
 		allowedNS = kc.AllowedNamespacesPerResource[details.resourceType]
-		finalNS   []KVItem
+		finalNS   []dropdownItem
 	)
 
-	initialNamespace := NewKV(details.namespace, details.namespace)
+	initialNamespace := newDropdownItem(details.namespace, details.namespace)
 	initialNamespace = e.appendNamespaceSuffixIfDefault(initialNamespace)
 
 	for _, item := range allClusterNamespaces.Items {
@@ -333,7 +333,7 @@ func (e *KubectlCmdBuilder) tryToGetNamespaceSelect(ctx context.Context, botName
 			continue
 		}
 
-		kv := NewKV(item.Name, item.Name)
+		kv := newDropdownItem(item.Name, item.Name)
 		if initialNamespace.Value == kv.Value {
 			kv = e.appendNamespaceSuffixIfDefault(kv)
 		}
@@ -345,7 +345,7 @@ func (e *KubectlCmdBuilder) tryToGetNamespaceSelect(ctx context.Context, botName
 }
 
 // UX requirement to append the (namespace) suffix if the namespace is called `default`.
-func (e *KubectlCmdBuilder) appendNamespaceSuffixIfDefault(in KVItem) KVItem {
+func (e *KubectlCmdBuilder) appendNamespaceSuffixIfDefault(in dropdownItem) dropdownItem {
 	if in.Name == "default" {
 		in.Name += " (namespace)"
 	}

--- a/pkg/execute/kubectl_cmd_builder.go
+++ b/pkg/execute/kubectl_cmd_builder.go
@@ -307,27 +307,34 @@ func (e *KubectlCmdBuilder) tryToGetNamespaceSelect(ctx context.Context, botName
 	var (
 		kc        = e.merger.MergeAllEnabled(bindings)
 		allowedNS = kc.AllowedNamespacesPerResource[details.resourceType]
-		finalNS   []string
+		finalNS   []KVItem
 	)
 
-	defaultNSExists := false
+	initialNamespace := NewKV(details.namespace, details.namespace)
+	initialNamespace = e.appendNamespaceSuffixIfDefault(initialNamespace)
+
 	for _, item := range allClusterNamespaces.Items {
 		if !allowedNS.IsAllowed(item.Name) {
 			continue
 		}
-		if details.namespace == item.Name {
-			defaultNSExists = true
+
+		kv := NewKV(item.Name, item.Name)
+		if initialNamespace.Value == kv.Value {
+			kv = e.appendNamespaceSuffixIfDefault(kv)
 		}
-		finalNS = append(finalNS, item.Name)
+
+		finalNS = append(finalNS, kv)
 	}
 
-	if defaultNSExists {
-		// The initial option MUST be a subset of all available dropdown options
-		// if the default namespace was not found on that list, don't include it.
-		ResourceNamespaceSelect(botName, finalNS, "")
-	}
+	return ResourceNamespaceSelect(botName, finalNS, initialNamespace)
+}
 
-	return ResourceNamespaceSelect(botName, finalNS, details.namespace)
+// UX requirement to append the (namespace) suffix if the namespace is called `default`.
+func (e *KubectlCmdBuilder) appendNamespaceSuffixIfDefault(in KVItem) KVItem {
+	if in.Name == "default" {
+		in.Name += " (namespace)"
+	}
+	return in
 }
 
 func (e *KubectlCmdBuilder) getEnableKubectlDetails(bindings []string) (verbs []string, resources []string, namespace string) {

--- a/pkg/execute/kubectl_cmd_builder_msg.go
+++ b/pkg/execute/kubectl_cmd_builder_msg.go
@@ -15,26 +15,27 @@ type (
 	// KubectlCmdBuilderOption defines option mutator signature.
 	KubectlCmdBuilderOption func(options *KubectlCmdBuilderOptions)
 
-	// KVItem describes the data for the dropdown item.
-	KVItem struct {
+	// dropdownItem describes the data for the dropdown item.
+	dropdownItem struct {
 		Name  string
 		Value string
 	}
 )
 
-// NewKV returns the KVItem instance.
-func NewKV(key, value string) KVItem {
-	return KVItem{
+// newDropdownItem returns the dropdownItem instance.
+func newDropdownItem(key, value string) dropdownItem {
+	return dropdownItem{
 		Name:  key,
 		Value: value,
 	}
 }
 
-// KVItemsFromSlice is a helper function to create the KVItem for dropdowns just from slice.
-func KVItemsFromSlice(in []string) []KVItem {
-	var out []KVItem
+// dropdownItemsFromSlice is a helper function to create the dropdown items from string slice.
+// Name and Value will represent the same data.
+func dropdownItemsFromSlice(in []string) []dropdownItem {
+	var out []dropdownItem
 	for _, item := range in {
-		out = append(out, NewKV(item, item))
+		out = append(out, newDropdownItem(item, item))
 	}
 	return out
 }
@@ -136,25 +137,25 @@ func FilterSection(botName string) interactive.LabelInput {
 
 // VerbSelect return drop-down select for kubectl verbs.
 func VerbSelect(botName string, verbs []string, initialItem string) *interactive.Select {
-	return selectDropdown("Select command", verbsDropdownCommand, botName, KVItemsFromSlice(verbs), NewKV(initialItem, initialItem))
+	return selectDropdown("Select command", verbsDropdownCommand, botName, dropdownItemsFromSlice(verbs), newDropdownItem(initialItem, initialItem))
 }
 
 // ResourceTypeSelect return drop-down select for kubectl resources types.
 func ResourceTypeSelect(botName string, resources []string, initialItem string) *interactive.Select {
-	return selectDropdown("Select resource", resourceTypesDropdownCommand, botName, KVItemsFromSlice(resources), NewKV(initialItem, initialItem))
+	return selectDropdown("Select resource", resourceTypesDropdownCommand, botName, dropdownItemsFromSlice(resources), newDropdownItem(initialItem, initialItem))
 }
 
 // ResourceNamesSelect return drop-down select for kubectl resources names.
 func ResourceNamesSelect(botName string, names []string, initialItem string) *interactive.Select {
-	return selectDropdown("Select resource name", resourceNamesDropdownCommand, botName, KVItemsFromSlice(names), NewKV(initialItem, initialItem))
+	return selectDropdown("Select resource name", resourceNamesDropdownCommand, botName, dropdownItemsFromSlice(names), newDropdownItem(initialItem, initialItem))
 }
 
 // ResourceNamespaceSelect return drop-down select for kubectl allowed namespaces.
-func ResourceNamespaceSelect(botName string, names []KVItem, initialNamespace KVItem) *interactive.Select {
+func ResourceNamespaceSelect(botName string, names []dropdownItem, initialNamespace dropdownItem) *interactive.Select {
 	return selectDropdown("Select namespace", resourceNamespaceDropdownCommand, botName, names, initialNamespace)
 }
 
-func selectDropdown(name, cmd, botName string, items []KVItem, initialItem KVItem) *interactive.Select {
+func selectDropdown(name, cmd, botName string, items []dropdownItem, initialItem dropdownItem) *interactive.Select {
 	if len(items) == 0 {
 		return nil
 	}

--- a/pkg/execute/kubectl_cmd_builder_msg.go
+++ b/pkg/execute/kubectl_cmd_builder_msg.go
@@ -14,7 +14,30 @@ type (
 	}
 	// KubectlCmdBuilderOption defines option mutator signature.
 	KubectlCmdBuilderOption func(options *KubectlCmdBuilderOptions)
+
+	// KVItem describes the data for the dropdown item.
+	KVItem struct {
+		Name  string
+		Value string
+	}
 )
+
+// NewKV returns the KVItem instance.
+func NewKV(key, value string) KVItem {
+	return KVItem{
+		Name:  key,
+		Value: value,
+	}
+}
+
+// KVItemsFromSlice is a helper function to create the KVItem for dropdowns just from slice.
+func KVItemsFromSlice(in []string) []KVItem {
+	var out []KVItem
+	for _, item := range in {
+		out = append(out, NewKV(item, item))
+	}
+	return out
+}
 
 // WithAdditionalSelects adds additional selects to a given kubectl KubectlCmdBuilderMessage message.
 func WithAdditionalSelects(in ...*interactive.Select) KubectlCmdBuilderOption {
@@ -89,7 +112,7 @@ func FilterSection(botName string) interactive.LabelInput {
 	return interactive.LabelInput{
 		Text:             "Filter output",
 		DispatchedAction: interactive.DispatchInputActionOnCharacter,
-		Placeholder:      "(Optional) Type to filter command output by.",
+		Placeholder:      "Filter output by string (optional)",
 		// the whitespace at the end is required, otherwise we will not recognize the command
 		// as we will receive:
 		//   kc-cmd-builder --filterinput string
@@ -102,50 +125,51 @@ func FilterSection(botName string) interactive.LabelInput {
 
 // VerbSelect return drop-down select for kubectl verbs.
 func VerbSelect(botName string, verbs []string, initialItem string) *interactive.Select {
-	return selectDropdown("Select command", verbsDropdownCommand, botName, verbs, initialItem)
+	return selectDropdown("Select command", verbsDropdownCommand, botName, KVItemsFromSlice(verbs), NewKV(initialItem, initialItem))
 }
 
 // ResourceTypeSelect return drop-down select for kubectl resources types.
 func ResourceTypeSelect(botName string, resources []string, initialItem string) *interactive.Select {
-	return selectDropdown("Select resource", resourceTypesDropdownCommand, botName, resources, initialItem)
+	return selectDropdown("Select resource", resourceTypesDropdownCommand, botName, KVItemsFromSlice(resources), NewKV(initialItem, initialItem))
 }
 
 // ResourceNamesSelect return drop-down select for kubectl resources names.
 func ResourceNamesSelect(botName string, names []string, initialItem string) *interactive.Select {
-	return selectDropdown("Select resource name", resourceNamesDropdownCommand, botName, names, initialItem)
+	return selectDropdown("Select resource name", resourceNamesDropdownCommand, botName, KVItemsFromSlice(names), NewKV(initialItem, initialItem))
 }
 
 // ResourceNamespaceSelect return drop-down select for kubectl allowed namespaces.
-func ResourceNamespaceSelect(botName string, names []string, initialNamespace string) *interactive.Select {
+func ResourceNamespaceSelect(botName string, names []KVItem, initialNamespace KVItem) *interactive.Select {
 	return selectDropdown("Select namespace", resourceNamespaceDropdownCommand, botName, names, initialNamespace)
 }
 
-func selectDropdown(name, cmd, botName string, items []string, initialItem string) *interactive.Select {
+func selectDropdown(name, cmd, botName string, items []KVItem, initialItem KVItem) *interactive.Select {
 	if len(items) == 0 {
 		return nil
 	}
 
 	var opts []interactive.OptionItem
 	foundInitialOptOnList := false
-	for _, itemName := range items {
-		if itemName == "" {
+	for _, item := range items {
+		if item.Value == "" || item.Name == "" {
 			continue
 		}
 
-		if initialItem == itemName {
+		if initialItem.Value == item.Value && initialItem.Name == item.Name {
 			foundInitialOptOnList = true
 		}
+
 		opts = append(opts, interactive.OptionItem{
-			Name:  itemName,
-			Value: itemName,
+			Name:  item.Name,
+			Value: item.Value,
 		})
 	}
 
 	var initialOption *interactive.OptionItem
-	if initialItem != "" && foundInitialOptOnList {
+	if foundInitialOptOnList {
 		initialOption = &interactive.OptionItem{
-			Name:  initialItem,
-			Value: initialItem,
+			Name:  initialItem.Name,
+			Value: initialItem.Value,
 		}
 	}
 

--- a/pkg/execute/kubectl_cmd_builder_test.go
+++ b/pkg/execute/kubectl_cmd_builder_test.go
@@ -369,14 +369,14 @@ func fixNamespaceDropdown() interactive.Select {
 				Name: "Select namespace",
 				Options: []interactive.OptionItem{
 					{
-						Name:  "default",
+						Name:  "default (namespace)",
 						Value: "default",
 					},
 				},
 			},
 		},
 		InitialOption: &interactive.OptionItem{
-			Name:  "default",
+			Name:  "default (namespace)",
 			Value: "default",
 		},
 	}
@@ -449,7 +449,7 @@ func fixStateBuilderMessage(kcCommandPreview, kcCommand string, dropdowns ...int
 						ID:               "@BKTesting kc-cmd-builder --filter ",
 						DispatchedAction: interactive.DispatchInputActionOnCharacter,
 						Text:             "Filter output",
-						Placeholder:      "(Optional) Type to filter command output by.",
+						Placeholder:      "Filter output by string (optional)",
 					},
 				},
 			},


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

This PR address the Lacho feedback for the current implementation:

- Add namespace label to the `default` keyword (ONLY to it, rest should be without it):
![Screen Shot 2022-10-17 at 11 27 03](https://user-images.githubusercontent.com/17568639/196141917-c7e27fa3-9ff9-44cb-b943-124d81886f70.png)
![Screen Shot 2022-10-17 at 11 27 37](https://user-images.githubusercontent.com/17568639/196141975-3799b322-66dd-43a5-83ef-e05a8cb6a55b.png)

- Change filter placeholder
![Screen Shot 2022-10-17 at 11 28 33](https://user-images.githubusercontent.com/17568639/196142158-8cfef542-350f-4575-8397-7bdef0badd69.png)




## Related issue(s)

#748 