### PR TITLE
Fixup `kubectl` help wording

### DIFF
--- a/pkg/bot/interactive/help.go
+++ b/pkg/bot/interactive/help.go
@@ -157,7 +157,7 @@ func (h *HelpMessage) actionSections() []Section {
 
 func (h *HelpMessage) kubectlSections() []Section {
 	// TODO(https://github.com/kubeshop/botkube/issues/802): remove this warning in after releasing 0.17.
-	warn := ":warning: Botkube 0.17 and above will require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.\n\n`@Botkube k get pods` instead of `@Botkube get pods`\n"
+	warn := ":warning: Botkube 0.17 and above will require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.\n\ne.g. `@Botkube k get pods` instead of `@Botkube get pods`\n"
 
 	if h.platform == config.SocketSlackCommPlatformIntegration {
 		return []Section{
@@ -168,6 +168,9 @@ func (h *HelpMessage) kubectlSections() []Section {
 				},
 			},
 			{
+				Base: Base{
+					Description: "Build kubectl commands interactively",
+				},
 				Buttons: []Button{
 					h.btnBuilder.ForCommandWithDescCmd("kubectl", "kubectl", ButtonStylePrimary),
 				},

--- a/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_headers_and_default_new_lines.golden.txt
+++ b/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_headers_and_default_new_lines.golden.txt
@@ -31,7 +31,7 @@ By default, Botkube will notify only about cluster errors and recommendations.
 *Run kubectl commands (if enabled)*
 :warning: Botkube 0.17 and above will require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.
 
-`@Botkube k get pods` instead of `@Botkube get pods`
+e.g. `@Botkube k get pods` instead of `@Botkube get pods`
 
 You can run kubectl commands directly from Platform!
   - `@Botkube kubectl get services`

--- a/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_new_lines_and_default_headers.golden.txt
+++ b/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_new_lines_and_default_headers.golden.txt
@@ -6,6 +6,6 @@ Botkube is now active for "testing" cluster :rocket:<br><br>**Using multiple ins
 @Botkube [list|enable|disable] action [action name]
 ```<br>  - `@Botkube list actions`<br><br>**Run kubectl commands (if enabled)**<br>:warning: Botkube 0.17 and above will require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.
 
-`@Botkube k get pods` instead of `@Botkube get pods`
+e.g. `@Botkube k get pods` instead of `@Botkube get pods`
 
 You can run kubectl commands directly from Platform!<br>  - `@Botkube kubectl get services`<br>  - `@Botkube kubectl get pods`<br>  - `@Botkube kubectl get deployments`<br><br>To list all supported kubectl commands<br>  - `@Botkube commands list`<br><br>**Filters (advanced)**<br>You can extend Botkube functionality by writing additional filters that can check resource specs, validate some checks and add messages to the Event struct. Learn more at https://botkube.io/filters<br><br>**Angry? Amazed?**<br>Give feedback: https://feedback.botkube.io<br><br>Read our docs: https://botkube.io/docs<br>Join our Slack: https://join.botkube.io<br>Follow us on Twitter: https://twitter.com/botkube_io<br>

--- a/pkg/bot/interactive/testdata/TestInteractiveMessageToPlaintext.golden.txt
+++ b/pkg/bot/interactive/testdata/TestInteractiveMessageToPlaintext.golden.txt
@@ -27,7 +27,7 @@ Manage automated actions
 Run kubectl commands (if enabled)
 :warning: Botkube 0.17 and above will require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.
 
-`@Botkube k get pods` instead of `@Botkube get pods`
+e.g. `@Botkube k get pods` instead of `@Botkube get pods`
 
 You can run kubectl commands directly from Platform!
   - @Botkube kubectl get services


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Added e.g. to clarify the warning example
- Added description to the interactive kubectl section for the socket Slack help to differentiate interactive kubectl builder from typed kubectl commands
