### PR TITLE
Fetch only used plugin repositories, fix logging, add repo validation

### DIFF
--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -1,0 +1,82 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeshop/botkube/internal/loggerx"
+	"github.com/kubeshop/botkube/pkg/config"
+)
+
+func TestCollectEnabledRepositories(t *testing.T) {
+	tests := []struct {
+		name string
+
+		enabledExecutors    []string
+		enabledSources      []string
+		definedRepositories map[string]config.PluginsRepositories
+
+		expErrMsg string
+	}{
+		{
+			name: "report not defined repositories for source plugins",
+			enabledSources: []string{
+				"botkube/cm-watcher",
+				"mszostok/hakuna-matata",
+			},
+			expErrMsg: heredoc.Doc(`
+				2 errors occurred:
+					* repository "botkube" is not defined, but it is referred by source plugin called "botkube/cm-watcher"
+					* repository "mszostok" is not defined, but it is referred by source plugin called "mszostok/hakuna-matata"`),
+		},
+		{
+			name: "report not defined repositories for executor plugins",
+			enabledExecutors: []string{
+				"botkube/helm",
+				"botkube/kubectl",
+				"mszostok/hakuna-matata",
+			},
+			expErrMsg: heredoc.Doc(`
+				3 errors occurred:
+					* repository "botkube" is not defined, but it is referred by executor plugin called "botkube/helm"
+					* repository "botkube" is not defined, but it is referred by executor plugin called "botkube/kubectl"
+					* repository "mszostok" is not defined, but it is referred by executor plugin called "mszostok/hakuna-matata"`),
+		},
+		{
+			name: "report not defined repositories for source and executor plugins",
+			enabledSources: []string{
+				"botkube/cm-watcher",
+				"mszostok/hakuna-matata",
+			},
+			enabledExecutors: []string{
+				"botkube/helm",
+				"botkube/kubectl",
+				"mszostok/hakuna-matata",
+			},
+			expErrMsg: heredoc.Doc(`
+				5 errors occurred:
+					* repository "botkube" is not defined, but it is referred by executor plugin called "botkube/helm"
+					* repository "botkube" is not defined, but it is referred by executor plugin called "botkube/kubectl"
+					* repository "mszostok" is not defined, but it is referred by executor plugin called "mszostok/hakuna-matata"
+					* repository "botkube" is not defined, but it is referred by source plugin called "botkube/cm-watcher"
+					* repository "mszostok" is not defined, but it is referred by source plugin called "mszostok/hakuna-matata"`),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			manager := NewManager(loggerx.NewNoop(), config.Plugins{
+				Repositories: tc.definedRepositories,
+			}, tc.enabledExecutors, tc.enabledSources)
+
+			// when
+			out, err := manager.collectEnabledRepositories()
+
+			// then
+			assert.Empty(t, out)
+			assert.EqualError(t, err, tc.expErrMsg)
+		})
+	}
+}

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -37,7 +37,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, pluginName string, pluginConf
 		"sources":    sources,
 	})
 
-	log.Info("Staring source streaming...")
+	log.Info("Start source streaming...")
 
 	sourceClient, err := d.manager.GetSource(pluginName)
 	if err != nil {

--- a/pkg/bot/interactive/help.go
+++ b/pkg/bot/interactive/help.go
@@ -3,10 +3,8 @@ package interactive
 import (
 	"fmt"
 
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
 	"github.com/kubeshop/botkube/pkg/config"
+	formatx "github.com/kubeshop/botkube/pkg/format"
 )
 
 // RunCommandName defines the button name for the run commands.
@@ -233,7 +231,7 @@ func (h *HelpMessage) kubectlSections() []Section {
 		{
 			Base: Base{
 				Header:      "Run kubectl commands (if enabled)",
-				Description: fmt.Sprintf("%s\nYou can run kubectl commands directly from %s!", warn, cases.Title(language.English).String(string(h.platform))),
+				Description: fmt.Sprintf("%s\nYou can run kubectl commands directly from %s!", warn, formatx.ToTitle(h.platform)),
 			},
 			Buttons: []Button{
 				h.btnBuilder.ForCommandWithDescCmd(RunCommandName, "kubectl get services"),
@@ -265,7 +263,7 @@ func (h *HelpMessage) pluginHelpSections() []Section {
 			platformName = "slack" // normalize the SocketSlack to Slack
 		}
 
-		helpSection := helpFn(cases.Title(language.English).String(string(platformName)), h.btnBuilder)
+		helpSection := helpFn(formatx.ToTitle(platformName), h.btnBuilder)
 		out = append(out, helpSection)
 	}
 	return out

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,11 @@ const (
 	WebhookCommPlatformIntegration CommPlatformIntegration = "webhook"
 )
 
+// String returns string platform name.
+func (c CommPlatformIntegration) String() string {
+	return string(c)
+}
+
 // IntegrationType describes the type of integration with a communication platform.
 type IntegrationType string
 

--- a/pkg/format/title.go
+++ b/pkg/format/title.go
@@ -1,0 +1,13 @@
+package format
+
+import (
+	"fmt"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// ToTitle returns English specific title casing.
+func ToTitle(in fmt.Stringer) string {
+	return cases.Title(language.English).String(in.String())
+}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fetch only used plugin repositories, 
- Fix logging messages, 
- Add repo validation, so user gets more useful error message
  -  without that you only get `not found source plugin called "cm-test" in "botkube" repository`.  And it's misleading as it suggests that the `botkube` repository was found. Now, as the repositories are validated, this error message is valid.

## Related issue(s)

Fix #939 