### PR TITLE
Dynamically generate help messages

### DIFF
--- a/pkg/execute/action.go
+++ b/pkg/execute/action.go
@@ -21,7 +21,10 @@ const (
 )
 
 var (
-	actionResourcesNames = []string{"action", "actions", "act"}
+	actionFeatureName = FeatureName{
+		Name:    "action",
+		Aliases: []string{"actions", "act"},
+	}
 )
 
 // ActionExecutor executes all commands that are related to actions.
@@ -42,11 +45,6 @@ func NewActionExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReport
 	}
 }
 
-// ResourceNames returns slice of resources the executor supports
-func (e *ActionExecutor) ResourceNames() []string {
-	return actionResourcesNames
-}
-
 // Commands returns slice of commands the executor supports
 func (e *ActionExecutor) Commands() map[CommandVerb]CommandFn {
 	return map[CommandVerb]CommandFn{
@@ -54,6 +52,11 @@ func (e *ActionExecutor) Commands() map[CommandVerb]CommandFn {
 		CommandEnable:  e.Enable,
 		CommandDisable: e.Disable,
 	}
+}
+
+// FeatureName returns the name and aliases of the feature provided by this executor
+func (e *ActionExecutor) FeatureName() FeatureName {
+	return actionFeatureName
 }
 
 // List returns a tabular representation of Actions

--- a/pkg/execute/command.go
+++ b/pkg/execute/command.go
@@ -21,7 +21,10 @@ const (
 )
 
 var (
-	commandResourcesNames = []string{"command", "commands", "cmd", "cmds"}
+	commandFeatureName = FeatureName{
+		Name:    "command",
+		Aliases: []string{"commands", "cmd", "cmds"},
+	}
 )
 
 // CommandsExecutor executes all commands that are related to command
@@ -40,9 +43,9 @@ func NewCommandsExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsRepo
 	}
 }
 
-// ResourceNames returns slice of resources the executor supports
-func (e *CommandsExecutor) ResourceNames() []string {
-	return commandResourcesNames
+// FeatureName returns the name and aliases of the feature provided by this executor
+func (e *CommandsExecutor) FeatureName() FeatureName {
+	return commandFeatureName
 }
 
 // Commands returns slice of commands the executor supports

--- a/pkg/execute/config.go
+++ b/pkg/execute/config.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	configResourcesNames = noResourceNames
+	configFeatureName = FeatureName{Name: noFeature}
 )
 
 // ConfigExecutor executes all commands that are related to config
@@ -34,9 +34,9 @@ func NewConfigExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReport
 	}
 }
 
-// ResourceNames returns slice of resources the executor supports
-func (e *ConfigExecutor) ResourceNames() []string {
-	return configResourcesNames
+// FeatureName returns the name and aliases of the feature provided by this executor
+func (e *ConfigExecutor) FeatureName() FeatureName {
+	return configFeatureName
 }
 
 // Commands returns slice of commands the executor supports

--- a/pkg/execute/default_runner.go
+++ b/pkg/execute/default_runner.go
@@ -1,12 +1,10 @@
 package execute
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
-	"github.com/kubeshop/botkube/pkg/multierror"
 )
 
 // CommandRunner provides functionality to run arbitrary commands.
@@ -56,28 +54,6 @@ type (
 	executorFunc    func() (interactive.Message, error)
 	executorsRunner map[string]executorFunc
 )
-
-func newCmdsMapping(executors []CommandExecutor) (map[CommandVerb]map[string]CommandFn, error) {
-	mappingsErrs := multierror.New()
-	cmdsMapping := make(map[CommandVerb]map[string]CommandFn)
-	for _, executor := range executors {
-		cmds := executor.Commands()
-		resNames := executor.ResourceNames()
-
-		for verb, cmdFn := range cmds {
-			if value := cmdsMapping[verb]; value == nil {
-				cmdsMapping[verb] = make(map[string]CommandFn)
-			}
-			for _, resName := range resNames {
-				if _, ok := cmdsMapping[verb][resName]; ok {
-					mappingsErrs = multierror.Append(mappingsErrs, fmt.Errorf("Command collision: tried to register '%s %s', but it already exists", verb, resName))
-				}
-				cmdsMapping[verb][resName] = cmdFn
-			}
-		}
-	}
-	return cmdsMapping, mappingsErrs.ErrorOrNil()
-}
 
 func (cmds executorsRunner) SelectAndRun(cmdVerb string) (interactive.Message, error) {
 	cmdVerb = strings.ToLower(cmdVerb)

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -35,7 +35,7 @@ type DefaultExecutorFactory struct {
 	merger                *kubectl.Merger
 	cfgManager            ConfigPersistenceManager
 	kubectlCmdBuilder     *KubectlCmdBuilder
-	cmdsMapping           map[CommandVerb]map[string]CommandFn
+	cmdsMapping           *CommandMapping
 }
 
 // DefaultExecutorFactoryParams contains input parameters for DefaultExecutorFactory.
@@ -154,7 +154,7 @@ func NewExecutorFactory(params DefaultExecutorFactoryParams) (*DefaultExecutorFa
 		notifierExecutor,
 		configExecutor,
 	}
-	mappings, err := newCmdsMapping(executors)
+	mappings, err := NewCmdsMapping(executors)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/execute/feedback.go
+++ b/pkg/execute/feedback.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	feedbackResourcesNames = noResourceNames
+	feedbackFeatureName = FeatureName{Name: noFeature}
 )
 
 // FeedbackExecutor executes all commands that are related to feedback.
@@ -28,9 +28,9 @@ func NewFeedbackExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsRepo
 	}
 }
 
-// ResourceNames returns slice of resources the executor supports
-func (e *FeedbackExecutor) ResourceNames() []string {
-	return feedbackResourcesNames
+// FeatureName returns the name and aliases of the feature provided by this executor
+func (e *FeedbackExecutor) FeatureName() FeatureName {
+	return feedbackFeatureName
 }
 
 // Commands returns slice of commands the executor supports

--- a/pkg/execute/filter.go
+++ b/pkg/execute/filter.go
@@ -21,7 +21,10 @@ const (
 )
 
 var (
-	filterResourcesNames = []string{"filter", "filters", "flr"}
+	filterFeatureName = FeatureName{
+		Name:    "filter",
+		Aliases: []string{"filters", "flr"},
+	}
 )
 
 // TODO: Refactor as a part of https://github.com/kubeshop/botkube/issues/657
@@ -44,11 +47,6 @@ func NewFilterExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReport
 	}
 }
 
-// ResourceNames returns slice of resources the executor supports
-func (e *FilterExecutor) ResourceNames() []string {
-	return filterResourcesNames
-}
-
 // Commands returns slice of commands the executor supports
 func (e *FilterExecutor) Commands() map[CommandVerb]CommandFn {
 	return map[CommandVerb]CommandFn{
@@ -56,6 +54,11 @@ func (e *FilterExecutor) Commands() map[CommandVerb]CommandFn {
 		CommandEnable:  e.Enable,
 		CommandDisable: e.Disable,
 	}
+}
+
+// FeatureName returns the name and aliases of the feature provided by this executor
+func (e *FilterExecutor) FeatureName() FeatureName {
+	return filterFeatureName
 }
 
 // List returns a tabular representation of Filters

--- a/pkg/execute/help.go
+++ b/pkg/execute/help.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	helpResourcesNames = noResourceNames
+	helpFeatureName = FeatureName{Name: noFeature}
 )
 
 // HelpExecutor executes all commands that are related to help
@@ -28,9 +28,9 @@ func NewHelpExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReporter
 	}
 }
 
-// ResourceNames returns slice of resources the executor supports
-func (e *HelpExecutor) ResourceNames() []string {
-	return helpResourcesNames
+// FeatureName returns the name and aliases of the feature provided by this executor
+func (e *HelpExecutor) FeatureName() FeatureName {
+	return helpFeatureName
 }
 
 // Commands returns slice of commands the executor supports

--- a/pkg/execute/mapping.go
+++ b/pkg/execute/mapping.go
@@ -1,0 +1,154 @@
+package execute
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/kubeshop/botkube/pkg/bot/interactive"
+	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/multierror"
+)
+
+const (
+	helpMsgHeader = "%s %s [feature]\n\nAvailable features:\n"
+	// noFeature is used for commands that have no features defined
+	noFeature = ""
+	// incompleteCmdMsg incomplete command response message
+	incompleteCmdMsg = "You missed to pass options for the command. Please use 'help' to see command options."
+)
+
+// CommandVerb are commands supported by the bot
+type CommandVerb string
+
+// CommandVerb command options
+const (
+	CommandPing     CommandVerb = "ping"
+	CommandHelp     CommandVerb = "help"
+	CommandVersion  CommandVerb = "version"
+	CommandFeedback CommandVerb = "feedback"
+	CommandList     CommandVerb = "list"
+	CommandEnable   CommandVerb = "enable"
+	CommandDisable  CommandVerb = "disable"
+	CommandEdit     CommandVerb = "edit"
+	CommandStart    CommandVerb = "start"
+	CommandStop     CommandVerb = "stop"
+	CommandStatus   CommandVerb = "status"
+	CommandConfig   CommandVerb = "config"
+)
+
+// CommandExecutor defines command structure for executors
+type CommandExecutor interface {
+	Commands() map[CommandVerb]CommandFn
+	FeatureName() FeatureName
+}
+
+// CommandFn is a single command (eg. List())
+type CommandFn func(ctx context.Context, cmdCtx CommandContext) (interactive.Message, error)
+
+// CommandContext contains the context for CommandFn
+type CommandContext struct {
+	Args            []string
+	ClusterName     string
+	CommGroupName   string
+	BotName         string
+	RawCmd          string
+	User            string
+	Conversation    Conversation
+	Platform        config.CommPlatformIntegration
+	ExecutorFilter  executorFilter
+	NotifierHandler NotifierHandler
+	Mapping         *CommandMapping
+}
+
+// FeatureName defines the name and aliases for a feature
+type FeatureName struct {
+	Name    string
+	Aliases []string
+}
+
+// CommandMapping allows to register and lookup commands and dynamically build help messages
+type CommandMapping struct {
+	commands map[CommandVerb]map[string]CommandFn
+	help     map[CommandVerb][]FeatureName
+}
+
+// NewCmdsMapping registers command and help mappings
+func NewCmdsMapping(executors []CommandExecutor) (*CommandMapping, error) {
+	mappingsErrs := multierror.New()
+	cmdsMapping := make(map[CommandVerb]map[string]CommandFn)
+	helpMapping := make(map[CommandVerb][]FeatureName)
+	for _, executor := range executors {
+		cmds := executor.Commands()
+		subCmd := executor.FeatureName()
+		for verb, cmdFn := range cmds {
+			if value := cmdsMapping[verb]; value == nil {
+				cmdsMapping[verb] = make(map[string]CommandFn)
+			}
+			if value := helpMapping[verb]; value == nil {
+				helpMapping[verb] = make([]FeatureName, 0)
+			}
+			cmdsMapping[verb][subCmd.Name] = cmdFn
+			helpMapping[verb] = append(helpMapping[verb], subCmd)
+			for _, featureName := range subCmd.Aliases {
+				if _, ok := cmdsMapping[verb][featureName]; ok {
+					mappingsErrs = multierror.Append(mappingsErrs, fmt.Errorf("command collision: tried to register '%s %s', but it already exists", verb, featureName))
+				}
+				cmdsMapping[verb][featureName] = cmdFn
+			}
+		}
+	}
+	if err := mappingsErrs.ErrorOrNil(); err != nil {
+		return nil, err
+	}
+	return &CommandMapping{
+		commands: cmdsMapping,
+		help:     helpMapping,
+	}, nil
+}
+
+// FindFn looks up CommandFn by verb and feature
+func (m *CommandMapping) FindFn(verb CommandVerb, feature string) (CommandFn, bool, bool) {
+	features, ok := m.commands[verb]
+	if !ok {
+		return nil, false, false
+	}
+	fn, ok := features[feature]
+	if !ok {
+		return nil, true, false
+	}
+	return fn, true, true
+}
+
+// HelpMessageForVerb dynamically builds help message for given CommandVerb, or empty string
+func (m *CommandMapping) HelpMessageForVerb(verb CommandVerb, botName string) string {
+	cmd, ok := m.help[verb]
+	if !ok {
+		return incompleteCmdMsg
+	}
+	buf := new(bytes.Buffer)
+	w := tabwriter.NewWriter(buf, 3, 0, 1, ' ', 0)
+
+	fmt.Fprintf(w, helpMsgHeader, botName, verb)
+	for _, feature := range cmd {
+		aliases := removeEmptyFeatures(feature.Aliases)
+		fmtStr := fmt.Sprintf("%s\t", feature.Name)
+		for _, a := range aliases {
+			fmtStr += fmt.Sprintf("|\t%s\t", a)
+		}
+		fmt.Fprintln(w, fmtStr)
+	}
+	w.Flush()
+	return buf.String()
+}
+
+func removeEmptyFeatures(features []string) []string {
+	clean := make([]string, 0, len(features))
+	for _, f := range features {
+		if f != "" {
+			clean = append(clean, f)
+		}
+	}
+	return clean
+}

--- a/pkg/execute/ping.go
+++ b/pkg/execute/ping.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	pingResourcesNames = noResourceNames
+	pingFeatureName = FeatureName{Name: noFeature}
 )
 
 // PingExecutor executes all commands that are related to ping.
@@ -31,9 +31,9 @@ func NewPingExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReporter
 	}
 }
 
-// ResourceNames returns slice of resources the executor supports
-func (e *PingExecutor) ResourceNames() []string {
-	return pingResourcesNames
+// FeatureName returns the name and aliases of the feature provided by this executor
+func (e *PingExecutor) FeatureName() FeatureName {
+	return pingFeatureName
 }
 
 // Commands returns slice of commands the executor supports

--- a/pkg/execute/sourcebinding.go
+++ b/pkg/execute/sourcebinding.go
@@ -25,12 +25,15 @@ const (
 )
 
 var (
-	sourceBindingResourcesNames = []string{"sourcebindings", "sourcebinding"}
+	sourceBindingFeatureName = FeatureName{
+		Name:    "sourcebinding",
+		Aliases: []string{"sourcebindings"},
+	}
 )
 
-// ResourceNames returns slice of resources the executor supports
-func (e *SourceBindingExecutor) ResourceNames() []string {
-	return sourceBindingResourcesNames
+// FeatureName returns the name and aliases of the feature provided by this executor
+func (e *SourceBindingExecutor) FeatureName() FeatureName {
+	return sourceBindingFeatureName
 }
 
 // Commands returns slice of commands the executor supports

--- a/pkg/execute/version.go
+++ b/pkg/execute/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	versionResourcesNames = noResourceNames
+	versionFeatureName = FeatureName{Name: noFeature}
 )
 
 // VersionExecutor executes all commands that are related to version.
@@ -30,9 +30,9 @@ func NewVersionExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsRepor
 	}
 }
 
-// ResourceNames returns slice of resources the executor supports
-func (e *VersionExecutor) ResourceNames() []string {
-	return versionResourcesNames
+// FeatureName returns the name and aliases of the feature provided by this executor
+func (e *VersionExecutor) FeatureName() FeatureName {
+	return versionFeatureName
 }
 
 // Commands returns slice of commands the executor supports

--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -193,6 +193,10 @@ func runBotTest(t *testing.T,
 	// Discord bot needs a bit more time to connect to Discord API.
 	time.Sleep(appCfg.Discord.MessageWaitTimeout)
 	t.Log("Waiting for interactive help")
+
+	expected := interactive.NewHelpMessage(config.CommPlatformIntegration(botDriver.Type()), appCfg.ClusterName, botDriver.BotName()).Build()
+	t.Log(expected)
+
 	err = botDriver.WaitForInteractiveMessagePostedRecentlyEqual(botDriver.BotUserID(),
 		botDriver.Channel().ID(),
 		interactive.NewHelpMessage(config.CommPlatformIntegration(botDriver.Type()), appCfg.ClusterName, botDriver.BotName()).Build(),

--- a/test/e2e/discord_driver_test.go
+++ b/test/e2e/discord_driver_test.go
@@ -346,6 +346,7 @@ func (d *discordTester) WaitForInteractiveMessagePostedRecentlyEqual(userID, cha
 		if !strings.EqualFold(markdown, msg) {
 			count := countMatchBlock(markdown, msg)
 			msgDiff := diff(markdown, msg)
+			fmt.Printf("DIFF:\n%s\n", msgDiff)
 			return false, count, msgDiff
 		}
 		return true, 0, ""


### PR DESCRIPTION
## Dynamically generate help message when subcommand is missing

For commands that support subcommands/resources, when such subcommand is missing, return a dynamically
generated table of all subcommands supported by the command.

## Related issue(s)

#703 