### PR TITLE
Validate alias commands and display builtin command aliases

### DIFF
--- a/cmd/botkube/main.go
+++ b/cmd/botkube/main.go
@@ -67,10 +67,15 @@ func main() {
 
 // run wraps the main logic of the app to be able to properly clean up resources via deferred calls.
 func run() error {
+	// Set up context
+	ctx := signals.SetupSignalHandler()
+	ctx, cancelCtxFn := context.WithCancel(ctx)
+	defer cancelCtxFn()
+
 	// Load configuration
 	config.RegisterFlags(pflag.CommandLine)
 	var gqlClient intconfig.GqlClient = intconfig.NewGqlClient(intconfig.WithAPIURL(os.Getenv("CONFIG_PROVIDER_ENDPOINT")))
-	configs, err := config.FromProvider(&gqlClient)
+	configs, err := config.FromProvider(ctx, &gqlClient)
 	if err != nil {
 		return fmt.Errorf("while loading configuration files: %w", err)
 	}
@@ -102,11 +107,6 @@ func run() error {
 	defer analytics.ReportPanicIfOccurs(logger, reporter)
 
 	reportFatalError := reportFatalErrFn(logger, reporter)
-
-	// Set up context
-	ctx := signals.SetupSignalHandler()
-	ctx, cancelCtxFn := context.WithCancel(ctx)
-	defer cancelCtxFn()
 
 	errGroup, ctx := errgroup.WithContext(ctx)
 

--- a/cmd/botkube/main.go
+++ b/cmd/botkube/main.go
@@ -60,18 +60,18 @@ const (
 )
 
 func main() {
-	if err := run(); err != nil {
-		log.Fatal(err)
-	}
-}
-
-// run wraps the main logic of the app to be able to properly clean up resources via deferred calls.
-func run() error {
 	// Set up context
 	ctx := signals.SetupSignalHandler()
 	ctx, cancelCtxFn := context.WithCancel(ctx)
 	defer cancelCtxFn()
 
+	if err := run(ctx); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// run wraps the main logic of the app to be able to properly clean up resources via deferred calls.
+func run(ctx context.Context) error {
 	// Load configuration
 	config.RegisterFlags(pflag.CommandLine)
 	var gqlClient intconfig.GqlClient = intconfig.NewGqlClient(intconfig.WithAPIURL(os.Getenv("CONFIG_PROVIDER_ENDPOINT")))

--- a/helm/botkube/e2e-test-values.yaml
+++ b/helm/botkube/e2e-test-values.yaml
@@ -226,6 +226,8 @@ aliases:
     displayName: "Get Deployments"
   e:
     command: echo
+  p:
+    command: ping
 
 settings:
   clusterName: sample

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -305,6 +305,27 @@ type Executors struct {
 	Plugins Plugins `koanf:",remain"`
 }
 
+// CollectEnabledCommandPrefixes returns list of command prefixes for enabled executors.
+func (e Executors) CollectEnabledCommandPrefixes() []string {
+	var prefixes []string
+
+	// TODO: Remove this once we deprecate kubectl executor
+	// Case 1: kubectl
+	if e.Kubectl.Enabled {
+		prefixes = append(prefixes, kubectlCommandName)
+	}
+
+	// Case 2: plugin alias
+	for pluginName, plugin := range e.Plugins {
+		if !plugin.Enabled {
+			continue
+		}
+		prefixes = append(prefixes, ExecutorNameForKey(pluginName))
+	}
+
+	return prefixes
+}
+
 // Aliases contains aliases configuration.
 type Aliases map[string]Alias
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -310,12 +310,10 @@ func (e Executors) CollectEnabledCommandPrefixes() []string {
 	var prefixes []string
 
 	// TODO: Remove this once we deprecate kubectl executor
-	// Case 1: kubectl
 	if e.Kubectl.Enabled {
 		prefixes = append(prefixes, kubectlCommandName)
 	}
 
-	// Case 2: plugin alias
 	for pluginName, plugin := range e.Plugins {
 		if !plugin.Enabled {
 			continue

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -702,7 +702,7 @@ func LoadWithDefaults(configs [][]byte) (*Config, LoadWithDefaultsDetails, error
 
 // FromProvider resolves and returns paths for config files.
 // It reads them the 'BOTKUBE_CONFIG_PATHS' env variable. If not found, then it uses '--config' flag.
-func FromProvider(gql *config.GqlClient) (config.YAMLFiles, error) {
+func FromProvider(ctx context.Context, gql *config.GqlClient) (config.YAMLFiles, error) {
 	var provider config.Provider
 	if os.Getenv("CONFIG_PROVIDER_IDENTIFIER") != "" {
 		provider = config.NewGqlProvider(*gql)
@@ -711,7 +711,7 @@ func FromProvider(gql *config.GqlClient) (config.YAMLFiles, error) {
 	} else {
 		provider = config.NewFileSystemProvider(configPathsFlag)
 	}
-	return provider.Configs(context.Background())
+	return provider.Configs(ctx)
 }
 
 // RegisterFlags registers config related flags.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -273,12 +273,21 @@ func TestLoadedConfigValidationErrors(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid alias",
+			name: "missing alias command",
 			expErrMsg: heredoc.Doc(`
 				found critical validation errors: 1 error occurred:
 					* Key: 'Config.Aliases[eee].Command' Command is a required field`),
 			configs: [][]byte{
-				readTestdataFile(t, "invalid-alias.yaml"),
+				readTestdataFile(t, "missing-alias-command.yaml"),
+			},
+		},
+		{
+			name: "invalid alias command",
+			expErrMsg: heredoc.Doc(`
+				found critical validation errors: 1 error occurred:
+					* Key: 'Config.Aliases[foo].Command' Command prefix 'foo' not found in executors or builtin commands`),
+			configs: [][]byte{
+				readTestdataFile(t, "invalid-alias-command.yaml"),
 			},
 		},
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -92,7 +93,7 @@ func TestFromProvider(t *testing.T) {
 		t.Setenv("BOTKUBE_CONFIG_PATHS", "testdata/TestFromProvider/first.yaml,testdata/TestFromProvider/second.yaml,testdata/TestFromProvider/third.yaml")
 
 		// when
-		gotConfigs, err := config.FromProvider(nil)
+		gotConfigs, err := config.FromProvider(context.Background(), nil)
 		assert.NoError(t, err)
 
 		// then
@@ -109,7 +110,7 @@ func TestFromProvider(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		gotConfigs, err := config.FromProvider(nil)
+		gotConfigs, err := config.FromProvider(context.Background(), nil)
 		assert.NoError(t, err)
 
 		// then
@@ -129,7 +130,7 @@ func TestFromProvider(t *testing.T) {
 		t.Setenv("BOTKUBE_CONFIG_PATHS", "testdata/TestFromProvider/first.yaml,testdata/TestFromProvider/second.yaml,testdata/TestFromProvider/third.yaml")
 
 		// when
-		gotConfigs, err := config.FromProvider(nil)
+		gotConfigs, err := config.FromProvider(context.Background(), nil)
 		assert.NoError(t, err)
 
 		// then

--- a/pkg/config/testdata/TestLoadedConfigValidationErrors/invalid-alias-command.yaml
+++ b/pkg/config/testdata/TestLoadedConfigValidationErrors/invalid-alias-command.yaml
@@ -7,17 +7,24 @@ aliases:
   kgp:
     command: kubectl get pods
     displayName: "Kubectl Get Pods"
+  foo:
+    command: foo --bar
+    displayName: "Foo"
   helm:
     command: helm version
     displayName: "Helm version"
-  eee:
-    command: ""
+  p:
+    command: ping
+    displayName: "Botkube ping"
+  s:
+    command: show config
+    displayName: "Botkube show config"
 
 executors:
   'kubectl-read-only':
     kubectl:
       enabled: true
-  'helm':
+  helm:
     botkube/helm:
       config: {}
       enabled: true

--- a/pkg/config/testdata/TestLoadedConfigValidationErrors/missing-alias-command.yaml
+++ b/pkg/config/testdata/TestLoadedConfigValidationErrors/missing-alias-command.yaml
@@ -1,0 +1,25 @@
+communications: {"foo": {}}
+
+aliases:
+  kc:
+    command: kubectl
+    displayName: "Kubectl alias"
+  kgp:
+    command: kubectl get pods
+    displayName: "Kubectl Get Pods"
+  eee:
+    command: ""
+
+executors:
+  'kubectl-read-only':
+    kubectl:
+      enabled: true
+  'helm':
+    botkube/helm:
+      config: {}
+      enabled: true
+  'plugin-based':
+    botkube/echo@v1.0.1-devel:
+      enabled: false
+      config:
+        changeResponseToUpperCase: true

--- a/pkg/execute/action.go
+++ b/pkg/execute/action.go
@@ -46,11 +46,11 @@ func NewActionExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReport
 }
 
 // Commands returns slice of commands the executor supports
-func (e *ActionExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandList:    e.List,
-		CommandEnable:  e.Enable,
-		CommandDisable: e.Disable,
+func (e *ActionExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.ListVerb:    e.List,
+		command.EnableVerb:  e.Enable,
+		command.DisableVerb: e.Disable,
 	}
 }
 

--- a/pkg/execute/alias.go
+++ b/pkg/execute/alias.go
@@ -24,7 +24,7 @@ var featureName = FeatureName{
 	Aliases: []string{"aliases", "als"},
 }
 
-// AliasExecutor
+// AliasExecutor executes all commands that are related to aliases.
 type AliasExecutor struct {
 	log               logrus.FieldLogger
 	analyticsReporter AnalyticsReporter
@@ -37,9 +37,9 @@ func NewAliasExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReporte
 }
 
 // Commands returns slice of commands the executor supports.
-func (e *AliasExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandList: e.List,
+func (e *AliasExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.ListVerb: e.List,
 	}
 }
 
@@ -86,6 +86,14 @@ func (e *AliasExecutor) getTabularOutput(bindings []string) string {
 		}
 
 		aliasesForPrefix := alias.ListForExecutorPrefix(exName, aliasesCfg)
+		for _, aliasName := range aliasesForPrefix {
+			aliasesToDisplay[aliasName] = aliasesCfg[aliasName]
+		}
+	}
+
+	// check also builtin commands
+	for _, verb := range command.AllVerbs() {
+		aliasesForPrefix := alias.ListForBuiltinVerbPrefix(verb, aliasesCfg)
 		for _, aliasName := range aliasesForPrefix {
 			aliasesToDisplay[aliasName] = aliasesCfg[aliasName]
 		}

--- a/pkg/execute/alias/list.go
+++ b/pkg/execute/alias/list.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 )
 
 // ListExactForExecutor lists aliases for configured commands that are equal to the executor name.
@@ -39,6 +40,11 @@ func ListForExecutorPrefix(rawName string, aliases config.Aliases) []string {
 		executorNameWithSpace := fmt.Sprintf("%s ", executorName)
 		return strings.HasPrefix(cfg.Command, executorNameWithSpace)
 	})
+}
+
+// ListForBuiltinVerbPrefix lists aliases for builtin commands that starts with the verb prefix names.
+func ListForBuiltinVerbPrefix(verb command.Verb, aliases config.Aliases) []string {
+	return ListForExecutorPrefix(string(verb), aliases)
 }
 
 func listForExecutorWithFn(rawName string, aliases config.Aliases, shouldIncludeItem func(cfg config.Alias, executorName string) bool) []string {

--- a/pkg/execute/alias/list_test.go
+++ b/pkg/execute/alias/list_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/execute/alias"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 )
 
 func TestListForExecutor(t *testing.T) {
@@ -79,7 +80,7 @@ func TestListForExecutorPrefix(t *testing.T) {
 			Expected: nil,
 		},
 		{
-			Name:     "No alias for builtin",
+			Name:     "No alias for builtin executor",
 			Input:    "echo",
 			Expected: nil,
 		},
@@ -104,6 +105,56 @@ func TestListForExecutorPrefix(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			// when
 			actual := alias.ListForExecutorPrefix(tc.Input, aliases)
+
+			// then
+			assert.Equal(t, tc.Expected, actual)
+		})
+	}
+}
+
+func TestListForBuiltinVerbPrefix(t *testing.T) {
+	// given
+	aliases := config.Aliases{
+		"e": {
+			Command: "edit",
+		},
+		"esb": {
+			Command: "edit sourcebindings foo,bar",
+		},
+		"p": {
+			Command: "ping",
+		},
+		"pp": {
+			Command: "ping --cluster-name=dev",
+		},
+	}
+
+	testCases := []struct {
+		Name     string
+		Input    command.Verb
+		Expected []string
+	}{
+		{
+			Name:     "Ping",
+			Input:    "ping",
+			Expected: []string{"p", "pp"},
+		},
+		{
+			Name:     "edit",
+			Input:    "edit",
+			Expected: []string{"e", "esb"},
+		},
+		{
+			Name:     "No alias for builtin",
+			Input:    "make",
+			Expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			// when
+			actual := alias.ListForBuiltinVerbPrefix(tc.Input, aliases)
 
 			// then
 			assert.Equal(t, tc.Expected, actual)

--- a/pkg/execute/command/verb.go
+++ b/pkg/execute/command/verb.go
@@ -1,0 +1,32 @@
+package command
+
+// Verb are commands supported by the bot.
+type Verb string
+
+const (
+	PingVerb     Verb = "ping"
+	HelpVerb     Verb = "help"
+	VersionVerb  Verb = "version"
+	FeedbackVerb Verb = "feedback"
+	ListVerb     Verb = "list"
+	EnableVerb   Verb = "enable"
+	DisableVerb  Verb = "disable"
+	EditVerb     Verb = "edit"
+	StatusVerb   Verb = "status"
+	ShowVerb     Verb = "show"
+)
+
+func AllVerbs() []Verb {
+	return []Verb{
+		PingVerb,
+		HelpVerb,
+		VersionVerb,
+		FeedbackVerb,
+		ListVerb,
+		EnableVerb,
+		DisableVerb,
+		EditVerb,
+		StatusVerb,
+		ShowVerb,
+	}
+}

--- a/pkg/execute/config.go
+++ b/pkg/execute/config.go
@@ -43,9 +43,9 @@ func (e *ConfigExecutor) FeatureName() FeatureName {
 }
 
 // Commands returns slice of commands the executor supports
-func (e *ConfigExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandShow: e.Show,
+func (e *ConfigExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.ShowVerb: e.Show,
 	}
 }
 

--- a/pkg/execute/exec.go
+++ b/pkg/execute/exec.go
@@ -42,9 +42,9 @@ func NewExecExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReporter
 }
 
 // Commands returns slice of commands the executor supports
-func (e *ExecExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandList: e.List,
+func (e *ExecExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.ListVerb: e.List,
 	}
 }
 

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -191,7 +191,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.Message {
 		return respond(out, cmdCtx)
 	}
 
-	cmdVerb := CommandVerb(strings.ToLower(cmdCtx.Args[0]))
+	cmdVerb := command.Verb(strings.ToLower(cmdCtx.Args[0]))
 	var cmdRes string
 	if len(cmdCtx.Args) > 1 {
 		cmdRes = strings.ToLower(cmdCtx.Args[1])

--- a/pkg/execute/feedback.go
+++ b/pkg/execute/feedback.go
@@ -34,9 +34,9 @@ func (e *FeedbackExecutor) FeatureName() FeatureName {
 }
 
 // Commands returns slice of commands the executor supports
-func (e *FeedbackExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandFeedback: e.Feedback,
+func (e *FeedbackExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.FeedbackVerb: e.Feedback,
 	}
 }
 

--- a/pkg/execute/filter.go
+++ b/pkg/execute/filter.go
@@ -48,11 +48,11 @@ func NewFilterExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReport
 }
 
 // Commands returns slice of commands the executor supports
-func (e *FilterExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandList:    e.List,
-		CommandEnable:  e.Enable,
-		CommandDisable: e.Disable,
+func (e *FilterExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.ListVerb:    e.List,
+		command.EnableVerb:  e.Enable,
+		command.DisableVerb: e.Disable,
 	}
 }
 

--- a/pkg/execute/help.go
+++ b/pkg/execute/help.go
@@ -40,9 +40,9 @@ func (e *HelpExecutor) FeatureName() FeatureName {
 }
 
 // Commands returns slice of commands the executor supports
-func (e *HelpExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandHelp: e.Help,
+func (e *HelpExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.HelpVerb: e.Help,
 	}
 }
 

--- a/pkg/execute/mapping.go
+++ b/pkg/execute/mapping.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
 	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 	"github.com/kubeshop/botkube/pkg/multierror"
 )
 
@@ -19,26 +20,9 @@ const (
 	incompleteCmdMsg = "You missed to pass options for the command. Please use 'help' to see command options."
 )
 
-// CommandVerb are commands supported by the bot
-type CommandVerb string
-
-// CommandVerb command options
-const (
-	CommandPing     CommandVerb = "ping"
-	CommandHelp     CommandVerb = "help"
-	CommandVersion  CommandVerb = "version"
-	CommandFeedback CommandVerb = "feedback"
-	CommandList     CommandVerb = "list"
-	CommandEnable   CommandVerb = "enable"
-	CommandDisable  CommandVerb = "disable"
-	CommandEdit     CommandVerb = "edit"
-	CommandStatus   CommandVerb = "status"
-	CommandShow     CommandVerb = "show"
-)
-
 // CommandExecutor defines command structure for executors
 type CommandExecutor interface {
-	Commands() map[CommandVerb]CommandFn
+	Commands() map[command.Verb]CommandFn
 	FeatureName() FeatureName
 }
 
@@ -83,15 +67,15 @@ type FeatureName struct {
 
 // CommandMapping allows to register and lookup commands and dynamically build help messages
 type CommandMapping struct {
-	commands map[CommandVerb]map[string]CommandFn
-	help     map[CommandVerb][]FeatureName
+	commands map[command.Verb]map[string]CommandFn
+	help     map[command.Verb][]FeatureName
 }
 
 // NewCmdsMapping registers command and help mappings
 func NewCmdsMapping(executors []CommandExecutor) (*CommandMapping, error) {
 	mappingsErrs := multierror.New()
-	cmdsMapping := make(map[CommandVerb]map[string]CommandFn)
-	helpMapping := make(map[CommandVerb][]FeatureName)
+	cmdsMapping := make(map[command.Verb]map[string]CommandFn)
+	helpMapping := make(map[command.Verb][]FeatureName)
 	for _, executor := range executors {
 		cmds := executor.Commands()
 		subCmd := executor.FeatureName()
@@ -122,7 +106,7 @@ func NewCmdsMapping(executors []CommandExecutor) (*CommandMapping, error) {
 }
 
 // FindFn looks up CommandFn by verb and feature
-func (m *CommandMapping) FindFn(verb CommandVerb, feature string) (CommandFn, bool, bool) {
+func (m *CommandMapping) FindFn(verb command.Verb, feature string) (CommandFn, bool, bool) {
 	features, ok := m.commands[verb]
 	if !ok {
 		return nil, false, false
@@ -134,8 +118,8 @@ func (m *CommandMapping) FindFn(verb CommandVerb, feature string) (CommandFn, bo
 	return fn, true, true
 }
 
-// HelpMessageForVerb dynamically builds help message for given CommandVerb, or empty string
-func (m *CommandMapping) HelpMessageForVerb(verb CommandVerb, botName string) string {
+// HelpMessageForVerb dynamically builds help message for given command.Verb, or empty string
+func (m *CommandMapping) HelpMessageForVerb(verb command.Verb, botName string) string {
 	cmd, ok := m.help[verb]
 	if !ok {
 		return incompleteCmdMsg

--- a/pkg/execute/notifier.go
+++ b/pkg/execute/notifier.go
@@ -69,11 +69,11 @@ func (e *NotifierExecutor) FeatureName() FeatureName {
 }
 
 // Commands returns slice of commands the executor supports
-func (e *NotifierExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandEnable:  e.Enable,
-		CommandDisable: e.Disable,
-		CommandStatus:  e.Status,
+func (e *NotifierExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.EnableVerb:  e.Enable,
+		command.DisableVerb: e.Disable,
+		command.StatusVerb:  e.Status,
 	}
 }
 
@@ -138,7 +138,7 @@ func (e *NotifierExecutor) Status(ctx context.Context, cmdCtx CommandContext) (i
 	enabledStr := notifierStatusStrings[enabled]
 	msg := fmt.Sprintf(notifierStatusMsgFmt, cmdCtx.ClusterName, enabledStr)
 	if cmdRes == "" {
-		helpMsg := cmdCtx.Mapping.HelpMessageForVerb(CommandVerb(cmdVerb), cmdCtx.BotName)
+		helpMsg := cmdCtx.Mapping.HelpMessageForVerb(command.Verb(cmdVerb), cmdCtx.BotName)
 		msg = fmt.Sprintf("%s\n\n%s\n", msg, helpMsg)
 	}
 	return respond(msg, cmdCtx), nil

--- a/pkg/execute/ping.go
+++ b/pkg/execute/ping.go
@@ -37,9 +37,9 @@ func (e *PingExecutor) FeatureName() FeatureName {
 }
 
 // Commands returns slice of commands the executor supports
-func (e *PingExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandPing: e.Ping,
+func (e *PingExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.PingVerb: e.Ping,
 	}
 }
 

--- a/pkg/execute/source.go
+++ b/pkg/execute/source.go
@@ -41,9 +41,9 @@ func NewSourceExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReport
 }
 
 // Commands returns slice of commands the executor supports
-func (e *SourceExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandList: e.List,
+func (e *SourceExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.ListVerb: e.List,
 	}
 }
 

--- a/pkg/execute/sourcebinding.go
+++ b/pkg/execute/sourcebinding.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
 	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/execute/command"
 )
 
 const (
@@ -37,10 +38,10 @@ func (e *SourceBindingExecutor) FeatureName() FeatureName {
 }
 
 // Commands returns slice of commands the executor supports
-func (e *SourceBindingExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandEdit:   e.Edit,
-		CommandStatus: e.Status,
+func (e *SourceBindingExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.EditVerb:   e.Edit,
+		command.StatusVerb: e.Status,
 	}
 }
 

--- a/pkg/execute/sourcebinding.go
+++ b/pkg/execute/sourcebinding.go
@@ -102,7 +102,7 @@ func (e *SourceBindingExecutor) Status(_ context.Context, cmdCtx CommandContext)
 }
 
 // Edit executes the edit command based on args.
-func (e *SourceBindingExecutor) Edit(_ context.Context, cmdCtx CommandContext) (interactive.Message, error) {
+func (e *SourceBindingExecutor) Edit(ctx context.Context, cmdCtx CommandContext) (interactive.Message, error) {
 	var empty interactive.Message
 
 	if len(cmdCtx.Args) < 2 {
@@ -123,14 +123,14 @@ func (e *SourceBindingExecutor) Edit(_ context.Context, cmdCtx CommandContext) (
 		}
 	}()
 
-	msg, err := e.editSourceBindingHandler(cmdArgs, cmdCtx.CommGroupName, cmdCtx.Platform, cmdCtx.Conversation, cmdCtx.User, cmdCtx.BotName)
+	msg, err := e.editSourceBindingHandler(ctx, cmdArgs, cmdCtx.CommGroupName, cmdCtx.Platform, cmdCtx.Conversation, cmdCtx.User, cmdCtx.BotName)
 	if err != nil {
 		return empty, err
 	}
 	return msg, nil
 }
 
-func (e *SourceBindingExecutor) editSourceBindingHandler(cmdArgs []string, commGroupName string, platform config.CommPlatformIntegration, conversation Conversation, userID, botName string) (interactive.Message, error) {
+func (e *SourceBindingExecutor) editSourceBindingHandler(ctx context.Context, cmdArgs []string, commGroupName string, platform config.CommPlatformIntegration, conversation Conversation, userID, botName string) (interactive.Message, error) {
 	var empty interactive.Message
 
 	sourceBindings, err := e.normalizeSourceItems(cmdArgs)
@@ -167,7 +167,7 @@ func (e *SourceBindingExecutor) editSourceBindingHandler(cmdArgs []string, commG
 		return e.generateUnknownMessage(unknown), nil
 	}
 
-	err = e.cfgManager.PersistSourceBindings(context.Background(), commGroupName, platform, conversation.Alias, sourceBindings)
+	err = e.cfgManager.PersistSourceBindings(ctx, commGroupName, platform, conversation.Alias, sourceBindings)
 	if err != nil {
 		return empty, fmt.Errorf("while persisting source bindings configuration: %w", err)
 	}

--- a/pkg/execute/version.go
+++ b/pkg/execute/version.go
@@ -36,9 +36,9 @@ func (e *VersionExecutor) FeatureName() FeatureName {
 }
 
 // Commands returns slice of commands the executor supports
-func (e *VersionExecutor) Commands() map[CommandVerb]CommandFn {
-	return map[CommandVerb]CommandFn{
-		CommandVersion: e.Version,
+func (e *VersionExecutor) Commands() map[command.Verb]CommandFn {
+	return map[command.Verb]CommandFn{
+		command.VersionVerb: e.Version,
 	}
 }
 

--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -887,7 +887,7 @@ func runBotTest(t *testing.T,
 			kc    kubectl                    Kubectl alias
 			kgda  kubectl get deployments -A Get Deployments
 			kgp   kubectl get pods           Get Pods
-			p     ping                       `))
+			p     ping`))
 		contextMsg := "Only showing aliases for executors enabled for this channel."
 		expectedMessage := fmt.Sprintf("%s\n%s\n%s", cmdHeader(command), expectedBody, contextMsg)
 

--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -209,10 +209,11 @@ func runBotTest(t *testing.T,
 	t.Log("Running actual test cases")
 
 	t.Run("Ping", func(t *testing.T) {
-		command := "ping"
-		expectedMessage := fmt.Sprintf("`ping` on `%s`\n```\npong", appCfg.ClusterName)
+		aliasedCommand := "p"
+		expandedCommand := "ping"
+		expectedMessage := fmt.Sprintf("`%s` on `%s`\n```\npong", expandedCommand, appCfg.ClusterName)
 
-		botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), command)
+		botDriver.PostMessageToBot(t, botDriver.Channel().Identifier(), aliasedCommand)
 		err := botDriver.WaitForLastMessageContains(botDriver.BotUserID(), botDriver.Channel().ID(), expectedMessage)
 		assert.NoError(t, err)
 	})
@@ -885,7 +886,8 @@ func runBotTest(t *testing.T,
 			k     kubectl                    Kubectl alias
 			kc    kubectl                    Kubectl alias
 			kgda  kubectl get deployments -A Get Deployments
-			kgp   kubectl get pods           Get Pods`))
+			kgp   kubectl get pods           Get Pods
+			p     ping                       `))
 		contextMsg := "Only showing aliases for executors enabled for this channel."
 		expectedMessage := fmt.Sprintf("%s\n%s\n%s", cmdHeader(command), expectedBody, contextMsg)
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Validate alias command prefixes
- Display builtin command aliases
- Use proper context for querying Botkube config from GraphQL and editing SourceBindings

## Screenshot

![image](https://user-images.githubusercontent.com/7155799/216030740-a4e59daa-e0ee-4914-89be-fd0d5d0f82c7.png)

## Testing

No need to test it manually as the functionality was covered by unit and integration tests.

## Related issue(s)

Resolves https://github.com/kubeshop/botkube/issues/870
Resolves https://github.com/kubeshop/botkube/issues/908