### PR TITLE
helm option is added for config source

### DIFF
--- a/cmd/botkube/main.go
+++ b/cmd/botkube/main.go
@@ -69,7 +69,7 @@ func main() {
 func run() error {
 	// Load configuration
 	config.RegisterFlags(pflag.CommandLine)
-	var gqlClient intconfig.GqlClient = intconfig.NewGqlClient(intconfig.WithAPIURL(os.Getenv("CONFIG_SOURCE_ENDPOINT")))
+	var gqlClient intconfig.GqlClient = intconfig.NewGqlClient(intconfig.WithAPIURL(os.Getenv("CONFIG_PROVIDER_ENDPOINT")))
 	configs, err := config.FromProvider(&gqlClient)
 	if err != nil {
 		return fmt.Errorf("while loading configuration files: %w", err)

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -195,10 +195,10 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [plugins.cacheDir](./values.yaml#L869) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
 | [plugins.repositories](./values.yaml#L871) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}` | List of plugins repositories. |
 | [plugins.repositories.botkube](./values.yaml#L873) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
-| [config](./values.yaml#L877) | object | `{"source":{"endpoint":"","identifier":""}}` | Configuration for remote Botkube settings |
-| [config.source](./values.yaml#L879) | object | `{"endpoint":"","identifier":""}` | Base source definition |
-| [config.source.identifier](./values.yaml#L881) | string | `""` | Unique identifier for remote Botkube settings |
-| [config.source.endpoint](./values.yaml#L883) | string | `""` | Endpoint to fetch Botkube settings from |
+| [config](./values.yaml#L877) | object | `{"provider":{"endpoint":"","identifier":""}}` | Configuration for remote Botkube settings |
+| [config.provider](./values.yaml#L879) | object | `{"endpoint":"","identifier":""}` | Base provider definition |
+| [config.provider.identifier](./values.yaml#L881) | string | `""` | Unique identifier for remote Botkube settings |
+| [config.provider.endpoint](./values.yaml#L883) | string | `""` | Endpoint to fetch Botkube settings from |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -195,6 +195,19 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [plugins.cacheDir](./values.yaml#L869) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
 | [plugins.repositories](./values.yaml#L871) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}` | List of plugins repositories. |
 | [plugins.repositories.botkube](./values.yaml#L873) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
-| [config](./values.yaml#L877) | object | `{"source":{"endpoint":null,"identifier":null}}` | Configuration for remote Botkube settings |
-| [config.source](./values.yaml#L879) | object | `{"endpoint":null,"identifier":null}` | Base source definition |
-| [config.source.identifier](./values.yaml#L881) | string | `nil` | 
+| [config](./values.yaml#L877) | object | `{"source":{"endpoint":"","identifier":""}}` | Configuration for remote Botkube settings |
+| [config.source](./values.yaml#L879) | object | `{"endpoint":"","identifier":""}` | Base source definition |
+| [config.source.identifier](./values.yaml#L881) | string | `""` | Unique identifier for remote Botkube settings |
+| [config.source.endpoint](./values.yaml#L883) | string | `""` | Endpoint to fetch Botkube settings from |
+
+### AWS IRSA on EKS support
+
+AWS has introduced IAM Role for Service Accounts in order to provide fine-grained access. This is useful if you are looking to run Botkube inside an EKS cluster. For more details visit https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
+
+Annotate the Botkube Service Account as shown in the example below and add the necessary Trust Relationship to the corresponding Botkube role to get this working.
+
+```
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: "{role_arn_to_assume}"
+```

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -195,15 +195,6 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [plugins.cacheDir](./values.yaml#L869) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
 | [plugins.repositories](./values.yaml#L871) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}` | List of plugins repositories. |
 | [plugins.repositories.botkube](./values.yaml#L873) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
-
-### AWS IRSA on EKS support
-
-AWS has introduced IAM Role for Service Accounts in order to provide fine-grained access. This is useful if you are looking to run Botkube inside an EKS cluster. For more details visit https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html.
-
-Annotate the Botkube Service Account as shown in the example below and add the necessary Trust Relationship to the corresponding Botkube role to get this working.
-
-```
-serviceAccount:
-  annotations:
-    eks.amazonaws.com/role-arn: "{role_arn_to_assume}"
-```
+| [config](./values.yaml#L877) | object | `{"source":{"endpoint":null,"identifier":null}}` | Configuration for remote Botkube settings |
+| [config.source](./values.yaml#L879) | object | `{"endpoint":null,"identifier":null}` | Base source definition |
+| [config.source.identifier](./values.yaml#L881) | string | `nil` | 

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -113,12 +113,12 @@ spec:
               value: "{{.Release.Namespace}}"
             - name: BOTKUBE_SETTINGS_LIFECYCLE__SERVER_DEPLOYMENT_NAME
               value: "{{ include "botkube.fullname" . }}"
-            {{- if .Values.config.source.endpoint }}
-            - name: CONFIG_SOURCE_ENDPOINT
+            {{- if .Values.config.provider.endpoint }}
+            - name: CONFIG_PROVIDER_ENDPOINT
               value: {{ .Values.config.source.endpoint }}
             {{- end }}
-            {{- if .Values.config.source.identifier }}
-            - name: CONFIG_SOURCE_IDENTIFIER
+            {{- if .Values.config.provider.identifier }}
+            - name: CONFIG_PROVIDER_IDENTIFIER
               value: "{{ .Values.config.source.identifier }}"
             {{- end }}
           {{- with .Values.extraEnv }}

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -113,6 +113,14 @@ spec:
               value: "{{.Release.Namespace}}"
             - name: BOTKUBE_SETTINGS_LIFECYCLE__SERVER_DEPLOYMENT_NAME
               value: "{{ include "botkube.fullname" . }}"
+            {{- if .Values.config.source.endpoint }}
+            - name: CONFIG_SOURCE_ENDPOINT
+              value: {{ .Values.config.source.endpoint }}
+            {{- end }}
+            {{- if .Values.config.source.identifier }}
+            - name: CONFIG_SOURCE_IDENTIFIER
+              value: "{{ .Values.config.source.identifier }}"
+            {{- end }}
           {{- with .Values.extraEnv }}
             {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -115,11 +115,11 @@ spec:
               value: "{{ include "botkube.fullname" . }}"
             {{- if .Values.config.provider.endpoint }}
             - name: CONFIG_PROVIDER_ENDPOINT
-              value: {{ .Values.config.source.endpoint }}
+              value: {{ .Values.config.provider.endpoint }}
             {{- end }}
             {{- if .Values.config.provider.identifier }}
             - name: CONFIG_PROVIDER_IDENTIFIER
-              value: "{{ .Values.config.source.identifier }}"
+              value: "{{ .Values.config.provider.identifier }}"
             {{- end }}
           {{- with .Values.extraEnv }}
             {{ toYaml . | nindent 12 }}

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -872,3 +872,12 @@ plugins:
     # -- This repository serves officially supported Botkube plugins.
     botkube:
       url: https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml
+
+# -- Configuration for remote Botkube settings
+config:
+  # -- Base source definition
+  source:
+    # -- Unique identifier for remote Botkube settings
+    identifier:
+    # -- Endpoint to fetch Botkube settings from
+    endpoint:

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -878,6 +878,6 @@ config:
   # -- Base source definition
   source:
     # -- Unique identifier for remote Botkube settings
-    identifier:
+    identifier: ""
     # -- Endpoint to fetch Botkube settings from
-    endpoint:
+    endpoint: ""

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -875,8 +875,8 @@ plugins:
 
 # -- Configuration for remote Botkube settings
 config:
-  # -- Base source definition
-  source:
+  # -- Base provider definition
+  provider:
     # -- Unique identifier for remote Botkube settings
     identifier: ""
     # -- Endpoint to fetch Botkube settings from

--- a/internal/config/gql_provider.go
+++ b/internal/config/gql_provider.go
@@ -20,7 +20,7 @@ func NewGqlProvider(gql GqlClient) *GqlProvider {
 
 // Configs returns list of config files
 func (g *GqlProvider) Configs(ctx context.Context) (YAMLFiles, error) {
-	d := os.Getenv("CONFIG_SOURCE_IDENTIFIER")
+	d := os.Getenv("CONFIG_PROVIDER_IDENTIFIER")
 	if d == "" {
 		return nil, nil
 	}

--- a/internal/config/gql_provider_test.go
+++ b/internal/config/gql_provider_test.go
@@ -22,7 +22,7 @@ func (f *fakeGqlClient) GetDeployment(ctx context.Context, id string) (Deploymen
 func TestGqlProviderSuccess(t *testing.T) {
 	//given
 	f := fakeGqlClient{}
-	t.Setenv("CONFIG_SOURCE_IDENTIFIER", "16")
+	t.Setenv("CONFIG_PROVIDER_IDENTIFIER", "16")
 	p := NewGqlProvider(&f)
 
 	// when

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -666,7 +666,7 @@ func LoadWithDefaults(configs [][]byte) (*Config, LoadWithDefaultsDetails, error
 // It reads them the 'BOTKUBE_CONFIG_PATHS' env variable. If not found, then it uses '--config' flag.
 func FromProvider(gql *config.GqlClient) (config.YAMLFiles, error) {
 	var provider config.Provider
-	if os.Getenv("CONFIG_SOURCE_IDENTIFIER") != "" {
+	if os.Getenv("CONFIG_PROVIDER_IDENTIFIER") != "" {
 		provider = config.NewGqlProvider(*gql)
 	} else if os.Getenv("BOTKUBE_CONFIG_PATHS") != "" {
 		provider = config.NewEnvProvider()


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- `config.provider.endpoint` helm option is added
- `config.provider.identifier` helm option is added

## Testing

### With config source
```bash
helm install --version v0.17.0 botkube --namespace botkube --create-namespace \
--set settings.clusterName=dev \
--set executors.kubectl-read-only.kubectl.enabled=true \
--set 'executors.helm.botkube/helm.enabled'=false \
--set config.provider.identifier=12123 \
--set config.provider.endpoint=http://localhost:8080/graphql \
./helm/botkube
```
![Screen Shot 2023-01-12 at 18 14 02](https://user-images.githubusercontent.com/1237982/212104682-ed44244a-86fa-4ac9-a20b-c42e85e4df54.png)



### Without config source
```bash
helm install --version v0.17.0 botkube --namespace botkube --create-namespace \
--set settings.clusterName=dev \
--set executors.kubectl-read-only.kubectl.enabled=true \
--set 'executors.helm.botkube/helm.enabled'=false \
./helm/botkube
```

![Screen Shot 2023-01-12 at 11 58 04](https://user-images.githubusercontent.com/1237982/212027293-1d0cbd57-5dcf-401f-a815-cef946e9b3fe.png)


## Related issue(s)
Resolves #931 

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
