### PR TITLE
Prevent resource deletion from the actionable notifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,10 @@ This section describes how to build and run Botkube from source code.
 
         ```sh
         IMAGE_PLATFORM=linux/arm64 make container-image-single
-        docker tag ghcr.io/kubeshop/botkube:v9.99.9-dev <your_account>/botkube:v9.99.9-dev
-        docker push <your_account>/botkube:v9.99.9-dev
+        docker tag ghcr.io/kubeshop/botkube:v9.99.9-dev {your_account}/botkube:v9.99.9-dev
+        docker push {your_account}/botkube:v9.99.9-dev
         ```
-        Where `<your_account>` is Docker hub or any other registry provider account to which you can push the image.
+        Where `{your_account}` is Docker hub or any other registry provider account to which you can push the image.
 
    - **Multi-arch target builds for any K8s cluster**
 
@@ -59,18 +59,22 @@ This section describes how to build and run Botkube from source code.
 
      ```sh
      make container-image
-     docker tag ghcr.io/kubeshop/botkube:v9.99.9-dev-amd64 <your_account>/botkube:v9.99.9-dev
-     docker push <your_account>/botkube:v9.99.9-dev
+     docker tag ghcr.io/kubeshop/botkube:v9.99.9-dev-amd64 {your_account}/botkube:v9.99.9-dev
+     docker push {your_account}/botkube:v9.99.9-dev
      ```
-     Where `<your_account>` is Docker hub or any other registry provider account to which you can push the image.
+     
+     Where `{your_account}` is Docker hub or any other registry provider account to which you can push the image.
 
 2. Install Botkube with any of communication platform configured, according to [the installation instructions](https://botkube.io/docs/installation/). During the Helm chart installation step, set the following flags:
    
    ```sh
-   --set image.registry=<IMAGE_REGISTRY e.g. docker.io> \
-   --set image.repository=<your_account>/botkube \
+   export IMAGE_REGISTRY="{imageRegistry}" # e.g. docker.io
+   export IMAGE_PULL_POLICY="{pullPolicy}" # e.g. Always or IfNotPresent
+   
+   --set image.registry=${IMAGE_REGISTRY} \
+   --set image.repository={your_account}/botkube \
    --set image.tag=v9.99.9-dev \
-   --set image.pullPolicy=<IMAGE_PULL_POLICY e.g. Always>
+   --set image.pullPolicy=${IMAGE_PULL_POLICY}
    ```
    
    Check [values.yaml](./helm/botkube/values.yaml) for default options.

--- a/comm_config.yaml.tpl
+++ b/comm_config.yaml.tpl
@@ -1,6 +1,6 @@
 # Map of enabled communication mediums. The `communications` property name is an alias for a given configuration.
 #
-# Format: communications.<alias>
+# Format: communications.{alias}
 communications:
   'default-group':
     # Settings for Slack

--- a/global_config.yaml.tpl
+++ b/global_config.yaml.tpl
@@ -1,7 +1,7 @@
 # Map of enabled sources. The `source` property name is an alias for a given configuration.
 # It's used as a binding reference.
 #
-# Format: source.<alias>
+# Format: source.{alias}
 sources:
   'k8s-events':
 
@@ -22,7 +22,6 @@ sources:
           # If true, notifies about Ingress resources with invalid TLS secret reference.
           tlsSecretValid: true
 
-      # TODO: https://github.com/kubeshop/botkube/issues/596
       # New 'namespace' property.
       # It can be overridden in the nested level.
       # namespace:
@@ -254,7 +253,7 @@ configWatcher:
 # Map of enabled executors. The `executors` property name is an alias for a given configuration.
 # It's used as a binding reference.
 #
-# Format: executors.<alias>
+# Format: executors.{alias}
 executors:
   'kubectl-read-only':
     # Kubectl executor configs

--- a/helm/botkube/Chart.yaml
+++ b/helm/botkube/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: botkube
 home: https://botkube.io
-version: v0.13.0
-appVersion: v0.13.0
-icon: https://botkube.io/images/botkube.ico
+version: v9.99.9-dev
+appVersion: v9.99.9-dev
+icon: https://docs.botkube.io/images/botkube-black.svg
 description: Controller for the Botkube Slack app which helps you monitor your Kubernetes cluster,
  debug deployments and run specific checks on resources in the cluster.
 sources:

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -1,6 +1,6 @@
 # Botkube
 
-![Version: v0.13.0](https://img.shields.io/badge/Version-v0.13.0-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
+![Version: v9.99.9-dev](https://img.shields.io/badge/Version-v9.99.9--dev-informational?style=flat-square) ![AppVersion: v9.99.9-dev](https://img.shields.io/badge/AppVersion-v9.99.9--dev-informational?style=flat-square)
 
 Controller for the Botkube Slack app which helps you monitor your Kubernetes cluster, debug deployments and run specific checks on resources in the cluster.
 

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -160,12 +160,12 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 
 ### AWS IRSA on EKS support
 
-AWS has introduced IAM Role for Service Accounts in order to provide fine grained access. This is useful if you are looking to run Botkube inside an EKS cluster. For more details visit https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+AWS has introduced IAM Role for Service Accounts in order to provide fine-grained access. This is useful if you are looking to run Botkube inside an EKS cluster. For more details visit https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
 
 Annotate the Botkube Service Account as shown in the example below and add the necessary Trust Relationship to the corresponding Botkube role to get this working.
 
 ```
 serviceAccount:
   annotations:
-    eks.amazonaws.com/role-arn: "<role_arn_to_assume>"
+    eks.amazonaws.com/role-arn: "{role_arn_to_assume}"
 ```

--- a/helm/botkube/README.tpl.md
+++ b/helm/botkube/README.tpl.md
@@ -34,12 +34,12 @@
 
 ### AWS IRSA on EKS support
 
-AWS has introduced IAM Role for Service Accounts in order to provide fine grained access. This is useful if you are looking to run Botkube inside an EKS cluster. For more details visit https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+AWS has introduced IAM Role for Service Accounts in order to provide fine-grained access. This is useful if you are looking to run Botkube inside an EKS cluster. For more details visit https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
 
 Annotate the Botkube Service Account as shown in the example below and add the necessary Trust Relationship to the corresponding Botkube role to get this working.
 
 ```
 serviceAccount:
   annotations:
-    eks.amazonaws.com/role-arn: "<role_arn_to_assume>"
+    eks.amazonaws.com/role-arn: "{role_arn_to_assume}"
 ```

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -56,7 +56,7 @@ kubeconfig:
 # Key name is used as a binding reference.
 # @default -- See the `values.yaml` file for full object.
 #
-## Format: sources.<alias>
+## Format: sources.{alias}
 sources:
   'k8s-recommendation-events':
     displayName: "Kubernetes Recommendations"
@@ -237,7 +237,7 @@ filters:
 # Key name is used as a binding reference.
 # @default -- See the `values.yaml` file for full object.
 #
-## Format: executors.<alias>
+## Format: executors.{alias}
 executors:
   'kubectl-read-only':
     ## Kubectl executor configuration.
@@ -280,7 +280,7 @@ existingCommunicationsSecretName: ""
 # The property name under `communications` object is an alias for a given configuration group. You can define multiple communication groups with different names.
 # @default -- See the `values.yaml` file for full object.
 #
-## Format: communications.<alias>
+## Format: communications.{alias}
 communications:
   'default-group':
     ## Settings for Slack.
@@ -289,7 +289,7 @@ communications:
       enabled: false
       # -- Map of configured channels. The property name under `channels` object is an alias for a given configuration.
       #
-      ## Format: channels.<alias>
+      ## Format: channels.{alias}
       channels:
         'default':
           # -- Slack channel name without '#' prefix where you have added Botkube and want to receive notifications in.
@@ -317,7 +317,7 @@ communications:
       enabled: false
       # -- Map of configured channels. The property name under `channels` object is an alias for a given configuration.
       #
-      ## Format: channels.<alias>
+      ## Format: channels.{alias}
       channels:
         'default':
           # -- Slack channel name without '#' prefix where you have added Botkube and want to receive notifications in.
@@ -353,7 +353,7 @@ communications:
       team: 'MATTERMOST_TEAM'
       # -- Map of configured channels. The property name under `channels` object is an alias for a given configuration.
       #
-      ## Format: channels.<alias>
+      ## Format: channels.{alias}
       channels:
         'default':
           # -- The Mattermost channel name for receiving Botkube alerts.
@@ -407,7 +407,7 @@ communications:
       botID: 'DISCORD_BOT_ID'
       # -- Map of configured channels. The property name under `channels` object is an alias for a given configuration.
       #
-      ## Format: channels.<alias>
+      ## Format: channels.{alias}
       channels:
         'default':
           # -- Discord channel ID for receiving Botkube alerts.
@@ -451,7 +451,7 @@ communications:
       skipTLSVerify: false
       # -- Map of configured indices. The `indices` property name is an alias for a given configuration.
       #
-      ## Format: indices.<alias>
+      ## Format: indices.{alias}
       indices:
         'default':
           # -- Configures Elasticsearch index settings.
@@ -591,12 +591,12 @@ resources: {}
 # -- Extra environment variables to pass to the Botkube container.
 # [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables).
 extraEnv: []
-#  - name: <key>
+#  - name: {key}
 #    valueFrom:
 #      configMapKeyRef:
 #        name: configmap-name
 #        key: value_key
-#  - name: <key>
+#  - name: {key}
 #    value: value
 
 
@@ -605,7 +605,7 @@ extraEnv: []
 extraVolumes: []
 # - name: extra-volume-0
 #   secret:
-#     secretName: <secret-name>
+#     secretName: {secret-name}
 #
 ## For CSI e.g. Vault:
 # - name: secrets-store-inline

--- a/pkg/execute/kubectl/commander_test.go
+++ b/pkg/execute/kubectl/commander_test.go
@@ -83,6 +83,7 @@ func TestCommander_GetCommandsForEvent(t *testing.T) {
 				},
 				AllowedKubectlVerb: map[string]struct{}{
 					"get":      {},
+					"delete":   {}, // Ignore not supported event command verbs
 					"describe": {},
 					"logs":     {},
 				},
@@ -154,7 +155,7 @@ type fakeMerger struct {
 	res kubectl.EnabledKubectl
 }
 
-func (f *fakeMerger) MergeForNamespace(includeBindings []string, forNamespace string) kubectl.EnabledKubectl {
+func (f *fakeMerger) MergeForNamespace(_ []string, _ string) kubectl.EnabledKubectl {
 	return f.res
 }
 
@@ -167,7 +168,7 @@ func (f *fakeGuard) GetServerResourceMap() (map[string]metav1.APIResource, error
 	return f.resMap, nil
 }
 
-func (f *fakeGuard) GetResourceDetailsFromMap(selectedVerb, resourceType string, resMap map[string]metav1.APIResource) (kubectl.Resource, error) {
+func (f *fakeGuard) GetResourceDetailsFromMap(selectedVerb, resourceType string, _ map[string]metav1.APIResource) (kubectl.Resource, error) {
 	resources, ok := f.verbMap[selectedVerb]
 	if !ok {
 		return kubectl.Resource{}, kubectl.ErrVerbNotSupported
@@ -211,6 +212,13 @@ func fixVerbMapForFakeGuard() map[string]map[string]kubectl.Resource {
 			"pods": {
 				Name:                    "pods",
 				SlashSeparatedInCommand: true,
+				Namespaced:              true,
+			},
+		},
+		"delete": {
+			"pods": {
+				Name:                    "pods",
+				SlashSeparatedInCommand: false,
 				Namespaced:              true,
 			},
 		},


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Prevent resource deletion from the actionable notifications
    - This is the minimal acceptable option to avoid accidental resource deletion. As this is a rare edge case, it will be followed-up according to the community demand in https://github.com/kubeshop/botkube/issues/824.
- Unify documentation placeholder style (use `{ }` instead of `< >`
- Fix Helm chart icon and set Helm chart version on main to dev
    - The release pipeline will change it anyway, but at least it won't look odd on `main` that we have an outdated `0.13` chart. 

## Testing

Follow the same instructions from https://github.com/kubeshop/botkube/pull/803.
You won't see the `delete` option for any event notification anymore.

## Related issue(s)

Resolves https://github.com/kubeshop/botkube/issues/786
