### PR TITLE
Fix notifier verbs

### DIFF
--- a/pkg/execute/config.go
+++ b/pkg/execute/config.go
@@ -51,8 +51,8 @@ func (e *ConfigExecutor) Commands() map[CommandVerb]CommandFn {
 
 // Show returns Config in yaml format
 func (e *ConfigExecutor) Show(ctx context.Context, cmdCtx CommandContext) (interactive.Message, error) {
-	cmdVerb, _ := parseCmdVerb(cmdCtx.Args)
-	defer e.reportCommand(cmdVerb, cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
+	cmdVerb, cmdRes := parseCmdVerb(cmdCtx.Args)
+	defer e.reportCommand(cmdVerb, cmdRes, cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
 
 	cfg, err := e.renderBotkubeConfiguration()
 	if err != nil {
@@ -61,7 +61,8 @@ func (e *ConfigExecutor) Show(ctx context.Context, cmdCtx CommandContext) (inter
 	return respond(cfg, cmdCtx), nil
 }
 
-func (e *ConfigExecutor) reportCommand(cmdToReport string, commandOrigin command.Origin, platform config.CommPlatformIntegration) {
+func (e *ConfigExecutor) reportCommand(cmdVerb, cmdRes string, commandOrigin command.Origin, platform config.CommPlatformIntegration) {
+	cmdToReport := fmt.Sprintf("%s %s", cmdVerb, cmdRes)
 	err := e.analyticsReporter.ReportCommand(platform, cmdToReport, commandOrigin, false)
 	if err != nil {
 		e.log.Errorf("while reporting config command: %s", err.Error())

--- a/pkg/execute/config.go
+++ b/pkg/execute/config.go
@@ -13,7 +13,10 @@ import (
 )
 
 var (
-	configFeatureName = FeatureName{Name: noFeature}
+	configFeatureName = FeatureName{
+		Name:    "config",
+		Aliases: []string{"cfg", "configuration"},
+	}
 )
 
 // ConfigExecutor executes all commands that are related to config
@@ -42,12 +45,12 @@ func (e *ConfigExecutor) FeatureName() FeatureName {
 // Commands returns slice of commands the executor supports
 func (e *ConfigExecutor) Commands() map[CommandVerb]CommandFn {
 	return map[CommandVerb]CommandFn{
-		CommandConfig: e.Config,
+		CommandShow: e.Show,
 	}
 }
 
-// Config returns Config in yaml format
-func (e *ConfigExecutor) Config(ctx context.Context, cmdCtx CommandContext) (interactive.Message, error) {
+// Show returns Config in yaml format
+func (e *ConfigExecutor) Show(ctx context.Context, cmdCtx CommandContext) (interactive.Message, error) {
 	cmdVerb, _ := parseCmdVerb(cmdCtx.Args)
 	defer e.reportCommand(cmdVerb, cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
 

--- a/pkg/execute/config_test.go
+++ b/pkg/execute/config_test.go
@@ -81,7 +81,7 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			e := NewConfigExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, tc.Cfg)
-			msg, err := e.Config(context.Background(), tc.CmdCtx)
+			msg, err := e.Show(context.Background(), tc.CmdCtx)
 			require.NoError(t, err)
 			assert.Equal(t, msg.Body.CodeBlock, tc.ExpectedResult)
 		})

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -108,11 +108,12 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.Message {
 
 	if len(cmdCtx.Args) == 0 {
 		if e.conversation.IsAuthenticated {
-			return interactive.Message{
-				Base: interactive.Base{
-					Description: unsupportedCmdMsg,
-				},
+			msg, err := e.helpExecutor.Help(ctx, cmdCtx)
+			if err != nil {
+				e.log.Errorf("while getting help message: %s", err.Error())
+				return respond(err.Error(), cmdCtx)
 			}
+			return msg
 		}
 		return empty // this prevents all bots on all clusters to answer something
 	}

--- a/pkg/execute/mapping.go
+++ b/pkg/execute/mapping.go
@@ -33,7 +33,7 @@ const (
 	CommandDisable  CommandVerb = "disable"
 	CommandEdit     CommandVerb = "edit"
 	CommandStatus   CommandVerb = "status"
-	CommandConfig   CommandVerb = "config"
+	CommandShow     CommandVerb = "show"
 )
 
 // CommandExecutor defines command structure for executors

--- a/pkg/execute/mapping.go
+++ b/pkg/execute/mapping.go
@@ -32,8 +32,6 @@ const (
 	CommandEnable   CommandVerb = "enable"
 	CommandDisable  CommandVerb = "disable"
 	CommandEdit     CommandVerb = "edit"
-	CommandStart    CommandVerb = "start"
-	CommandStop     CommandVerb = "stop"
 	CommandStatus   CommandVerb = "status"
 	CommandConfig   CommandVerb = "config"
 )

--- a/pkg/execute/notifier.go
+++ b/pkg/execute/notifier.go
@@ -71,14 +71,14 @@ func (e *NotifierExecutor) FeatureName() FeatureName {
 // Commands returns slice of commands the executor supports
 func (e *NotifierExecutor) Commands() map[CommandVerb]CommandFn {
 	return map[CommandVerb]CommandFn{
-		CommandStart:  e.Start,
-		CommandStop:   e.Stop,
-		CommandStatus: e.Status,
+		CommandEnable:  e.Enable,
+		CommandDisable: e.Disable,
+		CommandStatus:  e.Status,
 	}
 }
 
-// Start starts the notifier
-func (e *NotifierExecutor) Start(ctx context.Context, cmdCtx CommandContext) (interactive.Message, error) {
+// Enable starts the notifier
+func (e *NotifierExecutor) Enable(ctx context.Context, cmdCtx CommandContext) (interactive.Message, error) {
 	cmdVerb, cmdRes := parseCmdVerb(cmdCtx.Args)
 	defer e.reportCommand(fmt.Sprintf("%s %s", cmdVerb, cmdRes), cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
 
@@ -103,8 +103,8 @@ func (e *NotifierExecutor) Start(ctx context.Context, cmdCtx CommandContext) (in
 	return respond(successMessage, cmdCtx), nil
 }
 
-// Stop stops the notifier
-func (e *NotifierExecutor) Stop(ctx context.Context, cmdCtx CommandContext) (interactive.Message, error) {
+// Disable stops the notifier
+func (e *NotifierExecutor) Disable(ctx context.Context, cmdCtx CommandContext) (interactive.Message, error) {
 	cmdVerb, cmdRes := parseCmdVerb(cmdCtx.Args)
 	defer e.reportCommand(fmt.Sprintf("%s %s", cmdVerb, cmdRes), cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
 

--- a/pkg/execute/notifier_test.go
+++ b/pkg/execute/notifier_test.go
@@ -86,7 +86,7 @@ func TestNotifierExecutorStart(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			e := NewNotifierExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, &fakeCfgPersistenceManager{expectedAlias: channelAlias}, notifierTestCfg)
-			msg, err := e.Start(context.Background(), tc.CmdCtx)
+			msg, err := e.Enable(context.Background(), tc.CmdCtx)
 			if err != nil {
 				assert.EqualError(t, err, tc.ExpectedError)
 				return
@@ -160,7 +160,7 @@ func TestNotifierExecutorStop(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			e := NewNotifierExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, &fakeCfgPersistenceManager{expectedAlias: channelAlias}, notifierTestCfg)
-			msg, err := e.Stop(context.Background(), tc.CmdCtx)
+			msg, err := e.Disable(context.Background(), tc.CmdCtx)
 			if err != nil {
 				assert.EqualError(t, err, tc.ExpectedError)
 				return

--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -575,7 +575,7 @@ func runBotTest(t *testing.T,
 		assert.NoError(t, err)
 
 		t.Log("Starting notifier in second channel...")
-		command = "start notifications"
+		command = "enable notifications"
 		expectedBody = codeBlock(fmt.Sprintf("Brace yourselves, incoming notifications from cluster '%s'.", appCfg.ClusterName))
 		expectedMessage = fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
 
@@ -645,7 +645,7 @@ func runBotTest(t *testing.T,
 		require.NoError(t, err)
 
 		t.Log("Stopping notifier in first channel...")
-		command = "stop notifications"
+		command = "disable notifications"
 		expectedBody = codeBlock(fmt.Sprintf("Sure! I won't send you notifications from cluster '%s' here.", appCfg.ClusterName))
 		expectedMessage = fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
 
@@ -698,7 +698,7 @@ func runBotTest(t *testing.T,
 		err = botDriver.WaitForLastMessagePostedWithAttachment(botDriver.BotUserID(), botDriver.SecondChannel().ID(), attachAssertionFn)
 
 		t.Log("Starting notifier in first channel")
-		command = "start notifications"
+		command = "enable notifications"
 		expectedBody = codeBlock(fmt.Sprintf("Brace yourselves, incoming notifications from cluster '%s'.", appCfg.ClusterName))
 		expectedMessage = fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
 


### PR DESCRIPTION
## Fix notifier verbs

Based on #703 notifier verbs are `enable, disable` and not `start, stop`.

## Related issue(s)

#703 
