### PR TITLE
Make the integration jobs independent

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -60,6 +60,9 @@ jobs:
       packages: read
 
     strategy:
+      # make the jobs independent
+      fail-fast: false
+
       matrix:
         integration:
           - slack

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -151,6 +151,9 @@ jobs:
       packages: read
 
     strategy:
+      # make the jobs independent
+      fail-fast: false
+
       matrix:
         integration:
           - slack


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Currently, when one of a job in matrix fails, the other one is canceled. This is problematic when we want to debug the root cause of the failure. If we make those jobs independent then we can see which one really fails and if it is a generic problem or only with one of our platform integration.

Changes are introduced based on the GitHub action documentation: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures

Example where Discord test failed and as a result canceled the Slack testing: https://github.com/kubeshop/botkube/actions/runs/3677219708

