### PR TITLE
Add option to set discord user's ID directly

### DIFF
--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -62,8 +62,10 @@ type SlackConfig struct {
 }
 
 type DiscordConfig struct {
-	BotName                  string `envconfig:"default=botkube"`
-	TesterName               string `envconfig:"default=botkube_tester"`
+	BotName                  string `envconfig:"optional"`
+	BotID                    string `envconfig:"default=983294404108378154"`
+	TesterName               string `envconfig:"optional"`
+	TesterID                 string `envconfig:"default=1020384322114572381"`
 	AdditionalContextMessage string `envconfig:"optional"`
 	GuildID                  string
 	TesterAppToken           string

--- a/test/e2e/discord_driver_test.go
+++ b/test/e2e/discord_driver_test.go
@@ -86,11 +86,20 @@ func (d *discordTester) SecondChannel() Channel {
 
 func (d *discordTester) InitUsers(t *testing.T) {
 	t.Helper()
-	d.botUserID = d.findUserID(t, d.cfg.BotName)
-	require.NotEmpty(t, d.botUserID, "could not find discord botUserID with name: %s", d.cfg.BotName)
 
-	d.testerUserID = d.findUserID(t, d.cfg.TesterName)
-	require.NotEmpty(t, d.testerUserID, "could not find discord testerUserID with name: %s", d.cfg.TesterName)
+	d.botUserID = d.cfg.BotID
+	if d.cfg.BotName != "" || d.botUserID == "" {
+		t.Log("Bot user ID not set, looking for ID based on Bot name...")
+		d.botUserID = d.findUserID(t, d.cfg.BotName)
+		require.NotEmpty(t, d.botUserID, "could not find discord botUserID with name: %s", d.cfg.BotName)
+	}
+
+	d.testerUserID = d.cfg.TesterID
+	if d.cfg.TesterName != "" || d.testerUserID == "" {
+		t.Log("Tester user ID not set, looking for ID based on Tester name...")
+		d.testerUserID = d.findUserID(t, d.cfg.TesterName)
+		require.NotEmpty(t, d.testerUserID, "could not find discord testerUserID with name: %s", d.cfg.TesterName)
+	}
 }
 
 func (d *discordTester) InitChannels(t *testing.T) []func() {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add option to set discord user's ID directly

