### PR TITLE
Fix marshalling event for Elasticsearch integration

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -13,32 +13,36 @@ import (
 	"github.com/kubeshop/botkube/pkg/k8sutil"
 )
 
-// Event to store required information from k8s objects
+// Event stores data about a given event for Kubernetes object.
+//
+// WARNING: When adding a new field, check if we shouldn't ignore it when marshalling and sending to ELS.
 type Event struct {
 	metaV1.TypeMeta
-	ObjectMeta metaV1.ObjectMeta
-
-	Code      string
-	Title     string
-	Name      string
-	Namespace string
-	Messages  []string
-	Type      config.EventType
-	Reason    string
-	Error     string
-	Level     config.Level
-	Cluster   string
-	Channel   string
-	TimeStamp time.Time
-	Count     int32
-	Action    string
-	Skip      bool `json:",omitempty"`
-	Resource  string
-	Object    interface{} `json:"-"`
-
+	Code            string
+	Title           string
+	Name            string
+	Namespace       string
+	Messages        []string
+	Type            config.EventType
+	Reason          string
+	Error           string
+	Level           config.Level
+	Cluster         string
+	Channel         string
+	TimeStamp       time.Time
+	Count           int32
+	Action          string
+	Skip            bool `json:",omitempty"`
+	Resource        string
 	Recommendations []string
 	Warnings        []string
 	Actions         []Action
+
+	// The following fields are ignored when marshalling the event by purpose.
+	// We send the whole Event struct via sink.Elasticsearch integration.
+	// When using ELS dynamic mapping, we should avoid complex, dynamic objects, which could result into type conflicts.
+	ObjectMeta metaV1.ObjectMeta `json:"-"`
+	Object     interface{}       `json:"-"`
 }
 
 // Action describes an automated action for a given event.


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Fix marshalling event for Elasticsearch integration

The `ObjectMeta` shouldn't be sent to Elasticsearch. That was an issue introduced a while ago.

## Testing
- Use the values:

```yaml
image:
  tag: 923-PR
  repository: kubeshop/pr/botkube
communications:
  "default-group":
    elasticsearch:
      enabled: true
      server: http://elasticsearch-master.default:9200
      username: elastic
      password: changeme
      skipTLSVerify: false                      # toggle verification of TLS certificate of the Elastic nodes. Verification is skipped when option is true. Enable to connect to clusters with self-signed certs
      # ELS index settings
      indices:
        'default':
          bindings:
            sources:
              - k8s-err-events
              - k8s-recommendation-events          
              - k8s-create-events
                                      
actions:
  'describe-created-resource':
    enabled: true
  'show-logs-on-error':
    # -- If true, enables the action.
    enabled: true    

analytics:
  disable: true
```

- Follow the instruction from #919.
- Use development instruction from https://docs.botkube.io/community/contribute/elasticsearch-develop

When fetching ELS index, you should see the events without K8s `ObjectMeta` and errors anymore:

```json
 {
        "_index" : "botkube-2023-01-09",
        "_type" : "botkube-event",
        "_id" : "qwTQlYUBe6B1gROVobr4",
        "_score" : 1.0,
        "_source" : {
          "kind" : "Pod",
          "apiVersion" : "v1",
          "Code" : "",
          "Title" : "v1/pods created",
          "Name" : "nginx",
          "Namespace" : "botkube",
          "Messages" : null,
          "Type" : "create",
          "Reason" : "",
          "Error" : "",
          "Level" : "info",
          "Cluster" : "dev",
          "Channel" : "",
          "TimeStamp" : "2023-01-09T09:15:56Z",
          "Count" : 0,
          "Action" : "",
          "Resource" : "v1/pods",
          "Recommendations" : [
            "The 'latest' tag used in 'nginx' image of Pod 'botkube/nginx' container 'nginx' should be avoided."
          ],
          "Warnings" : null,
          "Actions" : [
            {
              "Command" : "{{BotName}} kubectl describe pod -n botkube nginx",
              "ExecutorBindings" : [
                "kubectl-read-only"
              ],
              "DisplayName" : "Describe created resource"
            }
          ]
        }
      },
      {
        "_index" : "botkube-2023-01-09",
        "_type" : "botkube-event",
        "_id" : "rATRlYUBe6B1gROVJ7pi",
        "_score" : 1.0,
        "_source" : {
          "kind" : "Pod",
          "apiVersion" : "v1",
          "Code" : "",
          "Title" : "v1/pods created",
          "Name" : "ingress-nginx-controller-6d74cfb66b-dn7j7",
          "Namespace" : "ingress-nginx",
          "Messages" : null,
          "Type" : "create",
          "Reason" : "",
          "Error" : "",
          "Level" : "info",
          "Cluster" : "dev",
          "Channel" : "",
          "TimeStamp" : "2023-01-09T09:16:30Z",
          "Count" : 0,
          "Action" : "",
          "Resource" : "v1/pods",
          "Recommendations" : null,
          "Warnings" : null,
          "Actions" : [
            {
              "Command" : "{{BotName}} kubectl describe pod -n ingress-nginx ingress-nginx-controller-6d74cfb66b-dn7j7",
              "ExecutorBindings" : [
                "kubectl-read-only"
              ],
              "DisplayName" : "Describe created resource"
            }
          ]
        }
      },
      {
        "_index" : "botkube-2023-01-09",
        "_type" : "botkube-event",
        "_id" : "rQTRlYUBe6B1gROVNLq9",
        "_score" : 1.0,
        "_source" : {
          "kind" : "Pod",
          "apiVersion" : "v1",
          "Code" : "",
          "Title" : "v1/pods error",
          "Name" : "ingress-nginx-controller-6d74cfb66b-966ql",
          "Namespace" : "ingress-nginx",
          "Messages" : [
            "Readiness probe failed: HTTP probe failed with statuscode: 500"
          ],
          "Type" : "error",
          "Reason" : "Unhealthy",
          "Error" : "",
          "Level" : "error",
          "Cluster" : "dev",
          "Channel" : "",
          "TimeStamp" : "2023-01-09T09:16:33Z",
          "Count" : 1,
          "Action" : "",
          "Resource" : "v1/pods",
          "Recommendations" : null,
          "Warnings" : null,
          "Actions" : [
            {
              "Command" : "{{BotName}} kubectl logs pod/ingress-nginx-controller-6d74cfb66b-966ql -n ingress-nginx",
              "ExecutorBindings" : [
                "kubectl-read-only"
              ],
              "DisplayName" : "Show logs on error"
            }
          ]
        }
      }
```

## Related issue(s)

Resolves #919 

Similar to https://github.com/kubeshop/botkube/pull/701