### PR TITLE
Replace removed 'list commands', print multi-cluster info only for supported platforms

### DIFF
--- a/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_headers_and_default_new_lines.golden.txt
+++ b/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_headers_and_default_new_lines.golden.txt
@@ -1,11 +1,5 @@
 Botkube is now active for "testing" cluster :rocket:
 
-*Using multiple instances*
-If you are running multiple Botkube instances in the same channel to interact with testing, make sure to specify the cluster name when typing commands.
-```
---cluster-name=testing
-```
-
 *Ping your cluster*
 Check the status of connected Kubernetes cluster(s).
   - `@Botkube ping`
@@ -44,8 +38,8 @@ You can run kubectl commands directly from Platform!
   - `@Botkube kubectl get pods`
   - `@Botkube kubectl get deployments`
 
-To list all supported kubectl commands
-  - `@Botkube list commands`
+To list all enabled executors
+  - `@Botkube list executors`
 
 *Filters (advanced)*
 You can extend Botkube functionality by writing additional filters that can check resource specs, validate some checks and add messages to the Event struct. Learn more at https://docs.botkube.io/filters

--- a/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_new_lines_and_default_headers.golden.txt
+++ b/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_new_lines_and_default_headers.golden.txt
@@ -1,6 +1,4 @@
-Botkube is now active for "testing" cluster :rocket:<br><br>**Using multiple instances**<br>If you are running multiple Botkube instances in the same channel to interact with testing, make sure to specify the cluster name when typing commands.<br>```
---cluster-name=testing
-```<br><br>**Ping your cluster**<br>Check the status of connected Kubernetes cluster(s).<br>  - `@Botkube ping`<br><br>**Manage incoming notifications**<br>```
+Botkube is now active for "testing" cluster :rocket:<br><br>**Ping your cluster**<br>Check the status of connected Kubernetes cluster(s).<br>  - `@Botkube ping`<br><br>**Manage incoming notifications**<br>```
 @Botkube [start|stop|status] notifications
 ```<br>  - `@Botkube start notifications`<br>  - `@Botkube stop notifications`<br>  - `@Botkube status notifications`<br><br>**Notification settings for this channel**<br>By default, Botkube will notify only about cluster errors and recommendations.<br>  - `@Botkube edit SourceBindings`<br><br>**Manage automated actions**<br>```
 @Botkube [list|enable|disable] action [action name]
@@ -10,4 +8,4 @@ Botkube is now active for "testing" cluster :rocket:<br><br>**Using multiple ins
 
 e.g. `@Botkube k get pods` instead of `@Botkube get pods`
 
-You can run kubectl commands directly from Platform!<br>  - `@Botkube kubectl get services`<br>  - `@Botkube kubectl get pods`<br>  - `@Botkube kubectl get deployments`<br><br>To list all supported kubectl commands<br>  - `@Botkube list commands`<br><br>**Filters (advanced)**<br>You can extend Botkube functionality by writing additional filters that can check resource specs, validate some checks and add messages to the Event struct. Learn more at https://docs.botkube.io/filters<br><br>**Angry? Amazed?**<br>Give feedback: https://feedback.botkube.io<br><br>Read our docs: https://docs.botkube.io<br>Join our Slack: https://join.botkube.io<br>Follow us on Twitter: https://twitter.com/botkube_io<br>
+You can run kubectl commands directly from Platform!<br>  - `@Botkube kubectl get services`<br>  - `@Botkube kubectl get pods`<br>  - `@Botkube kubectl get deployments`<br><br>To list all enabled executors<br>  - `@Botkube list executors`<br><br>**Filters (advanced)**<br>You can extend Botkube functionality by writing additional filters that can check resource specs, validate some checks and add messages to the Event struct. Learn more at https://docs.botkube.io/filters<br><br>**Angry? Amazed?**<br>Give feedback: https://feedback.botkube.io<br><br>Read our docs: https://docs.botkube.io<br>Join our Slack: https://join.botkube.io<br>Follow us on Twitter: https://twitter.com/botkube_io<br>

--- a/pkg/bot/interactive/testdata/TestInteractiveMessageToPlaintext.golden.txt
+++ b/pkg/bot/interactive/testdata/TestInteractiveMessageToPlaintext.golden.txt
@@ -1,9 +1,4 @@
 
-Using multiple instances
-If you are running multiple Botkube instances in the same channel to interact with testing, make sure to specify the cluster name when typing commands.
---cluster-name=testing
-
-
 Ping your cluster
 Check the status of connected Kubernetes cluster(s).
   - @Botkube ping
@@ -39,8 +34,8 @@ You can run kubectl commands directly from Platform!
   - @Botkube kubectl get pods
   - @Botkube kubectl get deployments
 
-To list all supported kubectl commands
-  - @Botkube list commands
+To list all enabled executors
+  - @Botkube list executors
 
 Filters (advanced)
 You can extend Botkube functionality by writing additional filters that can check resource specs, validate some checks and add messages to the Event struct. Learn more at https://docs.botkube.io/filters

--- a/pkg/execute/kubectl.go
+++ b/pkg/execute/kubectl.go
@@ -23,10 +23,10 @@ const (
 
 const (
 	kubectlNotAuthorizedMsgFmt         = "Sorry, this channel is not authorized to execute kubectl command on cluster '%s'."
-	kubectlNotAllowedVerbMsgFmt        = "Sorry, the kubectl '%s' command cannot be executed in the '%s' Namespace on cluster '%s'. Use 'list commands' to see allowed commands."
-	kubectlNotAllowedVerbInAllNsMsgFmt = "Sorry, the kubectl '%s' command cannot be executed for all Namespaces on cluster '%s'. Use 'list commands' to see allowed commands."
-	kubectlNotAllowedKindMsgFmt        = "Sorry, the kubectl command is not authorized to work with '%s' resources in the '%s' Namespace on cluster '%s'. Use 'list commands' to see allowed commands."
-	kubectlNotAllowedKinInAllNsMsgFmt  = "Sorry, the kubectl command is not authorized to work with '%s' resources for all Namespaces on cluster '%s'. Use 'list commands' to see allowed commands."
+	kubectlNotAllowedVerbMsgFmt        = "Sorry, the kubectl '%s' command cannot be executed in the '%s' Namespace on cluster '%s'. Use 'list executors' to see allowed executors."
+	kubectlNotAllowedVerbInAllNsMsgFmt = "Sorry, the kubectl '%s' command cannot be executed for all Namespaces on cluster '%s'. Use 'list executors' to see allowed executors."
+	kubectlNotAllowedKindMsgFmt        = "Sorry, the kubectl command is not authorized to work with '%s' resources in the '%s' Namespace on cluster '%s'. Use 'list executors' to see allowed executors."
+	kubectlNotAllowedKinInAllNsMsgFmt  = "Sorry, the kubectl command is not authorized to work with '%s' resources for all Namespaces on cluster '%s'. Use 'list executors' to see allowed executors."
 	kubectlFlagAfterVerbMsg            = "Please specify the resource name after the verb, and all flags after the resource name. Format <verb> <resource> [flags]"
 	kubectlDefaultNamespace            = "default"
 )

--- a/pkg/execute/kubectl_test.go
+++ b/pkg/execute/kubectl_test.go
@@ -57,7 +57,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 					Resources: nil,
 				},
 			},
-			expErr: "Sorry, the kubectl command is not authorized to work with 'pod' resources in the 'foo' Namespace on cluster 'test'. Use 'list commands' to see allowed commands.",
+			expErr: "Sorry, the kubectl command is not authorized to work with 'pod' resources in the 'foo' Namespace on cluster 'test'. Use 'list executors' to see allowed executors.",
 		},
 		{
 			name: "Should forbid execution if namespace is not allowed in config",
@@ -74,7 +74,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 				},
 			},
 
-			expErr: "Sorry, the kubectl 'get' command cannot be executed in the 'default' Namespace on cluster 'test'. Use 'list commands' to see allowed commands.",
+			expErr: "Sorry, the kubectl 'get' command cannot be executed in the 'default' Namespace on cluster 'test'. Use 'list executors' to see allowed executors.",
 		},
 		{
 			name: "Should use default Namespace from config if not specified in command",
@@ -92,7 +92,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 				},
 			},
 
-			expErr: "Sorry, the kubectl 'get' command cannot be executed in the 'from-config' Namespace on cluster 'test'. Use 'list commands' to see allowed commands.",
+			expErr: "Sorry, the kubectl 'get' command cannot be executed in the 'from-config' Namespace on cluster 'test'. Use 'list executors' to see allowed executors.",
 		},
 		{
 			name: "Should explicitly use 'default' Namespace if not specified both in command and config",
@@ -109,7 +109,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 				},
 			},
 
-			expErr: "Sorry, the kubectl 'get' command cannot be executed in the 'default' Namespace on cluster 'test'. Use 'list commands' to see allowed commands.",
+			expErr: "Sorry, the kubectl 'get' command cannot be executed in the 'default' Namespace on cluster 'test'. Use 'list executors' to see allowed executors.",
 		},
 		{
 			name: "Should forbid execution in not allowed namespace",
@@ -126,7 +126,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 				},
 			},
 
-			expErr: "Sorry, the kubectl 'get' command cannot be executed in the 'team-b' Namespace on cluster 'test'. Use 'list commands' to see allowed commands.",
+			expErr: "Sorry, the kubectl 'get' command cannot be executed in the 'team-b' Namespace on cluster 'test'. Use 'list executors' to see allowed executors.",
 		},
 		{
 			name: "Should forbid execution if all namespace are allowed but command namespace is explicitly ignored in config",
@@ -144,7 +144,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 				},
 			},
 
-			expErr: "Sorry, the kubectl 'get' command cannot be executed in the 'team-b' Namespace on cluster 'test'. Use 'list commands' to see allowed commands.",
+			expErr: "Sorry, the kubectl 'get' command cannot be executed in the 'team-b' Namespace on cluster 'test'. Use 'list executors' to see allowed executors.",
 		},
 		{
 			name: "Should forbid execution for all Namespaces",
@@ -161,7 +161,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 				},
 			},
 
-			expErr: "Sorry, the kubectl 'get' command cannot be executed for all Namespaces on cluster 'test'. Use 'list commands' to see allowed commands.",
+			expErr: "Sorry, the kubectl 'get' command cannot be executed for all Namespaces on cluster 'test'. Use 'list executors' to see allowed executors.",
 		},
 		{
 			name: "Known limitation (since v0.12.4): Return error if flag is added before resource name",

--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -437,7 +437,7 @@ func runBotTest(t *testing.T,
 
 		t.Run("Get forbidden resource", func(t *testing.T) {
 			command := "get role"
-			expectedBody := codeBlock(fmt.Sprintf("Sorry, the kubectl command is not authorized to work with 'role' resources in the 'default' Namespace on cluster '%s'. Use 'list commands' to see allowed commands.", appCfg.ClusterName))
+			expectedBody := codeBlock(fmt.Sprintf("Sorry, the kubectl command is not authorized to work with 'role' resources in the 'default' Namespace on cluster '%s'. Use 'list executors' to see allowed executors.", appCfg.ClusterName))
 			expectedMessage := fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
 
 			botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)
@@ -467,7 +467,7 @@ func runBotTest(t *testing.T,
 
 		t.Run("Specify forbidden namespace", func(t *testing.T) {
 			command := "get po --namespace team-b"
-			expectedBody := codeBlock(fmt.Sprintf("Sorry, the kubectl command is not authorized to work with 'po' resources in the 'team-b' Namespace on cluster '%s'. Use 'list commands' to see allowed commands.", appCfg.ClusterName))
+			expectedBody := codeBlock(fmt.Sprintf("Sorry, the kubectl command is not authorized to work with 'po' resources in the 'team-b' Namespace on cluster '%s'. Use 'list executors' to see allowed executors.", appCfg.ClusterName))
 			expectedMessage := fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
 
 			botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)
@@ -500,7 +500,7 @@ func runBotTest(t *testing.T,
 
 			t.Run("Get all Pods (the 4th binding)", func(t *testing.T) {
 				command := "get pods -A"
-				expectedBody := codeBlock(fmt.Sprintf("Sorry, the kubectl command is not authorized to work with 'pods' resources for all Namespaces on cluster '%s'. Use 'list commands' to see allowed commands.", appCfg.ClusterName))
+				expectedBody := codeBlock(fmt.Sprintf("Sorry, the kubectl command is not authorized to work with 'pods' resources for all Namespaces on cluster '%s'. Use 'list executors' to see allowed executors.", appCfg.ClusterName))
 				expectedMessage := fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
 
 				botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Replace removed 'list commands'
- Print multi-cluster info only for supported platforms

Here is the updated Slack help message:
   ![Screenshot 2023-01-04 at 11 38 32](https://user-images.githubusercontent.com/17568639/210537278-abfb13b0-3e13-4d99-9f86-86cf9947faa7.png)

## Related issue(s)

Fix https://github.com/kubeshop/botkube/issues/891
