### PR TITLE
Remove support for running kubectl command without prefix

### DIFF
--- a/pkg/bot/discord.go
+++ b/pkg/bot/discord.go
@@ -291,7 +291,7 @@ func (b *Discord) send(channelID string, resp interactive.Message) error {
 	markdown := interactive.RenderMessage(b.mdFormatter, resp)
 
 	if len(markdown) == 0 {
-		return errors.New("while reading Slack response: empty response")
+		return errors.New("while reading Discord response: empty response")
 	}
 
 	// Upload message as a file if too long

--- a/pkg/bot/interactive/help.go
+++ b/pkg/bot/interactive/help.go
@@ -193,7 +193,7 @@ func (h *HelpMessage) configSections() []Section {
 
 func (h *HelpMessage) kubectlSections() []Section {
 	// TODO(https://github.com/kubeshop/botkube/issues/802): remove this warning in after releasing 0.17.
-	warn := ":warning: Botkube 0.17 and above will require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.\n\ne.g. `@Botkube k get pods` instead of `@Botkube get pods`\n"
+	warn := ":warning: Botkube 0.17 and above require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.\n\ne.g. `@Botkube k get pods` instead of `@Botkube get pods`\n"
 
 	if h.platform == config.SocketSlackCommPlatformIntegration {
 		return []Section{

--- a/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_headers_and_default_new_lines.golden.txt
+++ b/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_headers_and_default_new_lines.golden.txt
@@ -29,7 +29,7 @@ By default, Botkube will notify only about cluster errors and recommendations.
   - `@Botkube config`
 
 *Run kubectl commands (if enabled)*
-:warning: Botkube 0.17 and above will require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.
+:warning: Botkube 0.17 and above require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.
 
 e.g. `@Botkube k get pods` instead of `@Botkube get pods`
 

--- a/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_new_lines_and_default_headers.golden.txt
+++ b/pkg/bot/interactive/testdata/TestInteractiveMessageToMarkdown/render_with_custom_new_lines_and_default_headers.golden.txt
@@ -4,7 +4,7 @@ Botkube is now active for "testing" cluster :rocket:<br><br>**Ping your cluster*
 @Botkube [list|enable|disable] action [action name]
 ```<br>  - `@Botkube list actions`<br><br>**View current Botkube configuration**<br>```
 @Botkube config
-```<br>  - `@Botkube config`<br><br>**Run kubectl commands (if enabled)**<br>:warning: Botkube 0.17 and above will require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.
+```<br>  - `@Botkube config`<br><br>**Run kubectl commands (if enabled)**<br>:warning: Botkube 0.17 and above require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.
 
 e.g. `@Botkube k get pods` instead of `@Botkube get pods`
 

--- a/pkg/bot/interactive/testdata/TestInteractiveMessageToPlaintext.golden.txt
+++ b/pkg/bot/interactive/testdata/TestInteractiveMessageToPlaintext.golden.txt
@@ -25,7 +25,7 @@ View current Botkube configuration
   - @Botkube config
 
 Run kubectl commands (if enabled)
-:warning: Botkube 0.17 and above will require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.
+:warning: Botkube 0.17 and above require a prefix (`k`, `kc`, `kubectl`) when running kubectl commands through the bot.
 
 e.g. `@Botkube k get pods` instead of `@Botkube get pods`
 

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -130,7 +130,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.Message {
 		return empty // user specified different target cluster
 	}
 
-	if e.kubectlExecutor.CanHandle(e.conversation.ExecutorBindings, cmdCtx.Args) {
+	if e.kubectlExecutor.CanHandle(cmdCtx.Args) {
 		e.reportCommand(e.kubectlExecutor.GetCommandPrefix(cmdCtx.Args), cmdCtx.ExecutorFilter.IsActive())
 		out, err := e.kubectlExecutor.Execute(e.conversation.ExecutorBindings, cmdCtx.CleanCmd, e.conversation.IsAuthenticated, cmdCtx)
 		switch {

--- a/pkg/execute/kubectl/checker.go
+++ b/pkg/execute/kubectl/checker.go
@@ -43,9 +43,3 @@ func (c *Checker) IsVerbAllowedInNs(config EnabledKubectl, verb string) bool {
 	_, found := config.AllowedKubectlVerb[verb]
 	return found
 }
-
-// IsKnownVerb returns true if verb was found in a given map.
-func (c *Checker) IsKnownVerb(allVerbs map[string]struct{}, verb string) bool {
-	_, found := allVerbs[verb]
-	return found
-}

--- a/pkg/execute/kubectl/merger.go
+++ b/pkg/execute/kubectl/merger.go
@@ -49,31 +49,6 @@ func (kc *Merger) MergeAllEnabled(includeBindings []string) EnabledKubectl {
 	return kc.merge(kc.GetAllEnabled(includeBindings), includeBindings)
 }
 
-// MergeAllEnabledVerbs returns verbs collected from all enabled kubectl executors.
-func (kc *Merger) MergeAllEnabledVerbs(bindings []string) map[string]struct{} {
-	if kc.executors == nil {
-		return nil
-	}
-
-	verbs := map[string]struct{}{}
-
-	for _, name := range bindings {
-		executor, found := kc.executors[name]
-		if !found {
-			continue
-		}
-
-		if !executor.Kubectl.Enabled {
-			continue
-		}
-
-		for _, name := range executor.Kubectl.Commands.Verbs {
-			verbs[name] = struct{}{}
-		}
-	}
-	return verbs
-}
-
 // GetAllEnabled returns the collection of enabled kubectl executors for a given list of bindings without merging them.
 func (kc *Merger) GetAllEnabled(includeBindings []string) map[string]config.Kubectl {
 	onlyEnabled := func(executor config.Kubectl) bool {

--- a/pkg/execute/kubectl_test.go
+++ b/pkg/execute/kubectl_test.go
@@ -27,7 +27,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 		{
 			name: "Should forbid execution from not authorized channel when restrictions are enabled",
 
-			command:              "get pod --cluster-name test",
+			command:              "kc get pod --cluster-name test",
 			clusterName:          "test",
 			channelNotAuthorized: true,
 			kubectlCfg: config.Kubectl{
@@ -46,7 +46,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 		{
 			name: "Should forbid execution if resource is not allowed in config",
 
-			command: "get pod -n foo",
+			command: "kc get pod -n foo",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -62,7 +62,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 		{
 			name: "Should forbid execution if namespace is not allowed in config",
 
-			command: "get pod",
+			command: "kc get pod",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -79,7 +79,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 		{
 			name: "Should use default Namespace from config if not specified in command",
 
-			command: "get pod",
+			command: "kc get pod",
 			kubectlCfg: config.Kubectl{
 				Enabled:          true,
 				DefaultNamespace: "from-config",
@@ -97,7 +97,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 		{
 			name: "Should explicitly use 'default' Namespace if not specified both in command and config",
 
-			command: "get pod",
+			command: "k get pod",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -114,7 +114,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 		{
 			name: "Should forbid execution in not allowed namespace",
 
-			command: "get pod -n team-b",
+			command: "kubectl get pod -n team-b",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -131,7 +131,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 		{
 			name: "Should forbid execution if all namespace are allowed but command namespace is explicitly ignored in config",
 
-			command: "get pod -n team-b",
+			command: "kubectl get pod -n team-b",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -149,7 +149,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 		{
 			name: "Should forbid execution for all Namespaces",
 
-			command: "get pod -A",
+			command: "kc get pod -A",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -166,7 +166,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 		{
 			name: "Known limitation (since v0.12.4): Return error if flag is added before resource name",
 
-			command: "get -n team-a pod",
+			command: "kc get -n team-a pod",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -197,7 +197,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 			}))
 
 			// when
-			canHandle := executor.CanHandle(fixBindingsNames, strings.Fields(strings.TrimSpace(tc.command)))
+			canHandle := executor.CanHandle(strings.Fields(strings.TrimSpace(tc.command)))
 			gotOutMsg, err := executor.Execute(fixBindingsNames, tc.command, !tc.channelNotAuthorized, CommandContext{ProvidedClusterName: tc.clusterName, ClusterName: tc.clusterName})
 
 			// then
@@ -222,7 +222,7 @@ func TestKubectlExecute(t *testing.T) {
 		{
 			name: "Should all execution if resource is missing, so kubectl can validate it further",
 
-			command: "get",
+			command: "kc get",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -238,7 +238,7 @@ func TestKubectlExecute(t *testing.T) {
 		{
 			name: "Should allow execution if verb, resource, and all namespaces are allowed",
 
-			command: "get pod",
+			command: "kc get pod",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -255,7 +255,7 @@ func TestKubectlExecute(t *testing.T) {
 		{
 			name: "Should allow execution if verb, resource, and a given namespace are allowed",
 
-			command: "get pod -n team-a",
+			command: "kc get pod -n team-a",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -272,7 +272,7 @@ func TestKubectlExecute(t *testing.T) {
 		{
 			name: "Should allow execution from not authorized channel if restrictions are disabled",
 
-			command:              "get pod -n team-a",
+			command:              "kc get pod -n team-a",
 			channelNotAuthorized: true,
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
@@ -290,7 +290,7 @@ func TestKubectlExecute(t *testing.T) {
 		{
 			name: "Should allow execution from not authorized channel if restrictions are disabled",
 
-			command:              "get pod/name-foo-42 -n team-a",
+			command:              "kc get pod/name-foo-42 -n team-a",
 			channelNotAuthorized: true,
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
@@ -308,7 +308,7 @@ func TestKubectlExecute(t *testing.T) {
 		{
 			name: "Should allow execution for all Namespaces",
 
-			command: "get pod/name-foo-42 -n team-a",
+			command: "kc get pod/name-foo-42 -n team-a",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -325,7 +325,7 @@ func TestKubectlExecute(t *testing.T) {
 		{
 			name: "Should all execution for all Namespaces",
 
-			command: "get pod -A",
+			command: "kc get pod -A",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -355,7 +355,7 @@ func TestKubectlExecute(t *testing.T) {
 			}))
 
 			// when
-			canHandle := executor.CanHandle(fixBindingsNames, strings.Fields(strings.TrimSpace(tc.command)))
+			canHandle := executor.CanHandle(strings.Fields(strings.TrimSpace(tc.command)))
 			gotOutMsg, err := executor.Execute(fixBindingsNames, tc.command, !tc.channelNotAuthorized, CommandContext{})
 
 			// then
@@ -377,7 +377,7 @@ func TestKubectlCanHandle(t *testing.T) {
 	}{
 		{
 			name:    "Should allow for known verb",
-			command: "get pod --cluster-name test",
+			command: "kc get pod --cluster-name test",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
 				Namespaces: config.Namespaces{
@@ -407,22 +407,6 @@ func TestKubectlCanHandle(t *testing.T) {
 
 			expCanHandle: true,
 		},
-		{
-			name:    "Should forbid if verbs is unknown",
-			command: "get pod --cluster-name test",
-			kubectlCfg: config.Kubectl{
-				Enabled: true,
-				Namespaces: config.Namespaces{
-					Include: []string{"team-a"},
-				},
-				Commands: config.Commands{
-					Verbs:     []string{"describe"},
-					Resources: []string{"pod"},
-				},
-			},
-
-			expCanHandle: false,
-		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -434,63 +418,10 @@ func TestKubectlCanHandle(t *testing.T) {
 			executor := NewKubectl(loggerx.NewNoop(), config.Config{}, merger, kcChecker, nil)
 
 			// when
-			canHandle := executor.CanHandle(fixBindingsNames, strings.Fields(strings.TrimSpace(tc.command)))
+			canHandle := executor.CanHandle(strings.Fields(strings.TrimSpace(tc.command)))
 
 			// then
 			assert.Equal(t, tc.expCanHandle, canHandle)
-		})
-	}
-}
-
-func TestKubectlGetVerb(t *testing.T) {
-	tests := []struct {
-		name         string
-		command      string
-		expectedVerb string
-	}{
-		{
-			name:         "Should get proper verb without k8s prefix",
-			command:      "get pods --cluster-name test",
-			expectedVerb: "get",
-		},
-		{
-			name:         "Should get proper verb with k8s prefix kubectl",
-			command:      "kubectl get pods --cluster-name test",
-			expectedVerb: "get",
-		},
-		{
-			name:         "Should get proper verb with k8s prefix kc",
-			command:      "kc get pods --cluster-name test",
-			expectedVerb: "get",
-		},
-		{
-			name:         "Should get proper verb with k8s prefix k",
-			command:      "k get pods --cluster-name test",
-			expectedVerb: "get",
-		},
-	}
-	kubectlCfg := config.Kubectl{
-		Enabled: true,
-		Namespaces: config.Namespaces{
-			Include: []string{"team-a"},
-		},
-		Commands: config.Commands{
-			Verbs:     []string{"get"},
-			Resources: []string{"pod"},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := fixCfgWithKubectlExecutor(t, kubectlCfg)
-			merger := kubectl.NewMerger(cfg.Executors)
-			kcChecker := kubectl.NewChecker(nil)
-			executor := NewKubectl(loggerx.NewNoop(), config.Config{}, merger, kcChecker, nil)
-
-			args := strings.Fields(tc.command)
-			verb := executor.GetVerb(args)
-
-			assert.Equal(t, tc.expectedVerb, verb)
 		})
 	}
 }
@@ -501,11 +432,6 @@ func TestKubectlGetCommandPrefix(t *testing.T) {
 		command  string
 		expected string
 	}{
-		{
-			name:     "Should get proper command without k8s prefix",
-			command:  "get pods --cluster-name test",
-			expected: "get",
-		},
 		{
 			name:     "Should get proper command with k8s prefix kubectl",
 			command:  "kubectl get pods --cluster-name test",
@@ -554,11 +480,6 @@ func TestKubectlGetArgsWithoutAlias(t *testing.T) {
 		command  string
 		expected string
 	}{
-		{
-			name:     "Should get proper command without k8s prefix",
-			command:  "get pods --cluster-name test",
-			expected: "get pods --cluster-name test",
-		},
 		{
 			name:     "Should get proper command with k8s prefix kubectl",
 			command:  "kubectl get pods --cluster-name test",


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Remove support for running kubectl command without prefix

Related doc change: https://github.com/kubeshop/botkube-docs/pull/190

## Related issue(s)

Fix https://github.com/kubeshop/botkube/issues/802