### PR TITLE
Make plugin logger independent, fix naming in err msgs

### DIFF
--- a/internal/plugin/logger.go
+++ b/internal/plugin/logger.go
@@ -22,11 +22,13 @@ var specialCharsPattern = regexp.MustCompile(`(?i:[^A-Z0-9_])`)
 // - hashicorp client logger always has the configured log level
 // - binary standard output is logged only if debug level is set, otherwise it is discarded
 // - binary standard error is logged always on error level
-func NewPluginLoggers(parentLogger logrus.FieldLogger, pluginKey string, pluginType Type) (hclog.Logger, io.Writer, io.Writer) {
-	pluginLogLevel := getPluginLogLevel(parentLogger, pluginKey, pluginType)
+func NewPluginLoggers(bkLogger logrus.FieldLogger, pluginKey string, pluginType Type) (hclog.Logger, io.Writer, io.Writer) {
+	pluginLogLevel := getPluginLogLevel(bkLogger, pluginKey, pluginType)
 
-	log := parentLogger.WithField("plugin", pluginKey)
-	log.Level = pluginLogLevel
+	cfg := loggerx.Config{
+		Level: pluginLogLevel.String(),
+	}
+	log := loggerx.New(cfg).WithField("plugin", pluginKey)
 
 	var (
 		pluginLogger = loggerx.AsHCLog(log, pluginKey)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -326,8 +326,8 @@ func TestLoadedConfigEnabledPluginErrors(t *testing.T) {
 			name: "should report an issue with bindings for same plugin name but coming from two different repositories",
 			expErrMsg: heredoc.Doc(`
 				found critical validation errors: 2 errors occurred:
-					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[alias].Bindings.mszostok/prometheus@v1.2.0' conflicts with already bind "prometheus" plugin from "botkube" repository. Bind it to a different channel, or change it to the one from the "botkube" repository, or remove it.
-					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[alias].Bindings.mszostok/kubectl@v1.0.0' conflicts with already bind "kubectl" plugin from "botkube" repository. Bind it to a different channel, or change it to the one from the "botkube" repository, or remove it.`),
+					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[alias].Bindings.mszostok/prometheus@v1.2.0' conflicts with already bound "prometheus" plugin from "botkube" repository. Bind it to a different channel, change it to the one from the "botkube" repository, or remove it.
+					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[alias].Bindings.mszostok/kubectl@v1.0.0' conflicts with already bound "kubectl" plugin from "botkube" repository. Bind it to a different channel, change it to the one from the "botkube" repository, or remove it.`),
 			configFiles: []string{
 				testdataFile(t, "bind-diff-repo.yaml"),
 			},
@@ -336,8 +336,8 @@ func TestLoadedConfigEnabledPluginErrors(t *testing.T) {
 			name: "should report an issue with bindings for plugins coming from the same repository but one refers to the latest version",
 			expErrMsg: heredoc.Doc(`
 				found critical validation errors: 2 errors occurred:
-					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[latest].Bindings.botkube/prometheus@v1.2.0' conflicts with already bind "prometheus" plugin in the latest version. Bind it to a different channel, or change it to the latest version, or remove it.
-					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[latest].Bindings.botkube/kubectl@v1.0.0' conflicts with already bind "kubectl" plugin in the latest version. Bind it to a different channel, or change it to the latest version, or remove it.`),
+					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[latest].Bindings.botkube/prometheus@v1.2.0' conflicts with already bound "prometheus" plugin in the latest version. Bind it to a different channel, change it to the latest version, or remove it.
+					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[latest].Bindings.botkube/kubectl@v1.0.0' conflicts with already bound "kubectl" plugin in the latest version. Bind it to a different channel, change it to the latest version, or remove it.`),
 			configFiles: []string{
 				testdataFile(t, "bind-diff-ver-latest.yaml"),
 			},
@@ -346,8 +346,8 @@ func TestLoadedConfigEnabledPluginErrors(t *testing.T) {
 			name: "should report an issue with bindings for plugins coming from the same repository but with different version",
 			expErrMsg: heredoc.Doc(`
 				found critical validation errors: 2 errors occurred:
-					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[versions].Bindings.botkube/prometheus@v1.2.0' conflicts with already bind "prometheus" plugin in the "v1.0.0" version. Bind it to a different channel, or change it to the "v1.0.0" version, or remove it.
-					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[versions].Bindings.botkube/kubectl@v2.0.0' conflicts with already bind "kubectl" plugin in the "v1.0.0" version. Bind it to a different channel, or change it to the "v1.0.0" version, or remove it.`),
+					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[versions].Bindings.botkube/prometheus@v1.2.0' conflicts with already bound "prometheus" plugin in the "v1.0.0" version. Bind it to a different channel, change it to the "v1.0.0" version, or remove it.
+					* Key: 'Config.Communications[default-workspace].SocketSlack.Channels[versions].Bindings.botkube/kubectl@v2.0.0' conflicts with already bound "kubectl" plugin in the "v1.0.0" version. Bind it to a different channel, change it to the "v1.0.0" version, or remove it.`),
 			configFiles: []string{
 				testdataFile(t, "bind-diff-ver.yaml"),
 			},
@@ -376,20 +376,20 @@ func TestLoadedConfigEnabledPluginErrors(t *testing.T) {
 			name: "should report an issue with source configuration group that imports plugins with wrong syntax",
 			expErrMsg: heredoc.Doc(`
 				found critical validation errors: 7 errors occurred:
-					* Key: 'Config.Sources[wrong-name]./@v1.2.0' doesn't follow required {repo_name}/{plugin_name} syntax: 2 errors occurred:
+					* Key: 'Config.Sources[wrong-name]./@v1.2.0' doesn't follow the required {repo_name}/{plugin_name} syntax: 2 errors occurred:
 						* repository name is required
 						* plugin name is required
-					* Key: 'Config.Sources[wrong-name]./prometheus@v1.2.0' doesn't follow required {repo_name}/{plugin_name} syntax: 1 error occurred:
+					* Key: 'Config.Sources[wrong-name]./prometheus@v1.2.0' doesn't follow the required {repo_name}/{plugin_name} syntax: 1 error occurred:
 						* repository name is required
-					* Key: 'Config.Sources[wrong-name].botkube/@v1.0.0' doesn't follow required {repo_name}/{plugin_name} syntax: 1 error occurred:
+					* Key: 'Config.Sources[wrong-name].botkube/@v1.0.0' doesn't follow the required {repo_name}/{plugin_name} syntax: 1 error occurred:
 						* plugin name is required
-					* Key: 'Config.Executors[wrong-name]./@v1.0.0' doesn't follow required {repo_name}/{plugin_name} syntax: 2 errors occurred:
+					* Key: 'Config.Executors[wrong-name]./@v1.0.0' doesn't follow the required {repo_name}/{plugin_name} syntax: 2 errors occurred:
 						* repository name is required
 						* plugin name is required
-					* Key: 'Config.Executors[wrong-name]./kubectl@v1.0.0' doesn't follow required {repo_name}/{plugin_name} syntax: 1 error occurred:
+					* Key: 'Config.Executors[wrong-name]./kubectl@v1.0.0' doesn't follow the required {repo_name}/{plugin_name} syntax: 1 error occurred:
 						* repository name is required
-					* Key: 'Config.Executors[wrong-name].some-3rd-plugin' plugin key "some-3rd-plugin" doesn't follow required {repo_name}/{plugin_name} syntax
-					* Key: 'Config.Executors[wrong-name].testing/@v1.0.0' doesn't follow required {repo_name}/{plugin_name} syntax: 1 error occurred:
+					* Key: 'Config.Executors[wrong-name].some-3rd-plugin' plugin key "some-3rd-plugin" doesn't follow the required {repo_name}/{plugin_name} syntax
+					* Key: 'Config.Executors[wrong-name].testing/@v1.0.0' doesn't follow the required {repo_name}/{plugin_name} syntax: 1 error occurred:
 						* plugin name is required`),
 			configFiles: []string{
 				testdataFile(t, "cfg-group-wrong-plugin-def.yaml"),

--- a/pkg/config/plugin.go
+++ b/pkg/config/plugin.go
@@ -16,13 +16,13 @@ import (
 func DecomposePluginKey(key string) (string, string, string, error) {
 	repo, name, found := strings.Cut(key, "/")
 	if !found {
-		return "", "", "", fmt.Errorf("plugin key %q doesn't follow required {repo_name}/{plugin_name} syntax", key)
+		return "", "", "", fmt.Errorf("plugin key %q doesn't follow the required {repo_name}/{plugin_name} syntax", key)
 	}
 
 	name, ver, _ := strings.Cut(name, "@")
 
 	if err := validatePluginProperties(repo, name); err != nil {
-		return "", "", "", fmt.Errorf("doesn't follow required {repo_name}/{plugin_name} syntax: %v", err)
+		return "", "", "", fmt.Errorf("doesn't follow the required {repo_name}/{plugin_name} syntax: %v", err)
 	}
 
 	return repo, name, ver, nil
@@ -70,7 +70,7 @@ func validateBindPlugins(sl validator.StructLevel, enabledPluginsViaBindings []s
 		}
 
 		if alreadyIndexed.Repo != newEntry.Repo {
-			msg := fmt.Sprintf("conflicts with already bind %q plugin from %q repository. Bind it to a different channel, or change it to the one from the %q repository, or remove it.", name, alreadyIndexed.Repo, alreadyIndexed.Repo)
+			msg := fmt.Sprintf("conflicts with already bound %q plugin from %q repository. Bind it to a different channel, change it to the one from the %q repository, or remove it.", name, alreadyIndexed.Repo, alreadyIndexed.Repo)
 			sl.ReportError(key, "", key, conflictingPluginRepoTag, msg)
 			continue
 		}
@@ -79,7 +79,7 @@ func validateBindPlugins(sl validator.StructLevel, enabledPluginsViaBindings []s
 			if alreadyIndexed.Version != "" {
 				verInfo = fmt.Sprintf("%q", alreadyIndexed.Version)
 			}
-			msg := fmt.Sprintf("conflicts with already bind %q plugin in the %s version. Bind it to a different channel, or change it to the %s version, or remove it.", name, verInfo, verInfo)
+			msg := fmt.Sprintf("conflicts with already bound %q plugin in the %s version. Bind it to a different channel, change it to the %s version, or remove it.", name, verInfo, verInfo)
 
 			sl.ReportError(key, "", key, conflictingPluginVersionTag, msg)
 		}

--- a/pkg/config/plugin_test.go
+++ b/pkg/config/plugin_test.go
@@ -64,27 +64,27 @@ func TestDecomposePluginKey(t *testing.T) {
 			{
 				name:     "should report error of wrong pattern",
 				givenKey: "kubectl@v1.0.0",
-				expErr:   `plugin key "kubectl@v1.0.0" doesn't follow required {repo_name}/{plugin_name} syntax`,
+				expErr:   `plugin key "kubectl@v1.0.0" doesn't follow the required {repo_name}/{plugin_name} syntax`,
 			},
 			{
 				name:     "should report error about missing plugin name",
 				givenKey: "test/@v1.0.0",
 				expErr: heredoc.Doc(`
-					doesn't follow required {repo_name}/{plugin_name} syntax: 1 error occurred:
+					doesn't follow the required {repo_name}/{plugin_name} syntax: 1 error occurred:
 						* plugin name is required`),
 			},
 			{
 				name:     "should report error about missing repo name",
 				givenKey: "/kubectl@v1.0.0",
 				expErr: heredoc.Doc(`
-					doesn't follow required {repo_name}/{plugin_name} syntax: 1 error occurred:
+					doesn't follow the required {repo_name}/{plugin_name} syntax: 1 error occurred:
 						* repository name is required`),
 			},
 			{
 				name:     "should report error about missing repo and plugin names",
 				givenKey: "/@v1.0.0",
 				expErr: heredoc.Doc(`
-					doesn't follow required {repo_name}/{plugin_name} syntax: 2 errors occurred:
+					doesn't follow the required {repo_name}/{plugin_name} syntax: 2 errors occurred:
 						* repository name is required
 						* plugin name is required`),
 			},


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Make plugin logger independent - currently changing the plugin level also change the Botkube one, and otherwise.
- Fix naming in err msgs

