### PR TITLE
Fix changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           gh api repos/$GITHUB_REPOSITORY/releases/generate-notes \
             -f tag_name="${GITHUB_REF#refs/tags/}" \
-            -f target_commitish="${{ steps.prev-version.outputs.previous-version }}" \
+            -f previous_tag_name="${{ steps.prev-version.outputs.previous-version }}" \
             -q .body > CHANGELOG.md
 
       - name: Publish draft release


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix changelog generation

## Testing

Local run:
```
gh api repos/kubeshop/botkube/releases/generate-notes \
    -f tag_name="v0.17.0" \
    -f previous_tag_name="v0.16.0" \
    -q .body > CHANGELOG.md
```

generates a valid changelog. When the `previous_tag_name` is not specified, the `auto` is used, and it doesn't work well in our scenario.
