### PR TITLE
Add health endpoints

### DIFF
--- a/cmd/botkube/main.go
+++ b/cmd/botkube/main.go
@@ -141,7 +141,7 @@ func run() error {
 	}
 
 	// Prometheus metrics & health endpoint
-	metricsSrv := newDiagnosticServer(logger.WithField(componentLogFieldKey, "Diagnostics (metrics&health) server"), conf.Settings.MetricsPort)
+	metricsSrv := newDiagnosticServer(logger.WithField(componentLogFieldKey, "Diagnostics (metrics&health) server"), conf.Settings.DiagnosticsPort)
 	errGroup.Go(func() error {
 		defer analytics.ReportPanicIfOccurs(logger, reporter)
 		return metricsSrv.Serve(ctx)

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -153,47 +153,48 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [communications.default-group.webhook.bindings.sources](./values.yaml#L620) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for the webhook. |
 | [settings.clusterName](./values.yaml#L627) | string | `"not-configured"` | Cluster name to differentiate incoming messages. |
 | [settings.lifecycleServer](./values.yaml#L630) | object | `{"enabled":true,"port":2113}` | Server configuration which exposes functionality related to the app lifecycle. |
-| [settings.upgradeNotifier](./values.yaml#L634) | bool | `true` | If true, notifies about new Botkube releases. |
-| [settings.log.level](./values.yaml#L638) | string | `"info"` | Sets one of the log levels. Allowed values: `info`, `warn`, `debug`, `error`, `fatal`, `panic`. |
-| [settings.log.disableColors](./values.yaml#L640) | bool | `false` | If true, disable ANSI colors in logging. |
-| [settings.systemConfigMap](./values.yaml#L643) | object | `{"name":"botkube-system"}` | Botkube's system ConfigMap where internal data is stored. |
-| [settings.persistentConfig](./values.yaml#L648) | object | `{"runtime":{"configMap":{"annotations":{},"name":"botkube-runtime-config"},"fileName":"_runtime_state.yaml"},"startup":{"configMap":{"annotations":{},"name":"botkube-startup-config"},"fileName":"_startup_state.yaml"}}` | Persistent config contains ConfigMap where persisted configuration is stored. The persistent configuration is evaluated from both chart upgrade and Botkube commands used in runtime. |
-| [ssl.enabled](./values.yaml#L663) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
-| [ssl.existingSecretName](./values.yaml#L669) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
-| [ssl.cert](./values.yaml#L672) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
-| [service](./values.yaml#L675) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
-| [ingress](./values.yaml#L682) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
-| [serviceMonitor](./values.yaml#L693) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
-| [deployment.annotations](./values.yaml#L703) | object | `{}` | Extra annotations to pass to the Botkube Deployment. |
-| [extraAnnotations](./values.yaml#L710) | object | `{}` | Extra annotations to pass to the Botkube Pod. |
-| [extraLabels](./values.yaml#L712) | object | `{}` | Extra labels to pass to the Botkube Pod. |
-| [priorityClassName](./values.yaml#L714) | string | `""` | Priority class name for the Botkube Pod. |
-| [nameOverride](./values.yaml#L717) | string | `""` | Fully override "botkube.name" template. |
-| [fullnameOverride](./values.yaml#L719) | string | `""` | Fully override "botkube.fullname" template. |
-| [resources](./values.yaml#L725) | object | `{}` | The Botkube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
-| [extraEnv](./values.yaml#L737) | list | `[]` | Extra environment variables to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
-| [extraVolumes](./values.yaml#L749) | list | `[]` | Extra volumes to pass to the Botkube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
-| [extraVolumeMounts](./values.yaml#L764) | list | `[]` | Extra volume mounts to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
-| [nodeSelector](./values.yaml#L782) | object | `{}` | Node labels for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
-| [tolerations](./values.yaml#L786) | list | `[]` | Tolerations for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
-| [affinity](./values.yaml#L790) | object | `{}` | Affinity for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
-| [rbac](./values.yaml#L794) | object | `{"create":true,"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["get","watch","list"]}]}` | Role Based Access for Botkube Pod. [Ref doc](https://kubernetes.io/docs/admin/authorization/rbac/). |
-| [serviceAccount.create](./values.yaml#L803) | bool | `true` | If true, a ServiceAccount is automatically created. |
-| [serviceAccount.name](./values.yaml#L806) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
-| [serviceAccount.annotations](./values.yaml#L808) | object | `{}` | Extra annotations for the ServiceAccount. |
-| [extraObjects](./values.yaml#L811) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
-| [analytics.disable](./values.yaml#L839) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://docs.botkube.io/privacy#privacy-policy). |
-| [configWatcher.enabled](./values.yaml#L844) | bool | `true` | If true, restarts the Botkube Pod on config changes. |
-| [configWatcher.tmpDir](./values.yaml#L846) | string | `"/tmp/watched-cfg/"` | Directory, where watched configuration resources are stored. |
-| [configWatcher.initialSyncTimeout](./values.yaml#L849) | int | `0` | Timeout for the initial Config Watcher sync. If set to 0, waiting for Config Watcher sync will be skipped. In a result, configuration changes may not reload Botkube app during the first few seconds after Botkube startup. |
-| [configWatcher.image.registry](./values.yaml#L852) | string | `"ghcr.io"` | Config watcher image registry. |
-| [configWatcher.image.repository](./values.yaml#L854) | string | `"kubeshop/k8s-sidecar"` | Config watcher image repository. |
-| [configWatcher.image.tag](./values.yaml#L856) | string | `"ignore-initial-events"` | Config watcher image tag. |
-| [configWatcher.image.pullPolicy](./values.yaml#L858) | string | `"IfNotPresent"` | Config watcher image pull policy. |
-| [plugins](./values.yaml#L861) | object | `{"cacheDir":"/tmp","repositories":{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}}` | Configuration for Botkube executors and sources plugins. |
-| [plugins.cacheDir](./values.yaml#L863) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
-| [plugins.repositories](./values.yaml#L865) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}` | List of plugins repositories. |
-| [plugins.repositories.botkube](./values.yaml#L867) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
+| [settings.healthPort](./values.yaml#L633) | int | `2114` |  |
+| [settings.upgradeNotifier](./values.yaml#L635) | bool | `true` | If true, notifies about new Botkube releases. |
+| [settings.log.level](./values.yaml#L639) | string | `"info"` | Sets one of the log levels. Allowed values: `info`, `warn`, `debug`, `error`, `fatal`, `panic`. |
+| [settings.log.disableColors](./values.yaml#L641) | bool | `false` | If true, disable ANSI colors in logging. |
+| [settings.systemConfigMap](./values.yaml#L644) | object | `{"name":"botkube-system"}` | Botkube's system ConfigMap where internal data is stored. |
+| [settings.persistentConfig](./values.yaml#L649) | object | `{"runtime":{"configMap":{"annotations":{},"name":"botkube-runtime-config"},"fileName":"_runtime_state.yaml"},"startup":{"configMap":{"annotations":{},"name":"botkube-startup-config"},"fileName":"_startup_state.yaml"}}` | Persistent config contains ConfigMap where persisted configuration is stored. The persistent configuration is evaluated from both chart upgrade and Botkube commands used in runtime. |
+| [ssl.enabled](./values.yaml#L664) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
+| [ssl.existingSecretName](./values.yaml#L670) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
+| [ssl.cert](./values.yaml#L673) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
+| [service](./values.yaml#L676) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
+| [ingress](./values.yaml#L683) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
+| [serviceMonitor](./values.yaml#L694) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
+| [deployment.annotations](./values.yaml#L704) | object | `{}` | Extra annotations to pass to the Botkube Deployment. |
+| [extraAnnotations](./values.yaml#L711) | object | `{}` | Extra annotations to pass to the Botkube Pod. |
+| [extraLabels](./values.yaml#L713) | object | `{}` | Extra labels to pass to the Botkube Pod. |
+| [priorityClassName](./values.yaml#L715) | string | `""` | Priority class name for the Botkube Pod. |
+| [nameOverride](./values.yaml#L718) | string | `""` | Fully override "botkube.name" template. |
+| [fullnameOverride](./values.yaml#L720) | string | `""` | Fully override "botkube.fullname" template. |
+| [resources](./values.yaml#L726) | object | `{}` | The Botkube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
+| [extraEnv](./values.yaml#L738) | list | `[]` | Extra environment variables to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
+| [extraVolumes](./values.yaml#L750) | list | `[]` | Extra volumes to pass to the Botkube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
+| [extraVolumeMounts](./values.yaml#L765) | list | `[]` | Extra volume mounts to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
+| [nodeSelector](./values.yaml#L783) | object | `{}` | Node labels for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
+| [tolerations](./values.yaml#L787) | list | `[]` | Tolerations for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
+| [affinity](./values.yaml#L791) | object | `{}` | Affinity for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
+| [rbac](./values.yaml#L795) | object | `{"create":true,"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["get","watch","list"]}]}` | Role Based Access for Botkube Pod. [Ref doc](https://kubernetes.io/docs/admin/authorization/rbac/). |
+| [serviceAccount.create](./values.yaml#L804) | bool | `true` | If true, a ServiceAccount is automatically created. |
+| [serviceAccount.name](./values.yaml#L807) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
+| [serviceAccount.annotations](./values.yaml#L809) | object | `{}` | Extra annotations for the ServiceAccount. |
+| [extraObjects](./values.yaml#L812) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
+| [analytics.disable](./values.yaml#L840) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://docs.botkube.io/privacy#privacy-policy). |
+| [configWatcher.enabled](./values.yaml#L845) | bool | `true` | If true, restarts the Botkube Pod on config changes. |
+| [configWatcher.tmpDir](./values.yaml#L847) | string | `"/tmp/watched-cfg/"` | Directory, where watched configuration resources are stored. |
+| [configWatcher.initialSyncTimeout](./values.yaml#L850) | int | `0` | Timeout for the initial Config Watcher sync. If set to 0, waiting for Config Watcher sync will be skipped. In a result, configuration changes may not reload Botkube app during the first few seconds after Botkube startup. |
+| [configWatcher.image.registry](./values.yaml#L853) | string | `"ghcr.io"` | Config watcher image registry. |
+| [configWatcher.image.repository](./values.yaml#L855) | string | `"kubeshop/k8s-sidecar"` | Config watcher image repository. |
+| [configWatcher.image.tag](./values.yaml#L857) | string | `"ignore-initial-events"` | Config watcher image tag. |
+| [configWatcher.image.pullPolicy](./values.yaml#L859) | string | `"IfNotPresent"` | Config watcher image pull policy. |
+| [plugins](./values.yaml#L862) | object | `{"cacheDir":"/tmp","repositories":{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}}` | Configuration for Botkube executors and sources plugins. |
+| [plugins.cacheDir](./values.yaml#L864) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
+| [plugins.repositories](./values.yaml#L866) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}` | List of plugins repositories. |
+| [plugins.repositories.botkube](./values.yaml#L868) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
           env:
             - name: BOTKUBE_CONFIG_PATHS
               value: "/config/global_config.yaml,/config/comm_config.yaml,/config/{{ .Values.settings.persistentConfig.runtime.fileName}},/startup-config/{{ .Values.settings.persistentConfig.startup.fileName}}"
-            - name: BOTKUBE_SETTINGS_METRICS__PORT
+            - name: BOTKUBE_SETTINGS_DIAGNOSTICS__PORT
               value: {{ .Values.service.targetPort | quote }}
             {{- if .Values.kubeconfig.enabled }}
             - name: BOTKUBE_SETTINGS_KUBECONFIG

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             timeoutSeconds: 1
             httpGet:
               path: /healthz
-              port: {{ .Values.service.targetPort }}
+              port: {{ .Values.settings.healthPort }}
           livenessProbe:
             successThreshold: 1
             failureThreshold: 3
@@ -70,7 +70,7 @@ spec:
             timeoutSeconds: 1
             httpGet:
               path: /healthz
-              port: {{ .Values.service.targetPort }}
+              port: {{ .Values.settings.healthPort }}
           volumeMounts:
             - name: cache-volume
               mountPath: /tmp
@@ -97,7 +97,7 @@ spec:
           env:
             - name: BOTKUBE_CONFIG_PATHS
               value: "/config/global_config.yaml,/config/comm_config.yaml,/config/{{ .Values.settings.persistentConfig.runtime.fileName}},/startup-config/{{ .Values.settings.persistentConfig.startup.fileName}}"
-            - name: BOTKUBE_SETTINGS_DIAGNOSTICS__PORT
+            - name: BOTKUBE_SETTINGS_METRICS__PORT
               value: {{ .Values.service.targetPort | quote }}
             {{- if .Values.kubeconfig.enabled }}
             - name: BOTKUBE_SETTINGS_KUBECONFIG

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -53,6 +53,24 @@ spec:
           securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{ end }}
+          readinessProbe:
+            successThreshold: 1
+            failureThreshold: 3
+            periodSeconds: 5
+            initialDelaySeconds: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.targetPort }}
+          livenessProbe:
+            successThreshold: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            initialDelaySeconds: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.targetPort }}
           volumeMounts:
             - name: cache-volume
               mountPath: /tmp

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -630,6 +630,7 @@ settings:
   lifecycleServer:
     enabled: true
     port: 2113
+  healthPort: 2114
   # -- If true, notifies about new Botkube releases.
   upgradeNotifier: true
   ## Botkube logging settings.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -575,7 +575,8 @@ type Settings struct {
 	UpgradeNotifier       bool             `yaml:"upgradeNotifier"`
 	SystemConfigMap       K8sResourceRef   `yaml:"systemConfigMap"`
 	PersistentConfig      PersistentConfig `yaml:"persistentConfig"`
-	DiagnosticsPort       string           `yaml:"diagnosticsPort"`
+	MetricsPort           string           `yaml:"metricsPort"`
+	HealthPort            string           `yaml:"healthPort"`
 	LifecycleServer       LifecycleServer  `yaml:"lifecycleServer"`
 	Log                   loggerx.Config   `yaml:"log"`
 	InformersResyncPeriod time.Duration    `yaml:"informersResyncPeriod"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -575,7 +575,7 @@ type Settings struct {
 	UpgradeNotifier       bool             `yaml:"upgradeNotifier"`
 	SystemConfigMap       K8sResourceRef   `yaml:"systemConfigMap"`
 	PersistentConfig      PersistentConfig `yaml:"persistentConfig"`
-	MetricsPort           string           `yaml:"metricsPort"`
+	DiagnosticsPort       string           `yaml:"diagnosticsPort"`
 	LifecycleServer       LifecycleServer  `yaml:"lifecycleServer"`
 	Log                   loggerx.Config   `yaml:"log"`
 	InformersResyncPeriod time.Duration    `yaml:"informersResyncPeriod"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -576,6 +576,7 @@ type Settings struct {
 	SystemConfigMap       K8sResourceRef   `yaml:"systemConfigMap"`
 	PersistentConfig      PersistentConfig `yaml:"persistentConfig"`
 	MetricsPort           string           `yaml:"metricsPort"`
+	HealthPort            string           `yaml:"healthPort"`
 	LifecycleServer       LifecycleServer  `yaml:"lifecycleServer"`
 	Log                   loggerx.Config   `yaml:"log"`
 	InformersResyncPeriod time.Duration    `yaml:"informersResyncPeriod"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -576,7 +576,6 @@ type Settings struct {
 	SystemConfigMap       K8sResourceRef   `yaml:"systemConfigMap"`
 	PersistentConfig      PersistentConfig `yaml:"persistentConfig"`
 	MetricsPort           string           `yaml:"metricsPort"`
-	HealthPort            string           `yaml:"healthPort"`
 	LifecycleServer       LifecycleServer  `yaml:"lifecycleServer"`
 	Log                   loggerx.Config   `yaml:"log"`
 	InformersResyncPeriod time.Duration    `yaml:"informersResyncPeriod"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,7 +26,6 @@ func TestLoadConfigSuccess(t *testing.T) {
 	t.Setenv("BOTKUBE_SETTINGS_CLUSTER__NAME", "cluster-name-from-env")
 	t.Setenv("BOTKUBE_SETTINGS_KUBECONFIG", "kubeconfig-from-env")
 	t.Setenv("BOTKUBE_SETTINGS_METRICS__PORT", "1313")
-	t.Setenv("BOTKUBE_SETTINGS_HEALTH__PORT", "1414")
 	t.Setenv("BOTKUBE_PLUGINS_REPOSITORIES_BOTKUBE_URL", "http://localhost:3000/botkube.yaml")
 
 	// when

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -25,7 +25,8 @@ func TestLoadConfigSuccess(t *testing.T) {
 	t.Setenv("BOTKUBE_COMMUNICATIONS_DEFAULT-WORKSPACE_SOCKET__SLACK_APP__TOKEN", "xapp-token-from-env")
 	t.Setenv("BOTKUBE_SETTINGS_CLUSTER__NAME", "cluster-name-from-env")
 	t.Setenv("BOTKUBE_SETTINGS_KUBECONFIG", "kubeconfig-from-env")
-	t.Setenv("BOTKUBE_SETTINGS_DIAGNOSTICS__PORT", "1313")
+	t.Setenv("BOTKUBE_SETTINGS_METRICS__PORT", "1313")
+	t.Setenv("BOTKUBE_SETTINGS_HEALTH__PORT", "1314")
 	t.Setenv("BOTKUBE_PLUGINS_REPOSITORIES_BOTKUBE_URL", "http://localhost:3000/botkube.yaml")
 
 	// when
@@ -152,8 +153,8 @@ func TestNormalizeConfigEnvName(t *testing.T) {
 		},
 		{
 			name:            "env var with a camel key at the end",
-			givenEnvVarName: "BOTKUBE_SETTINGS_DIAGNOSTICS__PORT",
-			expYAMLKey:      "settings.diagnosticsPort",
+			givenEnvVarName: "BOTKUBE_SETTINGS_METRICS__PORT",
+			expYAMLKey:      "settings.metricsPort",
 		},
 		{
 			name:            "env var with two camel keys at the end",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,6 +26,7 @@ func TestLoadConfigSuccess(t *testing.T) {
 	t.Setenv("BOTKUBE_SETTINGS_CLUSTER__NAME", "cluster-name-from-env")
 	t.Setenv("BOTKUBE_SETTINGS_KUBECONFIG", "kubeconfig-from-env")
 	t.Setenv("BOTKUBE_SETTINGS_METRICS__PORT", "1313")
+	t.Setenv("BOTKUBE_SETTINGS_HEALTH__PORT", "1414")
 	t.Setenv("BOTKUBE_PLUGINS_REPOSITORIES_BOTKUBE_URL", "http://localhost:3000/botkube.yaml")
 
 	// when

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -25,7 +25,7 @@ func TestLoadConfigSuccess(t *testing.T) {
 	t.Setenv("BOTKUBE_COMMUNICATIONS_DEFAULT-WORKSPACE_SOCKET__SLACK_APP__TOKEN", "xapp-token-from-env")
 	t.Setenv("BOTKUBE_SETTINGS_CLUSTER__NAME", "cluster-name-from-env")
 	t.Setenv("BOTKUBE_SETTINGS_KUBECONFIG", "kubeconfig-from-env")
-	t.Setenv("BOTKUBE_SETTINGS_METRICS__PORT", "1313")
+	t.Setenv("BOTKUBE_SETTINGS_DIAGNOSTICS__PORT", "1313")
 	t.Setenv("BOTKUBE_PLUGINS_REPOSITORIES_BOTKUBE_URL", "http://localhost:3000/botkube.yaml")
 
 	// when
@@ -152,8 +152,8 @@ func TestNormalizeConfigEnvName(t *testing.T) {
 		},
 		{
 			name:            "env var with a camel key at the end",
-			givenEnvVarName: "BOTKUBE_SETTINGS_METRICS__PORT",
-			expYAMLKey:      "settings.metricsPort",
+			givenEnvVarName: "BOTKUBE_SETTINGS_DIAGNOSTICS__PORT",
+			expYAMLKey:      "settings.diagnosticsPort",
 		},
 		{
 			name:            "env var with two camel keys at the end",

--- a/pkg/config/default.yaml
+++ b/pkg/config/default.yaml
@@ -1,5 +1,6 @@
 settings:
-  diagnosticsPort: "2112"
+  metricsPort: "2112"
+  healthPort: "2114"
   log:
     level: "error"
     disableColors: "false"

--- a/pkg/config/default.yaml
+++ b/pkg/config/default.yaml
@@ -1,5 +1,5 @@
 settings:
-  metricsPort: "2112"
+  diagnosticsPort: "2112"
   log:
     level: "error"
     disableColors: "false"

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -444,7 +444,6 @@ settings:
             configMap:
                 name: runtime-config
     metricsPort: "1313"
-    healthPort: "1414"
     lifecycleServer:
         enabled: false
         port: 0

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -444,6 +444,7 @@ settings:
             configMap:
                 name: runtime-config
     metricsPort: "1313"
+    healthPort: "1414"
     lifecycleServer:
         enabled: false
         port: 0

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -443,7 +443,8 @@ settings:
             fileName: _runtime_state.yaml
             configMap:
                 name: runtime-config
-    diagnosticsPort: "1313"
+    metricsPort: "1313"
+    healthPort: "1314"
     lifecycleServer:
         enabled: false
         port: 0

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -443,7 +443,7 @@ settings:
             fileName: _runtime_state.yaml
             configMap:
                 name: runtime-config
-    metricsPort: "1313"
+    diagnosticsPort: "1313"
     lifecycleServer:
         enabled: false
         port: 0

--- a/pkg/execute/config_test.go
+++ b/pkg/execute/config_test.go
@@ -60,6 +60,7 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 						            fileName: ""
 						            configMap: {}
 						    metricsPort: ""
+						    healthPort: ""
 						    lifecycleServer:
 						        enabled: false
 						        port: 0

--- a/pkg/execute/config_test.go
+++ b/pkg/execute/config_test.go
@@ -59,7 +59,7 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 						        runtime:
 						            fileName: ""
 						            configMap: {}
-						    metricsPort: ""
+						    diagnosticsPort: ""
 						    lifecycleServer:
 						        enabled: false
 						        port: 0

--- a/pkg/execute/config_test.go
+++ b/pkg/execute/config_test.go
@@ -59,7 +59,8 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 						        runtime:
 						            fileName: ""
 						            configMap: {}
-						    diagnosticsPort: ""
+						    metricsPort: ""
+						    healthPort: ""
 						    lifecycleServer:
 						        enabled: false
 						        port: 0

--- a/pkg/execute/config_test.go
+++ b/pkg/execute/config_test.go
@@ -60,7 +60,6 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 						            fileName: ""
 						            configMap: {}
 						    metricsPort: ""
-						    healthPort: ""
 						    lifecycleServer:
 						        enabled: false
 						        port: 0


### PR DESCRIPTION
## Add health probes

New http server is started with two handlers: ready and live. Both endpoints right now always return `200 ok`.

## Related issue(s)

https://github.com/kubeshop/botkube/issues/881
https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#interpreted_hc
