### PR TITLE
Move actions list E2E test after initial help message

### DIFF
--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -180,19 +180,6 @@ func runBotTest(t *testing.T,
 		return fmt.Sprintf("`%s` on `%s`", command, appCfg.ClusterName)
 	}
 
-	t.Run("List actions", func(t *testing.T) {
-		command := "list actions"
-		expectedBody := codeBlock(heredoc.Doc(`
-			ACTION                    ENABLED  DISPLAY NAME
-			describe-created-resource false    Describe created resource
-			get-created-resource      true     Get created resource
-			show-logs-on-error        false    Show logs on error`))
-
-		expectedMessage := fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
-		botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)
-		err := botDriver.WaitForLastMessageContains(botDriver.BotUserID(), botDriver.Channel().ID(), expectedMessage)
-		assert.NoError(t, err)
-	})
 	// TODO: configure and use MessageWaitTimeout from an (app) Config as it targets both Slack and Discord.
 	// Discord bot needs a bit more time to connect to Discord API.
 	time.Sleep(appCfg.Discord.MessageWaitTimeout)
@@ -714,7 +701,7 @@ func runBotTest(t *testing.T,
 		require.NoError(t, err)
 	})
 
-	t.Run("Recommendations and automations", func(t *testing.T) {
+	t.Run("Recommendations and actions", func(t *testing.T) {
 		podCli := k8sCli.CoreV1().Pods(appCfg.Deployment.Namespace)
 
 		t.Log("Creating Pod...")
@@ -759,6 +746,20 @@ func runBotTest(t *testing.T,
 		}
 		err = botDriver.WaitForMessagePosted(botDriver.BotUserID(), botDriver.Channel().ID(), 2, automationAssertionFn)
 		require.NoError(t, err)
+	})
+
+	t.Run("List actions", func(t *testing.T) {
+		command := "list actions"
+		expectedBody := codeBlock(heredoc.Doc(`
+			ACTION                    ENABLED  DISPLAY NAME
+			describe-created-resource false    Describe created resource
+			get-created-resource      true     Get created resource
+			show-logs-on-error        false    Show logs on error`))
+
+		expectedMessage := fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
+		botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)
+		err := botDriver.WaitForLastMessageContains(botDriver.BotUserID(), botDriver.Channel().ID(), expectedMessage)
+		assert.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Move actions list E2E test after initial help message

The E2E tests are flaky as bot didn't respond - we should wait for Bot initial message before running any command.

This PR will have the tests rerun 3 times to make sure everything works as expected:
- https://github.com/kubeshop/botkube/actions/runs/3546594270/attempts/1
- https://github.com/kubeshop/botkube/actions/runs/3546594270
- https://github.com/kubeshop/botkube/actions/runs/3546594305

## Related issue(s)

#833 
