### PR TITLE
Use real command guard and cached client, fix bug with orphan resource name

### DIFF
--- a/cmd/botkube/main.go
+++ b/cmd/botkube/main.go
@@ -399,7 +399,7 @@ func getK8sClients(cfg *rest.Config) (dynamic.Interface, discovery.DiscoveryInte
 
 	discoCacheClient := memory.NewMemCacheClient(discoveryClient)
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoCacheClient)
-	return dynamicK8sCli, discoveryClient, mapper, nil
+	return dynamicK8sCli, discoCacheClient, mapper, nil
 }
 
 func reportFatalErrFn(logger logrus.FieldLogger, reporter analytics.Reporter) func(ctx string, err error) error {

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -64,6 +64,7 @@ type AnalyticsReporter interface {
 type CommandGuard interface {
 	GetAllowedResourcesForVerb(verb string, allConfiguredResources []string) ([]kubectl.Resource, error)
 	GetResourceDetails(verb, resourceType string) (kubectl.Resource, error)
+	FilterSupportedVerbs(allVerbs []string) []string
 }
 
 // NewExecutorFactory creates new DefaultExecutorFactory.
@@ -92,7 +93,7 @@ func NewExecutorFactory(params DefaultExecutorFactoryParams) *DefaultExecutorFac
 			params.Merger,
 			kcExecutor,
 			params.NamespaceLister,
-			// TODO: Pass params.CommandGuard,
+			params.CommandGuard,
 		),
 		editExecutor: NewEditExecutor(
 			params.Log.WithField("component", "Notifier Executor"),

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -89,14 +89,14 @@ func NewExecutorFactory(params DefaultExecutorFactoryParams) *DefaultExecutorFac
 			params.AnalyticsReporter,
 		),
 		kubectlCmdBuilder: NewKubectlCmdBuilder(
-			params.Log.WithField("component", "Notifier Executor"),
+			params.Log.WithField("component", "Kubectl Command Builder"),
 			params.Merger,
 			kcExecutor,
 			params.NamespaceLister,
 			params.CommandGuard,
 		),
 		editExecutor: NewEditExecutor(
-			params.Log.WithField("component", "Notifier Executor"),
+			params.Log.WithField("component", "Botkube Edit Executor"),
 			params.AnalyticsReporter,
 			params.CfgManager,
 			params.Cfg,

--- a/pkg/execute/kubectl/guard.go
+++ b/pkg/execute/kubectl/guard.go
@@ -40,7 +40,8 @@ var (
 
 	// additionalResourceVerbs contains map of per-resource verbs which are not returned by K8s API, but should be supported.
 	additionalResourceVerbs = map[string][]string{
-		"nodes": {"cordon", "uncordon", "drain"},
+		"nodes": {"cordon", "uncordon", "drain", "top"},
+		"pods":  {"top"},
 	}
 
 	// additionalResourcelessVerbs contains map of per-resource verbs which are not returned by K8s API, but should be supported.
@@ -84,6 +85,7 @@ var (
 		"scale":        {},
 		"wait":         {},
 		"proxy":        {},
+		"run":          {},
 	}
 )
 

--- a/pkg/execute/kubectl/guard.go
+++ b/pkg/execute/kubectl/guard.go
@@ -135,6 +135,11 @@ func (g *CommandGuard) GetAllowedResourcesForVerb(verb string, allConfiguredReso
 
 // GetResourceDetails returns a Resource struct for a given resource type and verb.
 func (g *CommandGuard) GetResourceDetails(selectedVerb, resourceType string) (Resource, error) {
+	_, found := resourcelessVerbs[selectedVerb]
+	if found {
+		return Resource{}, nil
+	}
+
 	resMap, err := g.GetServerResourceMap()
 	if err != nil {
 		return Resource{}, err

--- a/pkg/execute/kubectl_cmd_builder_msg.go
+++ b/pkg/execute/kubectl_cmd_builder_msg.go
@@ -84,6 +84,17 @@ func PreviewSection(botName, cmd string, input interactive.LabelInput) []interac
 	}
 }
 
+// InternalErrorSection returns preview command section with Run button.
+func InternalErrorSection() interactive.Section {
+	return interactive.Section{
+		Base: interactive.Base{
+			Body: interactive.Body{
+				CodeBlock: "Sorry, an internal error occurred while rendering command preview. See the logs for more details.",
+			},
+		},
+	}
+}
+
 // FilterSection returns filter input block.
 func FilterSection(botName string) interactive.LabelInput {
 	return interactive.LabelInput{

--- a/pkg/execute/kubectl_cmd_builder_msg.go
+++ b/pkg/execute/kubectl_cmd_builder_msg.go
@@ -186,10 +186,15 @@ func selectDropdown(name, cmd, botName string, items []string, initialItem strin
 //  1. This select is converted to external data source (https://api.slack.com/reference/block-kit/block-elements#external_select)
 //  2. We change the `min_query_length` to 0 to remove th "Type minimum of 3 characters to see options" message.
 //  3. Our backend doesn't return any options, so you see "No result".
-func EmptyResourceNameDropdown(botName string) *interactive.Select {
+//  4. We don't set the command, so the ID of this select is always randomized by Slack server.
+//     As a result, the dropdown value is not cached, and we avoid problem with showing the outdated value.
+func EmptyResourceNameDropdown() *interactive.Select {
 	return &interactive.Select{
-		Type:    interactive.ExternalSelect,
-		Name:    "No resources found",
-		Command: fmt.Sprintf("%s %s", botName, resourceNamesDropdownCommand),
+		Type: interactive.ExternalSelect,
+		Name: "No resources found",
+		InitialOption: &interactive.OptionItem{
+			Name:  "No resources found",
+			Value: "no-resources",
+		},
 	}
 }

--- a/pkg/execute/kubectl_cmd_builder_test.go
+++ b/pkg/execute/kubectl_cmd_builder_test.go
@@ -70,7 +70,7 @@ func TestCommandPreview(t *testing.T) {
 				kcMerger      = newFakeKcMerger([]string{"get", "describe"}, []string{"deployments", "pods"})
 			)
 
-			kcCmdBuilderExecutor := execute.NewKubectlCmdBuilder(logger, kcMerger, kcExecutor, nsLister)
+			kcCmdBuilderExecutor := execute.NewKubectlCmdBuilder(logger, kcMerger, kcExecutor, nsLister, &FakeCommandGuard{})
 
 			// when
 			gotMsg, err := kcCmdBuilderExecutor.Do(context.Background(), tc.args, config.SocketSlackCommPlatformIntegration, fixBindings, state, testingBotName, "header")
@@ -174,7 +174,7 @@ func TestCommandBuilderCanHandleAndGetPrefix(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
-			kcCmdBuilderExecutor := execute.NewKubectlCmdBuilder(nil, nil, nil, nil)
+			kcCmdBuilderExecutor := execute.NewKubectlCmdBuilder(nil, nil, nil, nil, &FakeCommandGuard{})
 
 			// when
 			gotCanHandle := kcCmdBuilderExecutor.CanHandle(tc.args)
@@ -202,7 +202,7 @@ func TestErrorUserMessageOnPlatformsOtherThanSocketSlack(t *testing.T) {
 		t.Run(fmt.Sprintf("Should ignore %s", platform), func(t *testing.T) {
 			// given
 			const cmdHeader = "header"
-			kcCmdBuilderExecutor := execute.NewKubectlCmdBuilder(logger, nil, nil, nil)
+			kcCmdBuilderExecutor := execute.NewKubectlCmdBuilder(logger, nil, nil, nil, nil)
 
 			// when
 			gotMsg, err := kcCmdBuilderExecutor.Do(context.Background(), []string{"kc"}, platform, nil, nil, "", cmdHeader)
@@ -226,7 +226,7 @@ func TestShouldReturnInitialMessage(t *testing.T) {
 	var (
 		logger, _            = logtest.NewNullLogger()
 		kcMerger             = newFakeKcMerger([]string{"get", "describe"}, []string{"deployments", "pods"})
-		kcCmdBuilderExecutor = execute.NewKubectlCmdBuilder(logger, kcMerger, nil, nil)
+		kcCmdBuilderExecutor = execute.NewKubectlCmdBuilder(logger, kcMerger, nil, nil, &FakeCommandGuard{})
 		expMsg               = fixInitialBuilderMessage()
 	)
 
@@ -256,7 +256,7 @@ func TestShouldNotPrintTheResourceNameIfKubectlExecutorFails(t *testing.T) {
 		expMsg     = fixStateBuilderMessage("kubectl get pods -n default", "@BKTesting kubectl get pods -n default", fixVerbsDropdown(), fixResourceTypeDropdown(), fixEmptyResourceNamesDropdown(), fixNamespaceDropdown())
 	)
 
-	kcCmdBuilderExecutor := execute.NewKubectlCmdBuilder(logger, kcMerger, kcExecutor, nsLister)
+	kcCmdBuilderExecutor := execute.NewKubectlCmdBuilder(logger, kcMerger, kcExecutor, nsLister, &FakeCommandGuard{})
 
 	// when
 	gotMsg, err := kcCmdBuilderExecutor.Do(context.Background(), args, config.SocketSlackCommPlatformIntegration, []string{"kc-read-only"}, state, testingBotName, "header")

--- a/pkg/execute/kubectl_cmd_builder_test.go
+++ b/pkg/execute/kubectl_cmd_builder_test.go
@@ -38,25 +38,25 @@ func TestCommandPreview(t *testing.T) {
 			name: "Print all dropdowns and full command on verb change",
 			args: strings.Fields("kc-cmd-builder --verbs"),
 
-			expMsg: fixStateBuilderMessage("kubectl get pods nginx2 -n default", "@BKTesting kubectl get pods nginx2 -n default", fixAllDropdown()...),
+			expMsg: fixStateBuilderMessage("kubectl get pods nginx2 -n default", "@BKTesting kubectl get pods nginx2 -n default", fixAllDropdown(true)...),
 		},
 		{
 			name: "Print all dropdowns and command without the resource name on resource type change",
 			args: strings.Fields("kc-cmd-builder --resource-type"),
 
-			expMsg: fixStateBuilderMessage("kubectl get pods -n default", "@BKTesting kubectl get pods -n default", fixAllDropdown()...),
+			expMsg: fixStateBuilderMessage("kubectl get pods -n default", "@BKTesting kubectl get pods -n default", fixAllDropdown(false)...),
 		},
 		{
 			name: "Print all dropdowns and full command on resource name change",
 			args: strings.Fields("kc-cmd-builder --resource-name"),
 
-			expMsg: fixStateBuilderMessage("kubectl get pods nginx2 -n default", "@BKTesting kubectl get pods nginx2 -n default", fixAllDropdown()...),
+			expMsg: fixStateBuilderMessage("kubectl get pods nginx2 -n default", "@BKTesting kubectl get pods nginx2 -n default", fixAllDropdown(true)...),
 		},
 		{
 			name: "Print all dropdowns and command without the resource name on namespace change",
 			args: strings.Fields("kc-cmd-builder --namespace"),
 
-			expMsg: fixStateBuilderMessage("kubectl get pods -n default", "@BKTesting kubectl get pods -n default", fixAllDropdown()...),
+			expMsg: fixStateBuilderMessage("kubectl get pods -n default", "@BKTesting kubectl get pods -n default", fixAllDropdown(false)...),
 		},
 	}
 	for _, tc := range tests {
@@ -384,20 +384,28 @@ func fixNamespaceDropdown() interactive.Select {
 
 func fixEmptyResourceNamesDropdown() interactive.Select {
 	return interactive.Select{
-		Name:    "No resources found",
-		Type:    interactive.ExternalSelect,
-		Command: "@BKTesting kc-cmd-builder --resource-name",
+		Name: "No resources found",
+		Type: interactive.ExternalSelect,
+		InitialOption: &interactive.OptionItem{
+			Name:  "No resources found",
+			Value: "no-resources",
+		},
 	}
 }
 
-func fixResourceNamesDropdown() interactive.Select {
-	return interactive.Select{
-		Name:    "Select resource name",
-		Command: "@BKTesting kc-cmd-builder --resource-name",
-		InitialOption: &interactive.OptionItem{
+func fixResourceNamesDropdown(includeInitialOpt bool) interactive.Select {
+	var opt *interactive.OptionItem
+	if includeInitialOpt {
+		opt = &interactive.OptionItem{
 			Name:  "nginx2",
 			Value: "nginx2",
-		},
+		}
+	}
+
+	return interactive.Select{
+		Name:          "Select resource name",
+		Command:       "@BKTesting kc-cmd-builder --resource-name",
+		InitialOption: opt,
 		OptionGroups: []interactive.OptionGroup{
 			{
 				Name: "Select resource name",
@@ -420,11 +428,11 @@ func fixResourceNamesDropdown() interactive.Select {
 	}
 }
 
-func fixAllDropdown() []interactive.Select {
+func fixAllDropdown(includeResourceName bool) []interactive.Select {
 	return []interactive.Select{
 		fixVerbsDropdown(),
 		fixResourceTypeDropdown(),
-		fixResourceNamesDropdown(),
+		fixResourceNamesDropdown(includeResourceName),
 		fixNamespaceDropdown(),
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Use real command guard 
- Use cached K8s client - otherwise the interactive kc builder doesn't work as we are throttled by the K8s and we cannot return the response within 3 sec which is a req from Slack server,
- Fix bug with orphan resource name, see https://user-images.githubusercontent.com/7155799/195316607-3a55f1a3-8d0a-4b0f-9299-e5420c26593a.mp4
- In case of dropdown error, just don't print them
- In case of rendering the command preview, return:
   ![Screen Shot 2022-10-17 at 14 23 56](https://user-images.githubusercontent.com/17568639/196176223-ddf30c9a-9636-43c6-85f4-c60cfc135a46.png)

## Related issue(s)

#748 
