### PR TITLE
Fix bugs in executors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,3 +47,9 @@ linters-settings:
   gocyclo:
     # https://github.com/kubeshop/botkube/issues/745
     min-complexity: 40
+  revive:
+    rules:
+      # Disable warns about capitalized and ended with punctuation error messages
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-strings
+      - name: error-strings
+        disabled: true

--- a/cmd/executor/echo/main.go
+++ b/cmd/executor/echo/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/hashicorp/go-plugin"
@@ -50,6 +51,10 @@ func (EchoExecutor) Execute(_ context.Context, in executor.ExecuteInput) (execut
 	}
 
 	data := in.Command
+	if strings.Contains(data, "@fail") {
+		return executor.ExecuteOutput{}, errors.New("The @fail label was specified. Failing execution.")
+	}
+
 	if finalCfg.ChangeResponseToUpperCase != nil && *finalCfg.ChangeResponseToUpperCase {
 		data = strings.ToUpper(data)
 	}

--- a/pkg/execute/kubectl.go
+++ b/pkg/execute/kubectl.go
@@ -237,6 +237,8 @@ func (e *Kubectl) getFinalArgs(args []string) []string {
 // If `--namespace/-n` was not found, returns empty string.
 func (e *Kubectl) getNamespaceFlag(args []string) (string, error) {
 	f := pflag.NewFlagSet("extract-ns", pflag.ContinueOnError)
+	f.BoolP("help", "h", false, "to make sure that parsing is ignoring the --help,-h flags")
+
 	// ignore unknown flags errors, e.g. `--cluster-name` etc.
 	f.ParseErrorsWhitelist.UnknownFlags = true
 
@@ -252,6 +254,8 @@ func (e *Kubectl) getNamespaceFlag(args []string) (string, error) {
 // If `--A, --all-namespaces` was not found, returns empty string.
 func (e *Kubectl) getAllNamespaceFlag(args []string) (bool, error) {
 	f := pflag.NewFlagSet("extract-ns", pflag.ContinueOnError)
+	f.BoolP("help", "h", false, "to make sure that parsing is ignoring the --help,-h flags")
+
 	// ignore unknown flags errors, e.g. `--cluster-name` etc.
 	f.ParseErrorsWhitelist.UnknownFlags = true
 

--- a/pkg/execute/params.go
+++ b/pkg/execute/params.go
@@ -78,6 +78,8 @@ func extractFilterParam(cmd string) (string, string, error) {
 	var filters []string
 	args, _ := shellwords.Parse(cmd)
 	f := pflag.NewFlagSet("extract-filters", pflag.ContinueOnError)
+	f.BoolP("help", "h", false, "to make sure that parsing is ignoring the --help,-h flags")
+
 	f.ParseErrorsWhitelist.UnknownFlags = true
 	f.StringArrayVar(&filters, "filter", []string{}, "Output filter")
 	if err := f.Parse(args); err != nil {

--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -161,6 +161,7 @@ func runBotTest(t *testing.T,
 
 	t.Logf("Setting up test %s setup...", driverType)
 	botDriver.InitUsers(t)
+
 	cleanUpFns := botDriver.InitChannels(t)
 	for _, fn := range cleanUpFns {
 		t.Cleanup(fn)
@@ -243,9 +244,18 @@ func runBotTest(t *testing.T,
 	// Those are a temporary tests. When we will extract kubectl and kubernetes as plugins
 	// they won't be needed anymore.
 	t.Run("Botkube Plugins", func(t *testing.T) {
-		t.Run("Echo Executor", func(t *testing.T) {
+		t.Run("Echo Executor success", func(t *testing.T) {
 			command := "echo test"
 			expectedBody := codeBlock(strings.ToUpper(command))
+			expectedMessage := fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
+
+			botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)
+			err := botDriver.WaitForLastMessageEqual(botDriver.BotUserID(), botDriver.Channel().ID(), expectedMessage)
+			assert.NoError(t, err)
+		})
+		t.Run("Echo Executor failure", func(t *testing.T) {
+			command := "echo @fail"
+			expectedBody := codeBlock("The @fail label was specified. Failing execution.")
 			expectedMessage := fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
 
 			botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)

--- a/test/e2e/discord_driver_test.go
+++ b/test/e2e/discord_driver_test.go
@@ -87,10 +87,10 @@ func (d *discordTester) SecondChannel() Channel {
 func (d *discordTester) InitUsers(t *testing.T) {
 	t.Helper()
 	d.botUserID = d.findUserID(t, d.cfg.BotName)
-	assert.NotEmpty(t, d.botUserID, "could not find discord botUserID with name: %s", d.cfg.BotName)
+	require.NotEmpty(t, d.botUserID, "could not find discord botUserID with name: %s", d.cfg.BotName)
 
 	d.testerUserID = d.findUserID(t, d.cfg.TesterName)
-	assert.NotEmpty(t, d.testerUserID, "could not find discord testerUserID with name: %s", d.cfg.TesterName)
+	require.NotEmpty(t, d.testerUserID, "could not find discord testerUserID with name: %s", d.cfg.TesterName)
 }
 
 func (d *discordTester) InitChannels(t *testing.T) []func() {
@@ -369,11 +369,11 @@ func (d *discordTester) GetColorByLevel(level config.Level) string {
 }
 
 func (d *discordTester) findUserID(t *testing.T, name string) string {
-	t.Log("Getting users...")
-	res, err := d.cli.GuildMembersSearch(d.cfg.GuildID, name, 5)
+	t.Logf("Getting user %q...", name)
+	res, err := d.cli.GuildMembersSearch(d.cfg.GuildID, name, 50)
 	require.NoError(t, err)
 
-	t.Logf("Finding user ID by name %q...", name)
+	t.Logf("Finding user ID in %v...", res)
 	for _, m := range res {
 		if !strings.EqualFold(name, m.User.Username) {
 			continue


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Once the `@Botkube list --help` was specified the Botkube panic, as it was not handled properly by filter executor
- don't use filtering twice (now it's used only in `respond` function)
- fix logged field in plugin executor
- ignore `--help,-h` flag in exec filter
- handle `ExecutionCommandError` in plugin response (e2e tested via `@Botkube echo @fail`)

