### PR TITLE
Work around empty K8s resources list which causes Botkube crash

### DIFF
--- a/pkg/execute/kubectl/guard.go
+++ b/pkg/execute/kubectl/guard.go
@@ -160,7 +160,11 @@ func (g *CommandGuard) GetResourceDetails(selectedVerb, resourceType string) (Re
 func (g *CommandGuard) GetServerResourceMap() (map[string]v1.APIResource, error) {
 	resList, err := g.discoveryCli.ServerPreferredResources()
 	if err != nil {
-		return nil, fmt.Errorf("while getting server resources: %w", err)
+		if !shouldIgnoreResourceListError(err) {
+			return nil, fmt.Errorf("while getting resource list from K8s cluster: %w", err)
+		}
+
+		g.log.Warnf("Ignoring error while getting resource list from K8s cluster: %s", err.Error())
 	}
 
 	resourceMap := make(map[string]v1.APIResource)


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Work around empty K8s resources list which causes Botkube crash

See the discussion under #829.

## Testing

DO NOT checkout this PR (yet)

1. Install [KEDA](https://github.com/kedacore/charts/tree/main/keda) (Helm chart).
1. Run Botkube locally

    ```bash
    export BOTKUBE_SETTINGS_LOG_LEVEL=info
    export BOTKUBE_SETTINGS_KUBECONFIG=$KUBECONFIG
    export BOTKUBE_CONFIG_PATHS="$(pwd)/resource_config.yaml,$(pwd)/comm_config.yaml"
    go run ./cmd/botkube/main.go
    ```
1. See the crash error
1. Check out to this PR with `gh pr checkout 834`
1. Run Botkube locally once again

## Related issue(s)

Resolves #829 