### PR TITLE
Add default helm namespace, update helm help

### DIFF
--- a/internal/executor/helm/executor.go
+++ b/internal/executor/helm/executor.go
@@ -12,8 +12,9 @@ import (
 
 const (
 	// PluginName is the name of the Helm Botkube plugin.
-	PluginName     = "helm"
-	helmBinaryName = "helm"
+	PluginName       = "helm"
+	helmBinaryName   = "helm"
+	defaultNamespace = "default"
 )
 
 type command interface {
@@ -56,6 +57,8 @@ func (e *Executor) Metadata(context.Context) (api.MetadataOutput, error) {
 // - test
 // - rollback
 // - upgrade
+// - history
+// - get [all|manifest|hooks|notes]
 func (e *Executor) Execute(ctx context.Context, in executor.ExecuteInput) (executor.ExecuteOutput, error) {
 	cfg, err := MergeConfigs(in.Configs)
 	if err != nil {
@@ -72,6 +75,10 @@ func (e *Executor) Execute(ctx context.Context, in executor.ExecuteInput) (execu
 		wasHelpRequested = true
 	default:
 		return executor.ExecuteOutput{}, fmt.Errorf("while parsing input command: %w", err)
+	}
+
+	if helmCmd.Namespace == "" { // use 'default' namespace, instead of namespace where botkube was installed
+		args = append([]string{"-n", defaultNamespace}, args...)
 	}
 
 	switch {

--- a/internal/executor/helm/executor_test.go
+++ b/internal/executor/helm/executor_test.go
@@ -33,12 +33,12 @@ func TestExecutorHelmInstall(t *testing.T) {
 		{
 			name:         "install by chart reference and repo URL",
 			inputCommand: "helm install --repo https://example.com/charts/ mynginx nginx",
-			expCommand:   "install --repo https://example.com/charts/ mynginx nginx",
+			expCommand:   "-n default install --repo https://example.com/charts/ mynginx nginx",
 		},
 		{
 			name:         "install by chart reference and repo URL and with a given version",
 			inputCommand: "helm install --repo https://example.com/charts/ mynginx nginx --version 1.2.3",
-			expCommand:   "install --repo https://example.com/charts/ mynginx nginx --version 1.2.3",
+			expCommand:   "-n default install --repo https://example.com/charts/ mynginx nginx --version 1.2.3",
 		},
 	}
 	for _, tc := range tests {

--- a/internal/executor/helm/help.go
+++ b/internal/executor/helm/help.go
@@ -28,6 +28,8 @@ func (*HelpCommand) Help() string {
 		  uninstall   # Uninstalls a given release.
 		  upgrade     # Upgrades a given release.
 		  version     # Shows the version of the Helm CLI used by this Botkube plugin.
+		  history     # Shows release history
+		  get         # Shows extended information of a named release
 
 		Flags:
 		%s


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Add default helm namespace. By default, (when `-n/--namespace` is not provided) the Helm CLI used the namespace where Botkube was deployed and not the `default` one. 
- Update `helm help`

## Testing

1. Global Help

   ```bash
   @Botkube helm help
   @Botkube helm --help
   ```
1. Install (default and test namespace)

   ```bash
   @Botkube helm install -h

   # By absolute URL:
   @Botkube helm install
     --repo https://charts.bitnami.com/bitnami psql postgresql
     --set clusterDomain='testing.local'

   # By chart reference:
   @Botkube helm install https://charts.bitnami.com/bitnami/postgresql-12.1.0.tgz --create-namespace -n test --generate-name
   ```

1. List (default and all namespaces)

   ```bash
   @Botkube helm list
   @Botkube helm list -A
   @Botkube helm list -f 'p' -A
   ```

1. Upgrade (default namespace)

   ```bash
   @Botkube helm upgrade --repo https://charts.bitnami.com/bitnami psql postgresql --set clusterDomain='cluster.local'
   ```
