### PR TITLE
Support include/exclude regexes for event and resource constraints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/alexflint/go-arg v1.4.3
 	github.com/aws/aws-sdk-go v1.44.20
 	github.com/bwmarrin/discordgo v0.25.0
+	github.com/dlclark/regexp2 v1.8.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-playground/locales v0.14.0
 	github.com/go-playground/universal-translator v0.18.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ require (
 	github.com/alexflint/go-arg v1.4.3
 	github.com/aws/aws-sdk-go v1.44.20
 	github.com/bwmarrin/discordgo v0.25.0
-	github.com/dlclark/regexp2 v1.8.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-playground/locales v0.14.0
 	github.com/go-playground/universal-translator v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,6 @@ github.com/dhui/dktest v0.3.7/go.mod h1:nYMOkafiA07WchSwKnKFUSbGMb2hMm5DrCGiXYG6
 github.com/die-net/lrucache v0.0.0-20181227122439-19a39ef22a11/go.mod h1:ew0MSjCVDdtGMjF3kzLK9hwdgF5mOE8SbYVF3Rc7mkU=
 github.com/disintegration/imaging v1.6.0/go.mod h1:xuIt+sRxDFrHS0drzXUlCJthkJ8k7lkkUojDSR247MQ=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
-github.com/dlclark/regexp2 v1.8.0 h1:rJD5HeGIT/2b5CDk63FVCwZA3qgYElfg+oQK7uH5pfE=
-github.com/dlclark/regexp2 v1.8.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=

--- a/go.sum
+++ b/go.sum
@@ -477,6 +477,8 @@ github.com/dhui/dktest v0.3.7/go.mod h1:nYMOkafiA07WchSwKnKFUSbGMb2hMm5DrCGiXYG6
 github.com/die-net/lrucache v0.0.0-20181227122439-19a39ef22a11/go.mod h1:ew0MSjCVDdtGMjF3kzLK9hwdgF5mOE8SbYVF3Rc7mkU=
 github.com/disintegration/imaging v1.6.0/go.mod h1:xuIt+sRxDFrHS0drzXUlCJthkJ8k7lkkUojDSR247MQ=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
+github.com/dlclark/regexp2 v1.8.0 h1:rJD5HeGIT/2b5CDk63FVCwZA3qgYElfg+oQK7uH5pfE=
+github.com/dlclark/regexp2 v1.8.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -54,151 +54,159 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [sources.k8s-recommendation-events.kubernetes.recommendations.ingress.tlsSecretValid](./values.yaml#L122) | bool | `true` | If true, notifies about Ingress resources with invalid TLS secret reference. |
 | [sources.k8s-all-events.kubernetes](./values.yaml#L128) | object | See the `values.yaml` file for full object. | Describes Kubernetes source configuration. |
 | [sources.k8s-all-events.kubernetes.namespaces](./values.yaml#L132) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
-| [sources.k8s-all-events.kubernetes.event](./values.yaml#L145) | object | `{"message":"","reason":"","types":["create","delete","error"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
-| [sources.k8s-all-events.kubernetes.event.types](./values.yaml#L147) | list | `["create","delete","error"]` | Lists all event types to be watched. |
-| [sources.k8s-all-events.kubernetes.event.reason](./values.yaml#L152) | string | `""` | Optional regex to filter events by event reason. |
-| [sources.k8s-all-events.kubernetes.event.message](./values.yaml#L154) | string | `""` | Optional regex to filter events by message. If a given event has multiple messages, it is considered a match if any of the messages match the regex. |
-| [sources.k8s-all-events.kubernetes.annotations](./values.yaml#L157) | object | `{}` | Filters Kubernetes resources to watch by annotations. |
-| [sources.k8s-all-events.kubernetes.labels](./values.yaml#L159) | object | `{}` | Filters Kubernetes resources to watch by labels. |
-| [sources.k8s-all-events.kubernetes.resources](./values.yaml#L166) | list | See the `values.yaml` file for full object. | Describes the Kubernetes resources to watch. Resources are identified by its type in `{group}/{version}/{kind (plural)}` format. Examples: `apps/v1/deployments`, `v1/pods`. Each resource can override the namespaces and event configuration by using dedicated `event` and `namespaces` field. Also, each resource can specify its own `annotations`, `labels` and `name` regex. |
-| [sources.k8s-err-events.kubernetes](./values.yaml#L263) | object | See the `values.yaml` file for full object. | Describes Kubernetes source configuration. |
-| [sources.k8s-err-events.kubernetes.namespaces](./values.yaml#L267) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
-| [sources.k8s-err-events.kubernetes.event](./values.yaml#L271) | object | `{"types":["error"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
-| [sources.k8s-err-events.kubernetes.event.types](./values.yaml#L273) | list | `["error"]` | Lists all event types to be watched. |
-| [sources.k8s-err-events.kubernetes.resources](./values.yaml#L278) | list | See the `values.yaml` file for full object. | Describes the Kubernetes resources you want to watch. |
-| [sources.k8s-err-with-logs-events.kubernetes](./values.yaml#L300) | object | See the `values.yaml` file for full object. | Describes Kubernetes source configuration. |
-| [sources.k8s-err-with-logs-events.kubernetes.namespaces](./values.yaml#L304) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
-| [sources.k8s-err-with-logs-events.kubernetes.event](./values.yaml#L308) | object | `{"types":["error"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
-| [sources.k8s-err-with-logs-events.kubernetes.event.types](./values.yaml#L310) | list | `["error"]` | Lists all event types to be watched. |
-| [sources.k8s-err-with-logs-events.kubernetes.resources](./values.yaml#L315) | list | See the `values.yaml` file for full object. | Describes the Kubernetes resources you want to watch. |
-| [sources.k8s-create-events.kubernetes](./values.yaml#L328) | object | See the `values.yaml` file for full object. | Describes Kubernetes source configuration. |
-| [sources.k8s-create-events.kubernetes.namespaces](./values.yaml#L332) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
-| [sources.k8s-create-events.kubernetes.event](./values.yaml#L336) | object | `{"types":["create"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
-| [sources.k8s-create-events.kubernetes.event.types](./values.yaml#L338) | list | `["create"]` | Lists all event types to be watched. |
-| [sources.k8s-create-events.kubernetes.resources](./values.yaml#L343) | list | See the `values.yaml` file for full object. | Describes the Kubernetes resources you want to watch. |
-| [sources.prometheus.botkube/prometheus.enabled](./values.yaml#L360) | bool | `false` | If true, enables `prometheus` source. |
-| [sources.prometheus.botkube/prometheus.config.url](./values.yaml#L363) | string | `"http://localhost:9090"` | Prometheus endpoint without api version and resource. |
-| [sources.prometheus.botkube/prometheus.config.ignoreOldAlerts](./values.yaml#L365) | bool | `true` | If set as true, Prometheus source plugin will not send alerts that is created before plugin start time. |
-| [sources.prometheus.botkube/prometheus.config.alertStates](./values.yaml#L367) | list | `["firing","pending","inactive"]` | Only the alerts that have state provided in this config will be sent as notification. https://pkg.go.dev/github.com/prometheus/prometheus/rules#AlertState |
-| [sources.prometheus.botkube/prometheus.config.log](./values.yaml#L369) | object | `{"level":"info"}` | Logging configuration |
-| [sources.prometheus.botkube/prometheus.config.log.level](./values.yaml#L371) | string | `"info"` | Log level |
-| [filters](./values.yaml#L377) | object | See the `values.yaml` file for full object. | Filter settings for various sources. Currently, all filters are globally enabled or disabled. You can enable or disable filters with `@Botkube enable/disable filters` commands. |
-| [filters.kubernetes.objectAnnotationChecker](./values.yaml#L380) | bool | `true` | If true, enables support for `botkube.io/disable` and `botkube.io/channel` resource annotations. |
-| [filters.kubernetes.nodeEventsChecker](./values.yaml#L382) | bool | `true` | If true, filters out Node-related events that are not important. |
-| [executors](./values.yaml#L390) | object | See the `values.yaml` file for full object. | Map of executors. Executor contains configuration for running `kubectl` commands. The property name under `executors` is an alias for a given configuration. You can define multiple executor configurations with different names. Key name is used as a binding reference.   |
-| [executors.kubectl-read-only.kubectl.namespaces.include](./values.yaml#L398) | list | `[".*"]` | List of allowed Kubernetes Namespaces for command execution. It can also contain a regex expressions:  `- ".*"` - to specify all Namespaces. |
-| [executors.kubectl-read-only.kubectl.namespaces.exclude](./values.yaml#L403) | list | `[]` | List of ignored Kubernetes Namespace. It can also contain a regex expressions:  `- "test-.*"` - to specify all Namespaces. |
-| [executors.kubectl-read-only.kubectl.enabled](./values.yaml#L405) | bool | `false` | If true, enables `kubectl` commands execution. |
-| [executors.kubectl-read-only.kubectl.commands.verbs](./values.yaml#L409) | list | `["api-resources","api-versions","cluster-info","describe","explain","get","logs","top"]` | Configures which `kubectl` methods are allowed. |
-| [executors.kubectl-read-only.kubectl.commands.resources](./values.yaml#L411) | list | `["deployments","pods","namespaces","daemonsets","statefulsets","storageclasses","nodes","configmaps","services","ingresses"]` | Configures which K8s resource are allowed. |
-| [executors.kubectl-read-only.kubectl.defaultNamespace](./values.yaml#L413) | string | `"default"` | Configures the default Namespace for executing Botkube `kubectl` commands. If not set, uses the 'default'. |
-| [executors.kubectl-read-only.kubectl.restrictAccess](./values.yaml#L415) | bool | `false` | If true, enables commands execution from configured channel only. |
-| [executors.helm.botkube/helm.enabled](./values.yaml#L422) | bool | `false` | If true, enables `helm` commands execution. |
-| [executors.helm.botkube/helm.config.helmDriver](./values.yaml#L425) | string | `"secret"` | Allowed values are configmap, secret, memory. |
-| [executors.helm.botkube/helm.config.helmConfigDir](./values.yaml#L427) | string | `"/tmp/helm/"` | Location for storing Helm configuration. |
-| [executors.helm.botkube/helm.config.helmCacheDir](./values.yaml#L429) | string | `"/tmp/helm/.cache"` | Location for storing cached files. Must be under the Helm config directory. |
-| [aliases](./values.yaml#L437) | object | See the `values.yaml` file for full object. | Custom aliases for given commands. The aliases are replaced with the underlying command before executing it. Aliases can replace a single word or multiple ones. For example, you can define a `k` alias for `kubectl`, or `kgp` for `kubectl get pods`.   |
-| [existingCommunicationsSecretName](./values.yaml#L457) | string | `""` | Configures existing Secret with communication settings. It MUST be in the `botkube` Namespace. To reload Botkube once it changes, add label `botkube.io/config-watch: "true"`.  |
-| [communications](./values.yaml#L464) | object | See the `values.yaml` file for full object. | Map of communication groups. Communication group contains settings for multiple communication platforms. The property name under `communications` object is an alias for a given configuration group. You can define multiple communication groups with different names.   |
-| [communications.default-group.socketSlack.enabled](./values.yaml#L469) | bool | `false` | If true, enables Slack bot. |
-| [communications.default-group.socketSlack.channels](./values.yaml#L473) | object | `{"default":{"bindings":{"executors":["kubectl-read-only","helm"],"sources":["k8s-err-events","k8s-recommendation-events"]},"name":"SLACK_CHANNEL"}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
-| [communications.default-group.socketSlack.channels.default.name](./values.yaml#L476) | string | `"SLACK_CHANNEL"` | Slack channel name without '#' prefix where you have added Botkube and want to receive notifications in. |
-| [communications.default-group.socketSlack.channels.default.bindings.executors](./values.yaml#L479) | list | `["kubectl-read-only","helm"]` | Executors configuration for a given channel. |
-| [communications.default-group.socketSlack.channels.default.bindings.sources](./values.yaml#L483) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given channel. |
-| [communications.default-group.socketSlack.botToken](./values.yaml#L488) | string | `""` | Slack bot token for your own Slack app. [Ref doc](https://api.slack.com/authentication/token-types). |
-| [communications.default-group.socketSlack.appToken](./values.yaml#L491) | string | `""` | Slack app-level token for your own Slack app. [Ref doc](https://api.slack.com/authentication/token-types). |
-| [communications.default-group.socketSlack.notification.type](./values.yaml#L494) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
-| [communications.default-group.mattermost.enabled](./values.yaml#L498) | bool | `false` | If true, enables Mattermost bot. |
-| [communications.default-group.mattermost.botName](./values.yaml#L500) | string | `"Botkube"` | User in Mattermost which belongs the specified Personal Access token. |
-| [communications.default-group.mattermost.url](./values.yaml#L502) | string | `"MATTERMOST_SERVER_URL"` | The URL (including http/https schema) where Mattermost is running. e.g https://example.com:9243 |
-| [communications.default-group.mattermost.token](./values.yaml#L504) | string | `"MATTERMOST_TOKEN"` | Personal Access token generated by Botkube user. |
-| [communications.default-group.mattermost.team](./values.yaml#L506) | string | `"MATTERMOST_TEAM"` | The Mattermost Team name where Botkube is added. |
-| [communications.default-group.mattermost.channels](./values.yaml#L510) | object | `{"default":{"bindings":{"executors":["kubectl-read-only","helm"],"sources":["k8s-err-events","k8s-recommendation-events"]},"name":"MATTERMOST_CHANNEL","notification":{"disabled":false}}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
-| [communications.default-group.mattermost.channels.default.name](./values.yaml#L514) | string | `"MATTERMOST_CHANNEL"` | The Mattermost channel name for receiving Botkube alerts. The Botkube user needs to be added to it. |
-| [communications.default-group.mattermost.channels.default.notification.disabled](./values.yaml#L517) | bool | `false` | If true, the notifications are not sent to the channel. They can be enabled with `@Botkube` command anytime. |
-| [communications.default-group.mattermost.channels.default.bindings.executors](./values.yaml#L520) | list | `["kubectl-read-only","helm"]` | Executors configuration for a given channel. |
-| [communications.default-group.mattermost.channels.default.bindings.sources](./values.yaml#L524) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given channel. |
-| [communications.default-group.mattermost.notification.type](./values.yaml#L529) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
-| [communications.default-group.teams.enabled](./values.yaml#L534) | bool | `false` | If true, enables MS Teams bot. |
-| [communications.default-group.teams.botName](./values.yaml#L536) | string | `"Botkube"` | The Bot name set while registering Bot to MS Teams. |
-| [communications.default-group.teams.appID](./values.yaml#L538) | string | `"APPLICATION_ID"` | The Botkube application ID generated while registering Bot to MS Teams. |
-| [communications.default-group.teams.appPassword](./values.yaml#L540) | string | `"APPLICATION_PASSWORD"` | The Botkube application password generated while registering Bot to MS Teams. |
-| [communications.default-group.teams.bindings.executors](./values.yaml#L543) | list | `["kubectl-read-only","helm"]` | Executor bindings apply to all MS Teams channels where Botkube has access to. |
-| [communications.default-group.teams.bindings.sources](./values.yaml#L547) | list | `["k8s-err-events","k8s-recommendation-events"]` | Source bindings apply to all channels which have notification turned on with `@Botkube enable notifications` command. |
-| [communications.default-group.teams.messagePath](./values.yaml#L551) | string | `"/bots/teams"` | The path in endpoint URL provided while registering Botkube to MS Teams. |
-| [communications.default-group.teams.port](./values.yaml#L553) | int | `3978` | The Service port for bot endpoint on Botkube container. |
-| [communications.default-group.discord.enabled](./values.yaml#L558) | bool | `false` | If true, enables Discord bot. |
-| [communications.default-group.discord.token](./values.yaml#L560) | string | `"DISCORD_TOKEN"` | Botkube Bot Token. |
-| [communications.default-group.discord.botID](./values.yaml#L562) | string | `"DISCORD_BOT_ID"` | Botkube Application Client ID. |
-| [communications.default-group.discord.channels](./values.yaml#L566) | object | `{"default":{"bindings":{"executors":["kubectl-read-only","helm"],"sources":["k8s-err-events","k8s-recommendation-events"]},"id":"DISCORD_CHANNEL_ID","notification":{"disabled":false}}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
-| [communications.default-group.discord.channels.default.id](./values.yaml#L570) | string | `"DISCORD_CHANNEL_ID"` | Discord channel ID for receiving Botkube alerts. The Botkube user needs to be added to it. |
-| [communications.default-group.discord.channels.default.notification.disabled](./values.yaml#L573) | bool | `false` | If true, the notifications are not sent to the channel. They can be enabled with `@Botkube` command anytime. |
-| [communications.default-group.discord.channels.default.bindings.executors](./values.yaml#L576) | list | `["kubectl-read-only","helm"]` | Executors configuration for a given channel. |
-| [communications.default-group.discord.channels.default.bindings.sources](./values.yaml#L580) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given channel. |
-| [communications.default-group.discord.notification.type](./values.yaml#L585) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
-| [communications.default-group.elasticsearch.enabled](./values.yaml#L590) | bool | `false` | If true, enables Elasticsearch. |
-| [communications.default-group.elasticsearch.awsSigning.enabled](./values.yaml#L594) | bool | `false` | If true, enables awsSigning using IAM for Elasticsearch hosted on AWS. Make sure AWS environment variables are set. [Ref doc](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html). |
-| [communications.default-group.elasticsearch.awsSigning.awsRegion](./values.yaml#L596) | string | `"us-east-1"` | AWS region where Elasticsearch is deployed. |
-| [communications.default-group.elasticsearch.awsSigning.roleArn](./values.yaml#L598) | string | `""` | AWS IAM Role arn to assume for credentials, use this only if you don't want to use the EC2 instance role or not running on AWS instance. |
-| [communications.default-group.elasticsearch.server](./values.yaml#L600) | string | `"ELASTICSEARCH_ADDRESS"` | The server URL, e.g https://example.com:9243 |
-| [communications.default-group.elasticsearch.username](./values.yaml#L602) | string | `"ELASTICSEARCH_USERNAME"` | Basic Auth username. |
-| [communications.default-group.elasticsearch.password](./values.yaml#L604) | string | `"ELASTICSEARCH_PASSWORD"` | Basic Auth password. |
-| [communications.default-group.elasticsearch.skipTLSVerify](./values.yaml#L607) | bool | `false` | If true, skips the verification of TLS certificate of the Elastic nodes. It's useful for clusters with self-signed certificates. |
-| [communications.default-group.elasticsearch.indices](./values.yaml#L611) | object | `{"default":{"bindings":{"sources":["k8s-err-events","k8s-recommendation-events"]},"name":"botkube","replicas":0,"shards":1,"type":"botkube-event"}}` | Map of configured indices. The `indices` property name is an alias for a given configuration.   |
-| [communications.default-group.elasticsearch.indices.default.name](./values.yaml#L614) | string | `"botkube"` | Configures Elasticsearch index settings. |
-| [communications.default-group.elasticsearch.indices.default.bindings.sources](./values.yaml#L620) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given index. |
-| [communications.default-group.webhook.enabled](./values.yaml#L627) | bool | `false` | If true, enables Webhook. |
-| [communications.default-group.webhook.url](./values.yaml#L629) | string | `"WEBHOOK_URL"` | The Webhook URL, e.g.: https://example.com:80 |
-| [communications.default-group.webhook.bindings.sources](./values.yaml#L632) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for the webhook. |
-| [communications.default-group.slack](./values.yaml#L642) | object | See the `values.yaml` file for full object. | Settings for deprecated Slack integration. **DEPRECATED:** Legacy Slack integration has been deprecated and removed from the Slack App Directory. Use `socketSlack` instead. Read more here: https://docs.botkube.io/installation/slack/   |
-| [settings.clusterName](./values.yaml#L663) | string | `"not-configured"` | Cluster name to differentiate incoming messages. |
-| [settings.lifecycleServer](./values.yaml#L666) | object | `{"enabled":true,"port":2113}` | Server configuration which exposes functionality related to the app lifecycle. |
-| [settings.healthPort](./values.yaml#L669) | int | `2114` |  |
-| [settings.upgradeNotifier](./values.yaml#L671) | bool | `true` | If true, notifies about new Botkube releases. |
-| [settings.log.level](./values.yaml#L675) | string | `"info"` | Sets one of the log levels. Allowed values: `info`, `warn`, `debug`, `error`, `fatal`, `panic`. |
-| [settings.log.disableColors](./values.yaml#L677) | bool | `false` | If true, disable ANSI colors in logging. |
-| [settings.systemConfigMap](./values.yaml#L680) | object | `{"name":"botkube-system"}` | Botkube's system ConfigMap where internal data is stored. |
-| [settings.persistentConfig](./values.yaml#L685) | object | `{"runtime":{"configMap":{"annotations":{},"name":"botkube-runtime-config"},"fileName":"_runtime_state.yaml"},"startup":{"configMap":{"annotations":{},"name":"botkube-startup-config"},"fileName":"_startup_state.yaml"}}` | Persistent config contains ConfigMap where persisted configuration is stored. The persistent configuration is evaluated from both chart upgrade and Botkube commands used in runtime. |
-| [ssl.enabled](./values.yaml#L700) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
-| [ssl.existingSecretName](./values.yaml#L706) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
-| [ssl.cert](./values.yaml#L709) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
-| [service](./values.yaml#L712) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
-| [ingress](./values.yaml#L719) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
-| [serviceMonitor](./values.yaml#L730) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
-| [deployment.annotations](./values.yaml#L740) | object | `{}` | Extra annotations to pass to the Botkube Deployment. |
-| [extraAnnotations](./values.yaml#L747) | object | `{}` | Extra annotations to pass to the Botkube Pod. |
-| [extraLabels](./values.yaml#L749) | object | `{}` | Extra labels to pass to the Botkube Pod. |
-| [priorityClassName](./values.yaml#L751) | string | `""` | Priority class name for the Botkube Pod. |
-| [nameOverride](./values.yaml#L754) | string | `""` | Fully override "botkube.name" template. |
-| [fullnameOverride](./values.yaml#L756) | string | `""` | Fully override "botkube.fullname" template. |
-| [resources](./values.yaml#L762) | object | `{}` | The Botkube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
-| [extraEnv](./values.yaml#L774) | list | `[]` | Extra environment variables to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
-| [extraVolumes](./values.yaml#L786) | list | `[]` | Extra volumes to pass to the Botkube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
-| [extraVolumeMounts](./values.yaml#L801) | list | `[]` | Extra volume mounts to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
-| [nodeSelector](./values.yaml#L819) | object | `{}` | Node labels for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
-| [tolerations](./values.yaml#L823) | list | `[]` | Tolerations for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
-| [affinity](./values.yaml#L827) | object | `{}` | Affinity for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
-| [rbac](./values.yaml#L831) | object | `{"create":true,"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["get","watch","list"]}]}` | Role Based Access for Botkube Pod. [Ref doc](https://kubernetes.io/docs/admin/authorization/rbac/). |
-| [serviceAccount.create](./values.yaml#L840) | bool | `true` | If true, a ServiceAccount is automatically created. |
-| [serviceAccount.name](./values.yaml#L843) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
-| [serviceAccount.annotations](./values.yaml#L845) | object | `{}` | Extra annotations for the ServiceAccount. |
-| [extraObjects](./values.yaml#L848) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
-| [analytics.disable](./values.yaml#L876) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://docs.botkube.io/privacy#privacy-policy). |
-| [configWatcher.enabled](./values.yaml#L881) | bool | `true` | If true, restarts the Botkube Pod on config changes. |
-| [configWatcher.tmpDir](./values.yaml#L883) | string | `"/tmp/watched-cfg/"` | Directory, where watched configuration resources are stored. |
-| [configWatcher.initialSyncTimeout](./values.yaml#L886) | int | `0` | Timeout for the initial Config Watcher sync. If set to 0, waiting for Config Watcher sync will be skipped. In a result, configuration changes may not reload Botkube app during the first few seconds after Botkube startup. |
-| [configWatcher.image.registry](./values.yaml#L889) | string | `"ghcr.io"` | Config watcher image registry. |
-| [configWatcher.image.repository](./values.yaml#L891) | string | `"kubeshop/k8s-sidecar"` | Config watcher image repository. |
-| [configWatcher.image.tag](./values.yaml#L893) | string | `"ignore-initial-events"` | Config watcher image tag. |
-| [configWatcher.image.pullPolicy](./values.yaml#L895) | string | `"IfNotPresent"` | Config watcher image pull policy. |
-| [plugins](./values.yaml#L898) | object | `{"cacheDir":"/tmp","repositories":{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}}` | Configuration for Botkube executors and sources plugins. |
-| [plugins.cacheDir](./values.yaml#L900) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
-| [plugins.repositories](./values.yaml#L902) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}` | List of plugins repositories. |
-| [plugins.repositories.botkube](./values.yaml#L904) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
-| [config](./values.yaml#L908) | object | `{"provider":{"endpoint":"","identifier":""}}` | Configuration for remote Botkube settings |
-| [config.provider](./values.yaml#L910) | object | `{"endpoint":"","identifier":""}` | Base provider definition |
-| [config.provider.identifier](./values.yaml#L912) | string | `""` | Unique identifier for remote Botkube settings |
-| [config.provider.endpoint](./values.yaml#L914) | string | `""` | Endpoint to fetch Botkube settings from |
+| [sources.k8s-err-events.kubernetes.namespaces.include](./values.yaml#L136) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [sources.k8s-all-events.kubernetes.namespaces.include](./values.yaml#L136) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [sources.k8s-create-events.kubernetes.namespaces.include](./values.yaml#L136) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [sources.k8s-err-with-logs-events.kubernetes.namespaces.include](./values.yaml#L136) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [sources.k8s-all-events.kubernetes.event](./values.yaml#L146) | object | `{"message":{"exclude":[],"include":[]},"reason":{"exclude":[],"include":[]},"types":["create","delete","error"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
+| [sources.k8s-all-events.kubernetes.event.types](./values.yaml#L148) | list | `["create","delete","error"]` | Lists all event types to be watched. |
+| [sources.k8s-all-events.kubernetes.event.reason](./values.yaml#L154) | object | `{"exclude":[],"include":[]}` | Optional list of exact values or regex patterns to filter events by event reason. Skipped, if both include/exclude lists are empty. |
+| [sources.k8s-all-events.kubernetes.event.reason.include](./values.yaml#L156) | list | `[]` | Include contains a list of allowed values. It can also contain regex expressions. |
+| [sources.k8s-all-events.kubernetes.event.reason.exclude](./values.yaml#L159) | list | `[]` | Exclude contains a list of values to be ignored even if allowed by Include. It can also contain regex expressions. Exclude list is checked before the Include list. |
+| [sources.k8s-all-events.kubernetes.event.message](./values.yaml#L162) | object | `{"exclude":[],"include":[]}` | Optional list of exact values or regex patterns to filter event by event message. Skipped, if both include/exclude lists are empty. If a given event has multiple messages, it is considered a match if any of the messages match the constraints. |
+| [sources.k8s-all-events.kubernetes.event.message.include](./values.yaml#L164) | list | `[]` | Include contains a list of allowed values. It can also contain regex expressions. |
+| [sources.k8s-all-events.kubernetes.event.message.exclude](./values.yaml#L167) | list | `[]` | Exclude contains a list of values to be ignored even if allowed by Include. It can also contain regex expressions. Exclude list is checked before the Include list. |
+| [sources.k8s-all-events.kubernetes.annotations](./values.yaml#L171) | object | `{}` | Filters Kubernetes resources to watch by annotations. Each resource needs to have all the specified annotations. Regex expressions are not supported. |
+| [sources.k8s-all-events.kubernetes.labels](./values.yaml#L174) | object | `{}` | Filters Kubernetes resources to watch by labels. Each resource needs to have all the specified labels. Regex expressions are not supported. |
+| [sources.k8s-all-events.kubernetes.resources](./values.yaml#L181) | list | See the `values.yaml` file for full object. | Describes the Kubernetes resources to watch. Resources are identified by its type in `{group}/{version}/{kind (plural)}` format. Examples: `apps/v1/deployments`, `v1/pods`. Each resource can override the namespaces and event configuration by using dedicated `event` and `namespaces` field. Also, each resource can specify its own `annotations`, `labels` and `name` regex. |
+| [sources.k8s-err-events.kubernetes](./values.yaml#L291) | object | See the `values.yaml` file for full object. | Describes Kubernetes source configuration. |
+| [sources.k8s-err-events.kubernetes.namespaces](./values.yaml#L295) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
+| [sources.k8s-err-events.kubernetes.event](./values.yaml#L299) | object | `{"types":["error"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
+| [sources.k8s-err-events.kubernetes.event.types](./values.yaml#L301) | list | `["error"]` | Lists all event types to be watched. |
+| [sources.k8s-err-events.kubernetes.resources](./values.yaml#L306) | list | See the `values.yaml` file for full object. | Describes the Kubernetes resources you want to watch. |
+| [sources.k8s-err-with-logs-events.kubernetes](./values.yaml#L328) | object | See the `values.yaml` file for full object. | Describes Kubernetes source configuration. |
+| [sources.k8s-err-with-logs-events.kubernetes.namespaces](./values.yaml#L332) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
+| [sources.k8s-err-with-logs-events.kubernetes.event](./values.yaml#L336) | object | `{"types":["error"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
+| [sources.k8s-err-with-logs-events.kubernetes.event.types](./values.yaml#L338) | list | `["error"]` | Lists all event types to be watched. |
+| [sources.k8s-err-with-logs-events.kubernetes.resources](./values.yaml#L343) | list | See the `values.yaml` file for full object. | Describes the Kubernetes resources you want to watch. |
+| [sources.k8s-create-events.kubernetes](./values.yaml#L356) | object | See the `values.yaml` file for full object. | Describes Kubernetes source configuration. |
+| [sources.k8s-create-events.kubernetes.namespaces](./values.yaml#L360) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
+| [sources.k8s-create-events.kubernetes.event](./values.yaml#L364) | object | `{"types":["create"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
+| [sources.k8s-create-events.kubernetes.event.types](./values.yaml#L366) | list | `["create"]` | Lists all event types to be watched. |
+| [sources.k8s-create-events.kubernetes.resources](./values.yaml#L371) | list | See the `values.yaml` file for full object. | Describes the Kubernetes resources you want to watch. |
+| [sources.prometheus.botkube/prometheus.enabled](./values.yaml#L388) | bool | `false` | If true, enables `prometheus` source. |
+| [sources.prometheus.botkube/prometheus.config.url](./values.yaml#L391) | string | `"http://localhost:9090"` | Prometheus endpoint without api version and resource. |
+| [sources.prometheus.botkube/prometheus.config.ignoreOldAlerts](./values.yaml#L393) | bool | `true` | If set as true, Prometheus source plugin will not send alerts that is created before plugin start time. |
+| [sources.prometheus.botkube/prometheus.config.alertStates](./values.yaml#L395) | list | `["firing","pending","inactive"]` | Only the alerts that have state provided in this config will be sent as notification. https://pkg.go.dev/github.com/prometheus/prometheus/rules#AlertState |
+| [sources.prometheus.botkube/prometheus.config.log](./values.yaml#L397) | object | `{"level":"info"}` | Logging configuration |
+| [sources.prometheus.botkube/prometheus.config.log.level](./values.yaml#L399) | string | `"info"` | Log level |
+| [filters](./values.yaml#L405) | object | See the `values.yaml` file for full object. | Filter settings for various sources. Currently, all filters are globally enabled or disabled. You can enable or disable filters with `@Botkube enable/disable filters` commands. |
+| [filters.kubernetes.objectAnnotationChecker](./values.yaml#L408) | bool | `true` | If true, enables support for `botkube.io/disable` and `botkube.io/channel` resource annotations. |
+| [filters.kubernetes.nodeEventsChecker](./values.yaml#L410) | bool | `true` | If true, filters out Node-related events that are not important. |
+| [executors](./values.yaml#L418) | object | See the `values.yaml` file for full object. | Map of executors. Executor contains configuration for running `kubectl` commands. The property name under `executors` is an alias for a given configuration. You can define multiple executor configurations with different names. Key name is used as a binding reference.   |
+| [executors.kubectl-read-only.kubectl.namespaces.include](./values.yaml#L426) | list | `[".*"]` | List of allowed Kubernetes Namespaces for command execution. It can also contain a regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [executors.kubectl-read-only.kubectl.namespaces.exclude](./values.yaml#L431) | list | `[]` | List of ignored Kubernetes Namespace. It can also contain a regex expressions:  `- "test-.*"` - to specify all Namespaces. |
+| [executors.kubectl-read-only.kubectl.enabled](./values.yaml#L433) | bool | `false` | If true, enables `kubectl` commands execution. |
+| [executors.kubectl-read-only.kubectl.commands.verbs](./values.yaml#L437) | list | `["api-resources","api-versions","cluster-info","describe","explain","get","logs","top"]` | Configures which `kubectl` methods are allowed. |
+| [executors.kubectl-read-only.kubectl.commands.resources](./values.yaml#L439) | list | `["deployments","pods","namespaces","daemonsets","statefulsets","storageclasses","nodes","configmaps","services","ingresses"]` | Configures which K8s resource are allowed. |
+| [executors.kubectl-read-only.kubectl.defaultNamespace](./values.yaml#L441) | string | `"default"` | Configures the default Namespace for executing Botkube `kubectl` commands. If not set, uses the 'default'. |
+| [executors.kubectl-read-only.kubectl.restrictAccess](./values.yaml#L443) | bool | `false` | If true, enables commands execution from configured channel only. |
+| [executors.helm.botkube/helm.enabled](./values.yaml#L450) | bool | `false` | If true, enables `helm` commands execution. |
+| [executors.helm.botkube/helm.config.helmDriver](./values.yaml#L453) | string | `"secret"` | Allowed values are configmap, secret, memory. |
+| [executors.helm.botkube/helm.config.helmConfigDir](./values.yaml#L455) | string | `"/tmp/helm/"` | Location for storing Helm configuration. |
+| [executors.helm.botkube/helm.config.helmCacheDir](./values.yaml#L457) | string | `"/tmp/helm/.cache"` | Location for storing cached files. Must be under the Helm config directory. |
+| [aliases](./values.yaml#L465) | object | See the `values.yaml` file for full object. | Custom aliases for given commands. The aliases are replaced with the underlying command before executing it. Aliases can replace a single word or multiple ones. For example, you can define a `k` alias for `kubectl`, or `kgp` for `kubectl get pods`.   |
+| [existingCommunicationsSecretName](./values.yaml#L485) | string | `""` | Configures existing Secret with communication settings. It MUST be in the `botkube` Namespace. To reload Botkube once it changes, add label `botkube.io/config-watch: "true"`.  |
+| [communications](./values.yaml#L492) | object | See the `values.yaml` file for full object. | Map of communication groups. Communication group contains settings for multiple communication platforms. The property name under `communications` object is an alias for a given configuration group. You can define multiple communication groups with different names.   |
+| [communications.default-group.socketSlack.enabled](./values.yaml#L497) | bool | `false` | If true, enables Slack bot. |
+| [communications.default-group.socketSlack.channels](./values.yaml#L501) | object | `{"default":{"bindings":{"executors":["kubectl-read-only","helm"],"sources":["k8s-err-events","k8s-recommendation-events"]},"name":"SLACK_CHANNEL"}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
+| [communications.default-group.socketSlack.channels.default.name](./values.yaml#L504) | string | `"SLACK_CHANNEL"` | Slack channel name without '#' prefix where you have added Botkube and want to receive notifications in. |
+| [communications.default-group.socketSlack.channels.default.bindings.executors](./values.yaml#L507) | list | `["kubectl-read-only","helm"]` | Executors configuration for a given channel. |
+| [communications.default-group.socketSlack.channels.default.bindings.sources](./values.yaml#L511) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given channel. |
+| [communications.default-group.socketSlack.botToken](./values.yaml#L516) | string | `""` | Slack bot token for your own Slack app. [Ref doc](https://api.slack.com/authentication/token-types). |
+| [communications.default-group.socketSlack.appToken](./values.yaml#L519) | string | `""` | Slack app-level token for your own Slack app. [Ref doc](https://api.slack.com/authentication/token-types). |
+| [communications.default-group.socketSlack.notification.type](./values.yaml#L522) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
+| [communications.default-group.mattermost.enabled](./values.yaml#L526) | bool | `false` | If true, enables Mattermost bot. |
+| [communications.default-group.mattermost.botName](./values.yaml#L528) | string | `"Botkube"` | User in Mattermost which belongs the specified Personal Access token. |
+| [communications.default-group.mattermost.url](./values.yaml#L530) | string | `"MATTERMOST_SERVER_URL"` | The URL (including http/https schema) where Mattermost is running. e.g https://example.com:9243 |
+| [communications.default-group.mattermost.token](./values.yaml#L532) | string | `"MATTERMOST_TOKEN"` | Personal Access token generated by Botkube user. |
+| [communications.default-group.mattermost.team](./values.yaml#L534) | string | `"MATTERMOST_TEAM"` | The Mattermost Team name where Botkube is added. |
+| [communications.default-group.mattermost.channels](./values.yaml#L538) | object | `{"default":{"bindings":{"executors":["kubectl-read-only","helm"],"sources":["k8s-err-events","k8s-recommendation-events"]},"name":"MATTERMOST_CHANNEL","notification":{"disabled":false}}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
+| [communications.default-group.mattermost.channels.default.name](./values.yaml#L542) | string | `"MATTERMOST_CHANNEL"` | The Mattermost channel name for receiving Botkube alerts. The Botkube user needs to be added to it. |
+| [communications.default-group.mattermost.channels.default.notification.disabled](./values.yaml#L545) | bool | `false` | If true, the notifications are not sent to the channel. They can be enabled with `@Botkube` command anytime. |
+| [communications.default-group.mattermost.channels.default.bindings.executors](./values.yaml#L548) | list | `["kubectl-read-only","helm"]` | Executors configuration for a given channel. |
+| [communications.default-group.mattermost.channels.default.bindings.sources](./values.yaml#L552) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given channel. |
+| [communications.default-group.mattermost.notification.type](./values.yaml#L557) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
+| [communications.default-group.teams.enabled](./values.yaml#L562) | bool | `false` | If true, enables MS Teams bot. |
+| [communications.default-group.teams.botName](./values.yaml#L564) | string | `"Botkube"` | The Bot name set while registering Bot to MS Teams. |
+| [communications.default-group.teams.appID](./values.yaml#L566) | string | `"APPLICATION_ID"` | The Botkube application ID generated while registering Bot to MS Teams. |
+| [communications.default-group.teams.appPassword](./values.yaml#L568) | string | `"APPLICATION_PASSWORD"` | The Botkube application password generated while registering Bot to MS Teams. |
+| [communications.default-group.teams.bindings.executors](./values.yaml#L571) | list | `["kubectl-read-only","helm"]` | Executor bindings apply to all MS Teams channels where Botkube has access to. |
+| [communications.default-group.teams.bindings.sources](./values.yaml#L575) | list | `["k8s-err-events","k8s-recommendation-events"]` | Source bindings apply to all channels which have notification turned on with `@Botkube enable notifications` command. |
+| [communications.default-group.teams.messagePath](./values.yaml#L579) | string | `"/bots/teams"` | The path in endpoint URL provided while registering Botkube to MS Teams. |
+| [communications.default-group.teams.port](./values.yaml#L581) | int | `3978` | The Service port for bot endpoint on Botkube container. |
+| [communications.default-group.discord.enabled](./values.yaml#L586) | bool | `false` | If true, enables Discord bot. |
+| [communications.default-group.discord.token](./values.yaml#L588) | string | `"DISCORD_TOKEN"` | Botkube Bot Token. |
+| [communications.default-group.discord.botID](./values.yaml#L590) | string | `"DISCORD_BOT_ID"` | Botkube Application Client ID. |
+| [communications.default-group.discord.channels](./values.yaml#L594) | object | `{"default":{"bindings":{"executors":["kubectl-read-only","helm"],"sources":["k8s-err-events","k8s-recommendation-events"]},"id":"DISCORD_CHANNEL_ID","notification":{"disabled":false}}}` | Map of configured channels. The property name under `channels` object is an alias for a given configuration.   |
+| [communications.default-group.discord.channels.default.id](./values.yaml#L598) | string | `"DISCORD_CHANNEL_ID"` | Discord channel ID for receiving Botkube alerts. The Botkube user needs to be added to it. |
+| [communications.default-group.discord.channels.default.notification.disabled](./values.yaml#L601) | bool | `false` | If true, the notifications are not sent to the channel. They can be enabled with `@Botkube` command anytime. |
+| [communications.default-group.discord.channels.default.bindings.executors](./values.yaml#L604) | list | `["kubectl-read-only","helm"]` | Executors configuration for a given channel. |
+| [communications.default-group.discord.channels.default.bindings.sources](./values.yaml#L608) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given channel. |
+| [communications.default-group.discord.notification.type](./values.yaml#L613) | string | `"short"` | Configures notification type that are sent. Possible values: `short`, `long`. |
+| [communications.default-group.elasticsearch.enabled](./values.yaml#L618) | bool | `false` | If true, enables Elasticsearch. |
+| [communications.default-group.elasticsearch.awsSigning.enabled](./values.yaml#L622) | bool | `false` | If true, enables awsSigning using IAM for Elasticsearch hosted on AWS. Make sure AWS environment variables are set. [Ref doc](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html). |
+| [communications.default-group.elasticsearch.awsSigning.awsRegion](./values.yaml#L624) | string | `"us-east-1"` | AWS region where Elasticsearch is deployed. |
+| [communications.default-group.elasticsearch.awsSigning.roleArn](./values.yaml#L626) | string | `""` | AWS IAM Role arn to assume for credentials, use this only if you don't want to use the EC2 instance role or not running on AWS instance. |
+| [communications.default-group.elasticsearch.server](./values.yaml#L628) | string | `"ELASTICSEARCH_ADDRESS"` | The server URL, e.g https://example.com:9243 |
+| [communications.default-group.elasticsearch.username](./values.yaml#L630) | string | `"ELASTICSEARCH_USERNAME"` | Basic Auth username. |
+| [communications.default-group.elasticsearch.password](./values.yaml#L632) | string | `"ELASTICSEARCH_PASSWORD"` | Basic Auth password. |
+| [communications.default-group.elasticsearch.skipTLSVerify](./values.yaml#L635) | bool | `false` | If true, skips the verification of TLS certificate of the Elastic nodes. It's useful for clusters with self-signed certificates. |
+| [communications.default-group.elasticsearch.indices](./values.yaml#L639) | object | `{"default":{"bindings":{"sources":["k8s-err-events","k8s-recommendation-events"]},"name":"botkube","replicas":0,"shards":1,"type":"botkube-event"}}` | Map of configured indices. The `indices` property name is an alias for a given configuration.   |
+| [communications.default-group.elasticsearch.indices.default.name](./values.yaml#L642) | string | `"botkube"` | Configures Elasticsearch index settings. |
+| [communications.default-group.elasticsearch.indices.default.bindings.sources](./values.yaml#L648) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for a given index. |
+| [communications.default-group.webhook.enabled](./values.yaml#L655) | bool | `false` | If true, enables Webhook. |
+| [communications.default-group.webhook.url](./values.yaml#L657) | string | `"WEBHOOK_URL"` | The Webhook URL, e.g.: https://example.com:80 |
+| [communications.default-group.webhook.bindings.sources](./values.yaml#L660) | list | `["k8s-err-events","k8s-recommendation-events"]` | Notification sources configuration for the webhook. |
+| [communications.default-group.slack](./values.yaml#L670) | object | See the `values.yaml` file for full object. | Settings for deprecated Slack integration. **DEPRECATED:** Legacy Slack integration has been deprecated and removed from the Slack App Directory. Use `socketSlack` instead. Read more here: https://docs.botkube.io/installation/slack/   |
+| [settings.clusterName](./values.yaml#L691) | string | `"not-configured"` | Cluster name to differentiate incoming messages. |
+| [settings.lifecycleServer](./values.yaml#L694) | object | `{"enabled":true,"port":2113}` | Server configuration which exposes functionality related to the app lifecycle. |
+| [settings.healthPort](./values.yaml#L697) | int | `2114` |  |
+| [settings.upgradeNotifier](./values.yaml#L699) | bool | `true` | If true, notifies about new Botkube releases. |
+| [settings.log.level](./values.yaml#L703) | string | `"info"` | Sets one of the log levels. Allowed values: `info`, `warn`, `debug`, `error`, `fatal`, `panic`. |
+| [settings.log.disableColors](./values.yaml#L705) | bool | `false` | If true, disable ANSI colors in logging. |
+| [settings.systemConfigMap](./values.yaml#L708) | object | `{"name":"botkube-system"}` | Botkube's system ConfigMap where internal data is stored. |
+| [settings.persistentConfig](./values.yaml#L713) | object | `{"runtime":{"configMap":{"annotations":{},"name":"botkube-runtime-config"},"fileName":"_runtime_state.yaml"},"startup":{"configMap":{"annotations":{},"name":"botkube-startup-config"},"fileName":"_startup_state.yaml"}}` | Persistent config contains ConfigMap where persisted configuration is stored. The persistent configuration is evaluated from both chart upgrade and Botkube commands used in runtime. |
+| [ssl.enabled](./values.yaml#L728) | bool | `false` | If true, specify cert path in `config.ssl.cert` property or K8s Secret in `config.ssl.existingSecretName`. |
+| [ssl.existingSecretName](./values.yaml#L734) | string | `""` | Using existing SSL Secret. It MUST be in `botkube` Namespace.  |
+| [ssl.cert](./values.yaml#L737) | string | `""` | SSL Certificate file e.g certs/my-cert.crt. |
+| [service](./values.yaml#L740) | object | `{"name":"metrics","port":2112,"targetPort":2112}` | Configures Service settings for ServiceMonitor CR. |
+| [ingress](./values.yaml#L747) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
+| [serviceMonitor](./values.yaml#L758) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
+| [deployment.annotations](./values.yaml#L768) | object | `{}` | Extra annotations to pass to the Botkube Deployment. |
+| [extraAnnotations](./values.yaml#L775) | object | `{}` | Extra annotations to pass to the Botkube Pod. |
+| [extraLabels](./values.yaml#L777) | object | `{}` | Extra labels to pass to the Botkube Pod. |
+| [priorityClassName](./values.yaml#L779) | string | `""` | Priority class name for the Botkube Pod. |
+| [nameOverride](./values.yaml#L782) | string | `""` | Fully override "botkube.name" template. |
+| [fullnameOverride](./values.yaml#L784) | string | `""` | Fully override "botkube.fullname" template. |
+| [resources](./values.yaml#L790) | object | `{}` | The Botkube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
+| [extraEnv](./values.yaml#L802) | list | `[]` | Extra environment variables to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
+| [extraVolumes](./values.yaml#L814) | list | `[]` | Extra volumes to pass to the Botkube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
+| [extraVolumeMounts](./values.yaml#L829) | list | `[]` | Extra volume mounts to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
+| [nodeSelector](./values.yaml#L847) | object | `{}` | Node labels for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
+| [tolerations](./values.yaml#L851) | list | `[]` | Tolerations for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
+| [affinity](./values.yaml#L855) | object | `{}` | Affinity for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
+| [rbac](./values.yaml#L859) | object | `{"create":true,"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["get","watch","list"]}]}` | Role Based Access for Botkube Pod. [Ref doc](https://kubernetes.io/docs/admin/authorization/rbac/). |
+| [serviceAccount.create](./values.yaml#L868) | bool | `true` | If true, a ServiceAccount is automatically created. |
+| [serviceAccount.name](./values.yaml#L871) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
+| [serviceAccount.annotations](./values.yaml#L873) | object | `{}` | Extra annotations for the ServiceAccount. |
+| [extraObjects](./values.yaml#L876) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
+| [analytics.disable](./values.yaml#L904) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://docs.botkube.io/privacy#privacy-policy). |
+| [configWatcher.enabled](./values.yaml#L909) | bool | `true` | If true, restarts the Botkube Pod on config changes. |
+| [configWatcher.tmpDir](./values.yaml#L911) | string | `"/tmp/watched-cfg/"` | Directory, where watched configuration resources are stored. |
+| [configWatcher.initialSyncTimeout](./values.yaml#L914) | int | `0` | Timeout for the initial Config Watcher sync. If set to 0, waiting for Config Watcher sync will be skipped. In a result, configuration changes may not reload Botkube app during the first few seconds after Botkube startup. |
+| [configWatcher.image.registry](./values.yaml#L917) | string | `"ghcr.io"` | Config watcher image registry. |
+| [configWatcher.image.repository](./values.yaml#L919) | string | `"kubeshop/k8s-sidecar"` | Config watcher image repository. |
+| [configWatcher.image.tag](./values.yaml#L921) | string | `"ignore-initial-events"` | Config watcher image tag. |
+| [configWatcher.image.pullPolicy](./values.yaml#L923) | string | `"IfNotPresent"` | Config watcher image pull policy. |
+| [plugins](./values.yaml#L926) | object | `{"cacheDir":"/tmp","repositories":{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}}` | Configuration for Botkube executors and sources plugins. |
+| [plugins.cacheDir](./values.yaml#L928) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
+| [plugins.repositories](./values.yaml#L930) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}` | List of plugins repositories. |
+| [plugins.repositories.botkube](./values.yaml#L932) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
+| [config](./values.yaml#L936) | object | `{"provider":{"endpoint":"","identifier":""}}` | Configuration for remote Botkube settings |
+| [config.provider](./values.yaml#L938) | object | `{"endpoint":"","identifier":""}` | Base provider definition |
+| [config.provider.identifier](./values.yaml#L940) | string | `""` | Unique identifier for remote Botkube settings |
+| [config.provider.endpoint](./values.yaml#L942) | string | `""` | Endpoint to fetch Botkube settings from |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -180,31 +180,31 @@ sources:
       # @default -- See the `values.yaml` file for full object.
       resources:
         - type: v1/pods
-          namespaces:             # Overrides 'source'.kubernetes.namespaces
-            include:
-              - ".*"
-            exclude: []
-          annotations: {}         # Overrides 'source'.kubernetes.annotations
-          labels: {}              # Overrides 'source'.kubernetes.labels
-          # Optional resource name constraints.
-          name:
-            # Include contains a list of allowed values. It can also contain regex expressions.
-            include: []
-            # Exclude contains a list of values to be ignored even if allowed by Include. It can also contain regex expressions.
-            # Exclude list is checked before the Include list.
-            exclude: []
-          event:
-            # Overrides 'source'.kubernetes.event.reason
-            reason:
-              include: []
-              exclude: []
-            # Overrides 'source'.kubernetes.event.message
-            message:
-              include: []
-              exclude: []
-            # Overrides 'source'.kubernetes.event.types
-            types:
-              - create
+#          namespaces:             # Overrides 'source'.kubernetes.namespaces
+#            include:
+#              - ".*"
+#            exclude: []
+#          annotations: {}         # Overrides 'source'.kubernetes.annotations
+#          labels: {}              # Overrides 'source'.kubernetes.labels
+#          # Optional resource name constraints.
+#          name:
+#            # Include contains a list of allowed values. It can also contain regex expressions.
+#            include: []
+#            # Exclude contains a list of values to be ignored even if allowed by Include. It can also contain regex expressions.
+#            # Exclude list is checked before the Include list.
+#            exclude: []
+#          event:
+#            # Overrides 'source'.kubernetes.event.reason
+#            reason:
+#              include: []
+#              exclude: []
+#            # Overrides 'source'.kubernetes.event.message
+#            message:
+#              include: []
+#              exclude: []
+#            # Overrides 'source'.kubernetes.event.types
+#            types:
+#              - create
 
         - type: v1/services
         - type: networking.k8s.io/v1/ingresses

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -130,14 +130,15 @@ sources:
       # These namespaces are applied to every resource specified in the resources list.
       # However, every specified resource can override this by using its own namespaces object.
       namespaces: &k8s-events-namespaces
-        # Include contains a list of allowed Namespaces.
-        # It can also contain a regex expressions:
+        # -- Include contains a list of allowed Namespaces.
+        # It can also contain regex expressions:
         #  `- ".*"` - to specify all Namespaces.
         include:
           - ".*"
-        # Exclude contains a list of Namespaces to be ignored even if allowed by Include.
-        # It can also contain a regex expressions:
+        # -- Exclude contains a list of Namespaces to be ignored even if allowed by Include.
+        # It can also contain regex expressions:
         #  `- "test-.*"` - to specif all Namespaces with `test-` prefix.
+        # Exclude list is checked before the Include list.
         # exclude: []
 
       # -- Describes event constraints for Kubernetes resources.
@@ -148,14 +149,28 @@ sources:
           - create
           - delete
           - error
-        # -- Optional regex to filter events by event reason.
-        reason: ""
-        # -- Optional regex to filter events by message. If a given event has multiple messages, it is considered a match if any of the messages match the regex.
-        message: ""
+        # -- Optional list of exact values or regex patterns to filter events by event reason.
+        # Skipped, if both include/exclude lists are empty.
+        reason:
+          # -- Include contains a list of allowed values. It can also contain regex expressions.
+          include: []
+          # -- Exclude contains a list of values to be ignored even if allowed by Include. It can also contain regex expressions.
+          # Exclude list is checked before the Include list.
+          exclude: []
+        # -- Optional list of exact values or regex patterns to filter event by event message. Skipped, if both include/exclude lists are empty.
+        # If a given event has multiple messages, it is considered a match if any of the messages match the constraints.
+        message:
+          # -- Include contains a list of allowed values. It can also contain regex expressions.
+          include: []
+          # -- Exclude contains a list of values to be ignored even if allowed by Include. It can also contain regex expressions.
+          # Exclude list is checked before the Include list.
+          exclude: []
 
-      # -- Filters Kubernetes resources to watch by annotations.
+      # -- Filters Kubernetes resources to watch by annotations. Each resource needs to have all the specified annotations.
+      # Regex expressions are not supported.
       annotations: {}
-      # -- Filters Kubernetes resources to watch by labels.
+      # -- Filters Kubernetes resources to watch by labels. Each resource needs to have all the specified labels.
+      # Regex expressions are not supported.
       labels: {}
 
       # -- Describes the Kubernetes resources to watch.
@@ -165,18 +180,31 @@ sources:
       # @default -- See the `values.yaml` file for full object.
       resources:
         - type: v1/pods
-        #  namespaces:             # Overrides 'source'.kubernetes.namespaces
-        #    include:
-        #      - ".*"
-        #    exclude: []
-        #  annotations: {}         # Overrides 'source'.kubernetes.annotations
-        #  labels: {}              # Overrides 'source'.kubernetes.labels
-        #  name: "" # Optional resource name regex.
-        #  event:
-        #    reason: ""            # Overrides 'source'.kubernetes.event.reason
-        #    message: ""           # Overrides 'source'.kubernetes.event.message
-        #    types:                # Overrides 'source'.kubernetes.event.types
-        #      - create
+          namespaces:             # Overrides 'source'.kubernetes.namespaces
+            include:
+              - ".*"
+            exclude: []
+          annotations: {}         # Overrides 'source'.kubernetes.annotations
+          labels: {}              # Overrides 'source'.kubernetes.labels
+          # Optional resource name constraints.
+          name:
+            # Include contains a list of allowed values. It can also contain regex expressions.
+            include: []
+            # Exclude contains a list of values to be ignored even if allowed by Include. It can also contain regex expressions.
+            # Exclude list is checked before the Include list.
+            exclude: []
+          event:
+            # Overrides 'source'.kubernetes.event.reason
+            reason:
+              include: []
+              exclude: []
+            # Overrides 'source'.kubernetes.event.message
+            message:
+              include: []
+              exclude: []
+            # Overrides 'source'.kubernetes.event.types
+            types:
+              - create
 
         - type: v1/services
         - type: networking.k8s.io/v1/ingresses

--- a/internal/source/registration.go
+++ b/internal/source/registration.go
@@ -177,7 +177,6 @@ func (r registration) shouldSendEventToRoute(route route, event event.Event) (bo
 	// event message
 	if route.event.Message.AreConstraintsDefined() {
 		var anyMsgMatches bool
-		var lastErr error
 
 		eventMsgs := event.Messages
 		if len(eventMsgs) == 0 {
@@ -188,16 +187,12 @@ func (r registration) shouldSendEventToRoute(route route, event event.Event) (bo
 		for _, msg := range eventMsgs {
 			match, err := route.event.Message.IsAllowed(msg)
 			if err != nil {
-				lastErr = err
-				continue
+				return false, err
 			}
 			if match {
 				anyMsgMatches = true
 				break
 			}
-		}
-		if lastErr != nil {
-			return false, lastErr
 		}
 		if !anyMsgMatches {
 			log.Debugf("Ignoring as any event message from %q doesn't match constraints %+v", strings.Join(event.Messages, ";"), route.event.Message)

--- a/internal/source/registration.go
+++ b/internal/source/registration.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
-	"github.com/dlclark/regexp2"
 	"github.com/sirupsen/logrus"
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -208,30 +208,18 @@ func matchRegexForStringsIfDefined(regexStr string, str []string) (bool, error) 
 		return true, nil
 	}
 
-	regex, err := regexp2.Compile(regexStr, regexp2.None)
+	regex, err := regexp.Compile(regexStr)
 	if err != nil {
 		return false, fmt.Errorf("while compiling regex: %w", err)
 	}
 
-	if len(str) == 0 {
-		// no messages, so let's check if regex matches empty string
-		str = append(str, "")
-	}
-
-	errs := multierror.New()
 	for _, s := range str {
-		match, err := regex.MatchString(s)
-		if err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("while matching regex %s: %w", regexStr, err))
-			continue
-		}
-
-		if match {
-			return true, errs.ErrorOrNil()
+		if regex.MatchString(s) {
+			return true, nil
 		}
 	}
 
-	return false, errs.ErrorOrNil()
+	return false, nil
 }
 
 func kvsSatisfiedForMap(expectedKV, obj map[string]string) bool {

--- a/internal/source/registration.go
+++ b/internal/source/registration.go
@@ -213,6 +213,11 @@ func matchRegexForStringsIfDefined(regexStr string, str []string) (bool, error) 
 		return false, fmt.Errorf("while compiling regex: %w", err)
 	}
 
+	if len(str) == 0 {
+		// no messages, so let's check if regex matches empty string
+		str = append(str, "")
+	}
+
 	for _, s := range str {
 		if regex.MatchString(s) {
 			return true, nil

--- a/internal/source/registration_test.go
+++ b/internal/source/registration_test.go
@@ -158,6 +158,44 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success", "success2", "success3", "success-empty"},
 		},
 		{
+			Name: "Event message - empty - success",
+			Routes: []route{
+				{
+					source: "success",
+					event: config.KubernetesEvent{
+						Message: config.RegexConstraints{
+							Include: []string{"^$"},
+						},
+					},
+					namespaces: allNsCfg,
+				},
+				{
+					source: "success2",
+					event: config.KubernetesEvent{
+						Message: config.RegexConstraints{
+							Include: []string{".*"},
+						},
+					},
+					namespaces: allNsCfg,
+				},
+				{
+					source: "fail",
+					event: config.KubernetesEvent{
+						Message: config.RegexConstraints{
+							Exclude: []string{"^$"},
+						},
+					},
+					namespaces: allNsCfg,
+				},
+
+			},
+			Event: event.Event{
+				Name: "test-one",
+				Messages: nil,
+			},
+			ExpectedResult: []string{"success", "success2"},
+		},
+		{
 			Name: "Event message - error",
 			Routes: []route{
 				{

--- a/internal/source/registration_test.go
+++ b/internal/source/registration_test.go
@@ -38,6 +38,13 @@ func TestSourcesForEvent(t *testing.T) {
 					resourceName: "^Created",
 					namespaces:   allNsCfg,
 				},
+				{
+					source: "fail2",
+					event: config.KubernetesEvent{
+						Reason: "^(?!NodeNotReady)$",
+					},
+					namespaces: allNsCfg,
+				},
 			},
 			Event: event.Event{
 				Name:   "test-one",
@@ -68,7 +75,7 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success"},
 			ExpectedErrMessage: heredoc.Docf(`
 				1 error occurred:
-					* while compiling regex: error parsing regexp: missing closing ]: %s`, "`[`"),
+					* while compiling regex: error parsing regexp: unterminated [] set in %s`, "`[`"),
 		},
 		{
 			Name: "Event message - success",
@@ -106,6 +113,77 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success", "success2"},
 		},
 		{
+			Name: "Event message - negative lookahead",
+			Routes: []route{
+				{
+					source: "success",
+					event: config.KubernetesEvent{
+						Message: "^(?!Back-off).*$",
+					},
+					namespaces: allNsCfg,
+				},
+				{
+					source: "success2",
+					event: config.KubernetesEvent{
+						Message: "^(?!Back-off restarting failed container)$",
+					},
+					namespaces: allNsCfg,
+				},
+				{
+					source: "empty",
+					event: config.KubernetesEvent{
+						Message: "",
+					},
+					namespaces: allNsCfg,
+				},
+			},
+			Event: event.Event{
+				Name: "test-one",
+				Messages: []string{
+					"Back-off restarting failed container",
+				},
+			},
+			ExpectedResult: []string{"empty"},
+		},
+		{
+			Name: "Event message - empty",
+			Routes: []route{
+				{
+					source: "success",
+					event: config.KubernetesEvent{
+						Message: "^(?!Back-off).*$",
+					},
+					namespaces: allNsCfg,
+				},
+				{
+					source: "success2",
+					event: config.KubernetesEvent{
+						Message: "^(?!Back-off restarting failed container)$",
+					},
+					namespaces: allNsCfg,
+				},
+				{
+					source: "success3",
+					event: config.KubernetesEvent{
+						Message: "",
+					},
+					namespaces: allNsCfg,
+				},
+				{
+					source: "fail",
+					event: config.KubernetesEvent{
+						Message: "^Back-off",
+					},
+					namespaces: allNsCfg,
+				},
+			},
+			Event: event.Event{
+				Name:     "test-one",
+				Messages: nil,
+			},
+			ExpectedResult: []string{"success", "success2", "success3"},
+		},
+		{
 			Name: "Event message - error",
 			Routes: []route{
 				{
@@ -134,7 +212,7 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success"},
 			ExpectedErrMessage: heredoc.Docf(`
 				1 error occurred:
-					* while compiling regex: error parsing regexp: missing closing ]: %s`, "`[`"),
+					* while compiling regex: error parsing regexp: unterminated [] set in %s`, "`[`"),
 		},
 		{
 			Name: "Resource name - success",
@@ -147,6 +225,11 @@ func TestSourcesForEvent(t *testing.T) {
 				{
 					source:       "fail",
 					resourceName: "^one-.*",
+					namespaces:   allNsCfg,
+				},
+				{
+					source:       "fail2",
+					resourceName: "^(?!^test-).*$",
 					namespaces:   allNsCfg,
 				},
 			},
@@ -175,7 +258,7 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success"},
 			ExpectedErrMessage: heredoc.Docf(`
 				1 error occurred:
-					* while compiling regex: error parsing regexp: missing closing ]: %s`, "`[`"),
+					* while compiling regex: error parsing regexp: unterminated [] set in %s`, "`[`"),
 		},
 		{
 			Name: "Namespace",

--- a/internal/source/registration_test.go
+++ b/internal/source/registration_test.go
@@ -187,10 +187,9 @@ func TestSourcesForEvent(t *testing.T) {
 					},
 					namespaces: allNsCfg,
 				},
-
 			},
 			Event: event.Event{
-				Name: "test-one",
+				Name:     "test-one",
 				Messages: nil,
 			},
 			ExpectedResult: []string{"success", "success2"},
@@ -292,7 +291,7 @@ func TestSourcesForEvent(t *testing.T) {
 					namespaces: config.RegexConstraints{Include: []string{"^botkube-.*"}},
 				},
 				{
-					source: "success-empty",
+					source:     "success-empty",
 					namespaces: config.RegexConstraints{},
 				},
 				{

--- a/internal/source/registration_test.go
+++ b/internal/source/registration_test.go
@@ -227,7 +227,7 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success"},
 			ExpectedErrMessage: heredoc.Docf(`
 				1 error occurred:
-					* while matching "Third" with include regex "[": error parsing regexp: missing closing ]: %s`, "`[`"),
+					* while matching "Status one" with include regex "[": error parsing regexp: missing closing ]: %s`, "`[`"),
 		},
 		{
 			Name: "Resource name - success",

--- a/internal/source/registration_test.go
+++ b/internal/source/registration_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestSourcesForEvent(t *testing.T) {
 	// given
-	allNsCfg := config.Namespaces{Include: []string{".*"}}
+	allNsCfg := config.RegexConstraints{Include: []string{".*"}}
 	testCases := []struct {
 		Name               string
 		Routes             []route
@@ -182,11 +182,11 @@ func TestSourcesForEvent(t *testing.T) {
 			Routes: []route{
 				{
 					source:     "success",
-					namespaces: config.Namespaces{Include: []string{"^botkube-.*"}},
+					namespaces: config.RegexConstraints{Include: []string{"^botkube-.*"}},
 				},
 				{
 					source:     "fail",
-					namespaces: config.Namespaces{Include: []string{"^kube-.*"}},
+					namespaces: config.RegexConstraints{Include: []string{"^kube-.*"}},
 				},
 			},
 			Event: event.Event{

--- a/internal/source/registration_test.go
+++ b/internal/source/registration_test.go
@@ -38,13 +38,6 @@ func TestSourcesForEvent(t *testing.T) {
 					resourceName: "^Created",
 					namespaces:   allNsCfg,
 				},
-				{
-					source: "fail2",
-					event: config.KubernetesEvent{
-						Reason: "^(?!NodeNotReady)$",
-					},
-					namespaces: allNsCfg,
-				},
 			},
 			Event: event.Event{
 				Name:   "test-one",
@@ -75,7 +68,7 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success"},
 			ExpectedErrMessage: heredoc.Docf(`
 				1 error occurred:
-					* while compiling regex: error parsing regexp: unterminated [] set in %s`, "`[`"),
+					* while compiling regex: error parsing regexp: missing closing ]: %s`, "`[`"),
 		},
 		{
 			Name: "Event message - success",
@@ -113,77 +106,6 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success", "success2"},
 		},
 		{
-			Name: "Event message - negative lookahead",
-			Routes: []route{
-				{
-					source: "success",
-					event: config.KubernetesEvent{
-						Message: "^(?!Back-off).*$",
-					},
-					namespaces: allNsCfg,
-				},
-				{
-					source: "success2",
-					event: config.KubernetesEvent{
-						Message: "^(?!Back-off restarting failed container)$",
-					},
-					namespaces: allNsCfg,
-				},
-				{
-					source: "empty",
-					event: config.KubernetesEvent{
-						Message: "",
-					},
-					namespaces: allNsCfg,
-				},
-			},
-			Event: event.Event{
-				Name: "test-one",
-				Messages: []string{
-					"Back-off restarting failed container",
-				},
-			},
-			ExpectedResult: []string{"empty"},
-		},
-		{
-			Name: "Event message - empty",
-			Routes: []route{
-				{
-					source: "success",
-					event: config.KubernetesEvent{
-						Message: "^(?!Back-off).*$",
-					},
-					namespaces: allNsCfg,
-				},
-				{
-					source: "success2",
-					event: config.KubernetesEvent{
-						Message: "^(?!Back-off restarting failed container)$",
-					},
-					namespaces: allNsCfg,
-				},
-				{
-					source: "success3",
-					event: config.KubernetesEvent{
-						Message: "",
-					},
-					namespaces: allNsCfg,
-				},
-				{
-					source: "fail",
-					event: config.KubernetesEvent{
-						Message: "^Back-off",
-					},
-					namespaces: allNsCfg,
-				},
-			},
-			Event: event.Event{
-				Name:     "test-one",
-				Messages: nil,
-			},
-			ExpectedResult: []string{"success", "success2", "success3"},
-		},
-		{
 			Name: "Event message - error",
 			Routes: []route{
 				{
@@ -212,7 +134,7 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success"},
 			ExpectedErrMessage: heredoc.Docf(`
 				1 error occurred:
-					* while compiling regex: error parsing regexp: unterminated [] set in %s`, "`[`"),
+					* while compiling regex: error parsing regexp: missing closing ]: %s`, "`[`"),
 		},
 		{
 			Name: "Resource name - success",
@@ -225,11 +147,6 @@ func TestSourcesForEvent(t *testing.T) {
 				{
 					source:       "fail",
 					resourceName: "^one-.*",
-					namespaces:   allNsCfg,
-				},
-				{
-					source:       "fail2",
-					resourceName: "^(?!^test-).*$",
 					namespaces:   allNsCfg,
 				},
 			},
@@ -258,7 +175,7 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success"},
 			ExpectedErrMessage: heredoc.Docf(`
 				1 error occurred:
-					* while compiling regex: error parsing regexp: unterminated [] set in %s`, "`[`"),
+					* while compiling regex: error parsing regexp: missing closing ]: %s`, "`[`"),
 		},
 		{
 			Name: "Namespace",

--- a/internal/source/registration_test.go
+++ b/internal/source/registration_test.go
@@ -29,14 +29,20 @@ func TestSourcesForEvent(t *testing.T) {
 				{
 					source: "success",
 					event: config.KubernetesEvent{
-						Reason: "^NodeNotReady",
+						Reason: config.RegexConstraints{
+							Include: []string{"^NodeNotReady"},
+						},
 					},
 					namespaces: allNsCfg,
 				},
 				{
-					source:       "fail",
-					resourceName: "^Created",
-					namespaces:   allNsCfg,
+					source: "fail",
+					event: config.KubernetesEvent{
+						Reason: config.RegexConstraints{
+							Include: []string{"^Created"},
+						},
+					},
+					namespaces: allNsCfg,
 				},
 			},
 			Event: event.Event{
@@ -51,14 +57,20 @@ func TestSourcesForEvent(t *testing.T) {
 				{
 					source: "success",
 					event: config.KubernetesEvent{
-						Reason: "^NodeNotReady",
+						Reason: config.RegexConstraints{
+							Include: []string{"^NodeNotReady"},
+						},
 					},
 					namespaces: allNsCfg,
 				},
 				{
-					source:       "error",
-					resourceName: "[",
-					namespaces:   allNsCfg,
+					source: "error",
+					event: config.KubernetesEvent{
+						Reason: config.RegexConstraints{
+							Exclude: []string{"["},
+						},
+					},
+					namespaces: allNsCfg,
 				},
 			},
 			Event: event.Event{
@@ -68,7 +80,7 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success"},
 			ExpectedErrMessage: heredoc.Docf(`
 				1 error occurred:
-					* while compiling regex: error parsing regexp: missing closing ]: %s`, "`[`"),
+					* while matching "NodeNotReady" with exclude regex "[": error parsing regexp: missing closing ]: %s`, "`[`"),
 		},
 		{
 			Name: "Event message - success",
@@ -76,21 +88,47 @@ func TestSourcesForEvent(t *testing.T) {
 				{
 					source: "success",
 					event: config.KubernetesEvent{
-						Message: "^Status.*",
+						Message: config.RegexConstraints{
+							Include: []string{"^Status.*"},
+						},
 					},
 					namespaces: allNsCfg,
 				},
 				{
 					source: "success2",
 					event: config.KubernetesEvent{
-						Message: "^Second.*",
+						Message: config.RegexConstraints{
+							Include: []string{"^Second.*"},
+						},
+					},
+					namespaces: allNsCfg,
+				},
+				{
+					source: "success3",
+					event: config.KubernetesEvent{
+						Message: config.RegexConstraints{
+							Include: []string{".*"},
+							Exclude: []string{"^Something.*"},
+						},
 					},
 					namespaces: allNsCfg,
 				},
 				{
 					source: "fail",
 					event: config.KubernetesEvent{
-						Message: "^Resource",
+						Message: config.RegexConstraints{
+							Include: []string{"^Resource"},
+						},
+					},
+					namespaces: allNsCfg,
+				},
+				{
+					source: "fail2",
+					event: config.KubernetesEvent{
+						Message: config.RegexConstraints{
+							Include: []string{".*"},
+							Exclude: []string{"^Second", "^Status", "^Third"},
+						},
 					},
 					namespaces: allNsCfg,
 				},
@@ -103,7 +141,7 @@ func TestSourcesForEvent(t *testing.T) {
 					"Third",
 				},
 			},
-			ExpectedResult: []string{"success", "success2"},
+			ExpectedResult: []string{"success", "success2", "success3"},
 		},
 		{
 			Name: "Event message - error",
@@ -111,14 +149,18 @@ func TestSourcesForEvent(t *testing.T) {
 				{
 					source: "success",
 					event: config.KubernetesEvent{
-						Message: "^Status.*",
+						Message: config.RegexConstraints{
+							Include: []string{"^Status.*"},
+						},
 					},
 					namespaces: allNsCfg,
 				},
 				{
 					source: "error",
 					event: config.KubernetesEvent{
-						Message: "[",
+						Message: config.RegexConstraints{
+							Include: []string{"["},
+						},
 					},
 					namespaces: allNsCfg,
 				},
@@ -134,20 +176,24 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success"},
 			ExpectedErrMessage: heredoc.Docf(`
 				1 error occurred:
-					* while compiling regex: error parsing regexp: missing closing ]: %s`, "`[`"),
+					* while matching "Third" with include regex "[": error parsing regexp: missing closing ]: %s`, "`[`"),
 		},
 		{
 			Name: "Resource name - success",
 			Routes: []route{
 				{
-					source:       "success",
-					resourceName: "^test-.*",
-					namespaces:   allNsCfg,
+					source: "success",
+					resourceName: config.RegexConstraints{
+						Include: []string{"^test-.*"},
+					},
+					namespaces: allNsCfg,
 				},
 				{
-					source:       "fail",
-					resourceName: "^one-.*",
-					namespaces:   allNsCfg,
+					source: "fail",
+					resourceName: config.RegexConstraints{
+						Include: []string{"^one-.*"},
+					},
+					namespaces: allNsCfg,
 				},
 			},
 			Event: event.Event{
@@ -159,14 +205,18 @@ func TestSourcesForEvent(t *testing.T) {
 			Name: "Resource name - error",
 			Routes: []route{
 				{
-					source:       "success",
-					resourceName: "^test-.*",
-					namespaces:   allNsCfg,
+					source: "success",
+					resourceName: config.RegexConstraints{
+						Include: []string{"^test-.*"},
+					},
+					namespaces: allNsCfg,
 				},
 				{
-					source:       "error",
-					resourceName: "[",
-					namespaces:   allNsCfg,
+					source: "error",
+					resourceName: config.RegexConstraints{
+						Include: []string{"["},
+					},
+					namespaces: allNsCfg,
 				},
 			},
 			Event: event.Event{
@@ -175,7 +225,7 @@ func TestSourcesForEvent(t *testing.T) {
 			ExpectedResult: []string{"success"},
 			ExpectedErrMessage: heredoc.Docf(`
 				1 error occurred:
-					* while compiling regex: error parsing regexp: missing closing ]: %s`, "`[`"),
+					* while matching "test-one" with include regex "[": error parsing regexp: missing closing ]: %s`, "`[`"),
 		},
 		{
 			Name: "Namespace",

--- a/internal/source/registration_test.go
+++ b/internal/source/registration_test.go
@@ -36,6 +36,13 @@ func TestSourcesForEvent(t *testing.T) {
 					namespaces: allNsCfg,
 				},
 				{
+					source: "success-empty",
+					event: config.KubernetesEvent{
+						Reason: config.RegexConstraints{},
+					},
+					namespaces: allNsCfg,
+				},
+				{
 					source: "fail",
 					event: config.KubernetesEvent{
 						Reason: config.RegexConstraints{
@@ -49,7 +56,7 @@ func TestSourcesForEvent(t *testing.T) {
 				Name:   "test-one",
 				Reason: "NodeNotReady",
 			},
-			ExpectedResult: []string{"success"},
+			ExpectedResult: []string{"success", "success-empty"},
 		},
 		{
 			Name: "Event reason - error",
@@ -114,6 +121,13 @@ func TestSourcesForEvent(t *testing.T) {
 					namespaces: allNsCfg,
 				},
 				{
+					source: "success-empty",
+					event: config.KubernetesEvent{
+						Message: config.RegexConstraints{},
+					},
+					namespaces: allNsCfg,
+				},
+				{
 					source: "fail",
 					event: config.KubernetesEvent{
 						Message: config.RegexConstraints{
@@ -141,7 +155,7 @@ func TestSourcesForEvent(t *testing.T) {
 					"Third",
 				},
 			},
-			ExpectedResult: []string{"success", "success2", "success3"},
+			ExpectedResult: []string{"success", "success2", "success3", "success-empty"},
 		},
 		{
 			Name: "Event message - error",
@@ -189,6 +203,11 @@ func TestSourcesForEvent(t *testing.T) {
 					namespaces: allNsCfg,
 				},
 				{
+					source:       "success-empty",
+					resourceName: config.RegexConstraints{},
+					namespaces:   allNsCfg,
+				},
+				{
 					source: "fail",
 					resourceName: config.RegexConstraints{
 						Include: []string{"^one-.*"},
@@ -199,7 +218,7 @@ func TestSourcesForEvent(t *testing.T) {
 			Event: event.Event{
 				Name: "test-one",
 			},
-			ExpectedResult: []string{"success"},
+			ExpectedResult: []string{"success", "success-empty"},
 		},
 		{
 			Name: "Resource name - error",
@@ -235,6 +254,10 @@ func TestSourcesForEvent(t *testing.T) {
 					namespaces: config.RegexConstraints{Include: []string{"^botkube-.*"}},
 				},
 				{
+					source: "success-empty",
+					namespaces: config.RegexConstraints{},
+				},
+				{
 					source:     "fail",
 					namespaces: config.RegexConstraints{Include: []string{"^kube-.*"}},
 				},
@@ -243,7 +266,7 @@ func TestSourcesForEvent(t *testing.T) {
 				Name:      "test-one",
 				Namespace: "botkube-one",
 			},
-			ExpectedResult: []string{"success"},
+			ExpectedResult: []string{"success", "success-empty"},
 		},
 		{
 			Name: "Labels",

--- a/internal/source/router.go
+++ b/internal/source/router.go
@@ -21,7 +21,7 @@ type eventHandler func(ctx context.Context, event event.Event, sources []string,
 
 type route struct {
 	source        string
-	resourceName  string
+	resourceName  config.RegexConstraints
 	labels        map[string]string
 	annotations   map[string]string
 	namespaces    config.RegexConstraints
@@ -414,7 +414,7 @@ func flattenEventTypes(globalEvents []config.EventType, resourceEvents config.Ku
 // sourceOrResourceNamespaces returns the kubernetes source namespaces
 // unless the resource namespaces are configured.
 func sourceOrResourceNamespaces(sourceNs, resourceNs config.RegexConstraints) config.RegexConstraints {
-	if resourceNs.IsConfigured() {
+	if resourceNs.AreConstraintsDefined() {
 		return resourceNs
 	}
 	return sourceNs

--- a/internal/source/router.go
+++ b/internal/source/router.go
@@ -24,7 +24,7 @@ type route struct {
 	resourceName  string
 	labels        map[string]string
 	annotations   map[string]string
-	namespaces    config.Namespaces
+	namespaces    config.RegexConstraints
 	updateSetting config.UpdateSetting
 	event         config.KubernetesEvent
 }
@@ -331,7 +331,7 @@ func (r *Router) setEventRouteForRecommendationsIfShould(routeMap *map[config.Ev
 
 	recommRoute := route{
 		source: srcGroupName,
-		namespaces: config.Namespaces{
+		namespaces: config.RegexConstraints{
 			Include: []string{config.AllNamespaceIndicator},
 		},
 	}
@@ -413,7 +413,7 @@ func flattenEventTypes(globalEvents []config.EventType, resourceEvents config.Ku
 
 // sourceOrResourceNamespaces returns the kubernetes source namespaces
 // unless the resource namespaces are configured.
-func sourceOrResourceNamespaces(sourceNs, resourceNs config.Namespaces) config.Namespaces {
+func sourceOrResourceNamespaces(sourceNs, resourceNs config.RegexConstraints) config.RegexConstraints {
 	if resourceNs.IsConfigured() {
 		return resourceNs
 	}

--- a/internal/source/router_test.go
+++ b/internal/source/router_test.go
@@ -86,7 +86,7 @@ func TestRouter_BuildTable_CreatesRoutesWithProperEventsList(t *testing.T) {
 							Resources: []config.Resource{
 								{
 									Type: hasRoutes,
-									Namespaces: config.Namespaces{
+									Namespaces: config.RegexConstraints{
 										Include: []string{"default"},
 									},
 									Event: config.KubernetesEvent{
@@ -125,7 +125,7 @@ func TestRouter_BuildTable_CreatesRoutesWithProperEventsList(t *testing.T) {
 							Resources: []config.Resource{
 								{
 									Type: hasRoutes,
-									Namespaces: config.Namespaces{
+									Namespaces: config.RegexConstraints{
 										Include: []string{"default"},
 									},
 									UpdateSetting: config.UpdateSetting{
@@ -154,7 +154,7 @@ func TestRouter_BuildTable_CreatesRoutesWithProperEventsList(t *testing.T) {
 							Resources: []config.Resource{
 								{
 									Type: hasRoutes,
-									Namespaces: config.Namespaces{
+									Namespaces: config.RegexConstraints{
 										Include: []string{"default"},
 									},
 									Event: config.KubernetesEvent{
@@ -209,7 +209,7 @@ func TestRouter_BuildTable_CreatesRoutesForBoundSources(t *testing.T) {
 					Resources: []config.Resource{
 						{
 							Type: hasRoutes,
-							Namespaces: config.Namespaces{
+							Namespaces: config.RegexConstraints{
 								Include: []string{"default"},
 							},
 							Event: config.KubernetesEvent{
@@ -233,7 +233,7 @@ func TestRouter_BuildTable_CreatesRoutesForBoundSources(t *testing.T) {
 					Resources: []config.Resource{
 						{
 							Type: hasNoRoutes,
-							Namespaces: config.Namespaces{
+							Namespaces: config.RegexConstraints{
 								Include: []string{"all"},
 							},
 							Event: config.KubernetesEvent{
@@ -264,7 +264,7 @@ func TestRouter_BuildTable_CreatesRoutesWithNamespacesPresetFromKubernetesSource
 	testCases := []struct {
 		Name     string
 		Input    *config.Config
-		Expected config.Namespaces
+		Expected config.RegexConstraints
 	}{
 		{
 			Name: "Use sources Namespaces",
@@ -272,7 +272,7 @@ func TestRouter_BuildTable_CreatesRoutesWithNamespacesPresetFromKubernetesSource
 				Sources: map[string]config.Sources{
 					"k8s-events": {
 						Kubernetes: config.KubernetesSource{
-							Namespaces: config.Namespaces{
+							Namespaces: config.RegexConstraints{
 								Include: []string{"botkube"},
 								Exclude: []string{"default"},
 							},
@@ -290,7 +290,7 @@ func TestRouter_BuildTable_CreatesRoutesWithNamespacesPresetFromKubernetesSource
 					},
 				},
 			},
-			Expected: config.Namespaces{
+			Expected: config.RegexConstraints{
 				Include: []string{"botkube"},
 				Exclude: []string{"default"},
 			},
@@ -301,14 +301,14 @@ func TestRouter_BuildTable_CreatesRoutesWithNamespacesPresetFromKubernetesSource
 				Sources: map[string]config.Sources{
 					"k8s-events": {
 						Kubernetes: config.KubernetesSource{
-							Namespaces: config.Namespaces{
+							Namespaces: config.RegexConstraints{
 								Include: []string{"botkube"},
 								Exclude: []string{"default"},
 							},
 							Resources: []config.Resource{
 								{
 									Type: "apps/v1/deployments",
-									Namespaces: config.Namespaces{
+									Namespaces: config.RegexConstraints{
 										Include: []string{".*"},
 									},
 									Event: config.KubernetesEvent{
@@ -322,7 +322,7 @@ func TestRouter_BuildTable_CreatesRoutesWithNamespacesPresetFromKubernetesSource
 					},
 				},
 			},
-			Expected: config.Namespaces{
+			Expected: config.RegexConstraints{
 				Include: []string{".*"},
 			},
 		},
@@ -362,7 +362,7 @@ func TestSetEventRouteForRecommendationsIfShould(t *testing.T) {
 				config.UpdateEvent: {{source: "foo"}, {source: "bar"}},
 			},
 			Expected: map[config.EventType][]route{
-				config.CreateEvent: {{source: "foo", namespaces: config.Namespaces{Include: []string{config.AllNamespaceIndicator}}}},
+				config.CreateEvent: {{source: "foo", namespaces: config.RegexConstraints{Include: []string{config.AllNamespaceIndicator}}}},
 				config.UpdateEvent: {{source: "foo"}, {source: "bar"}},
 			},
 		},
@@ -375,7 +375,7 @@ func TestSetEventRouteForRecommendationsIfShould(t *testing.T) {
 					},
 					{
 						source: "foo",
-						namespaces: config.Namespaces{
+						namespaces: config.RegexConstraints{
 							Include: []string{"foo", "bar"},
 							Exclude: []string{"default"},
 						},
@@ -393,7 +393,7 @@ func TestSetEventRouteForRecommendationsIfShould(t *testing.T) {
 					},
 					{
 						source: "foo",
-						namespaces: config.Namespaces{
+						namespaces: config.RegexConstraints{
 							Include: []string{"foo", "bar"},
 							Exclude: []string{"default"},
 						},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,10 +5,10 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
-	"github.com/dlclark/regexp2"
 	"github.com/knadh/koanf"
 	koanfyaml "github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
@@ -434,7 +434,7 @@ func (n *Namespaces) IsAllowed(givenNs string) bool {
 			}
 
 			// regexp
-			matched, err := n.matchString(excludeNamespace, givenNs)
+			matched, err := regexp.MatchString(excludeNamespace, givenNs)
 			if err == nil && matched {
 				return false
 			}
@@ -454,7 +454,7 @@ func (n *Namespaces) IsAllowed(givenNs string) bool {
 			}
 
 			// regexp
-			matched, err := n.matchString(includeNamespace, givenNs)
+			matched, err := regexp.MatchString(includeNamespace, givenNs)
 			if err == nil && matched {
 				return true
 			}
@@ -463,20 +463,6 @@ func (n *Namespaces) IsAllowed(givenNs string) bool {
 
 	// 2.1. If not included, return false
 	return false
-}
-
-func (n *Namespaces) matchString(regexStr, s string) (bool, error) {
-	regex, err := regexp2.Compile(regexStr, regexp2.None)
-	if err != nil {
-		return false, fmt.Errorf("while compiling regex: %w", err)
-	}
-
-	match, err := regex.MatchString(s)
-	if err != nil {
-		return false, fmt.Errorf("while matching regex: %w", err)
-	}
-
-	return match, nil
 }
 
 // Notification holds notification configuration.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,10 @@ const (
 
 const (
 	// AllNamespaceIndicator represents a keyword for allowing all Kubernetes Namespaces.
-	AllNamespaceIndicator = ".*"
+	AllNamespaceIndicator = allValuesPattern
+
+	// allValuesPattern represents a keyword for allowing all values.
+	allValuesPattern = ".*"
 )
 
 // EventType to watch

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -425,25 +425,25 @@ func (r *RegexConstraints) AreConstraintsDefined() bool {
 // IsAllowed checks if a given value is allowed based on the config.
 // Firstly, it checks if the value is excluded. If not, then it checks if the value is included.
 func (r *RegexConstraints) IsAllowed(value string) (bool, error) {
-	if r == nil || value == "" {
+	if r == nil {
 		return false, nil
 	}
 
 	// 1. Check if excluded
 	if len(r.Exclude) > 0 {
-		for _, excludeNamespace := range r.Exclude {
-			if strings.TrimSpace(excludeNamespace) == "" {
+		for _, excludeValue := range r.Exclude {
+			if strings.TrimSpace(excludeValue) == "" {
 				continue
 			}
 			// exact match
-			if excludeNamespace == value {
+			if excludeValue == value {
 				return false, nil
 			}
 
 			// regexp
-			matched, err := regexp.MatchString(excludeNamespace, value)
+			matched, err := regexp.MatchString(excludeValue, value)
 			if err != nil {
-				return false, fmt.Errorf("while matching %q with exclude regex %q: %v", value, excludeNamespace, err)
+				return false, fmt.Errorf("while matching %q with exclude regex %q: %v", value, excludeValue, err)
 			}
 			if matched {
 				return false, nil
@@ -453,20 +453,16 @@ func (r *RegexConstraints) IsAllowed(value string) (bool, error) {
 
 	// 2. Check if included, if matched, return true
 	if len(r.Include) > 0 {
-		for _, includeNamespace := range r.Include {
-			if strings.TrimSpace(includeNamespace) == "" {
-				continue
-			}
-
+		for _, includeValue := range r.Include {
 			// exact match
-			if includeNamespace == value {
+			if includeValue == value {
 				return true, nil
 			}
 
 			// regexp
-			matched, err := regexp.MatchString(includeNamespace, value)
+			matched, err := regexp.MatchString(includeValue, value)
 			if err != nil {
-				return false, fmt.Errorf("while matching %q with include regex %q: %v", value, includeNamespace, err)
+				return false, fmt.Errorf("while matching %q with include regex %q: %v", value, includeValue, err)
 			}
 			if matched {
 				return true, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,10 +5,10 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
+	"github.com/dlclark/regexp2"
 	"github.com/knadh/koanf"
 	koanfyaml "github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
@@ -434,7 +434,7 @@ func (n *Namespaces) IsAllowed(givenNs string) bool {
 			}
 
 			// regexp
-			matched, err := regexp.MatchString(excludeNamespace, givenNs)
+			matched, err := n.matchString(excludeNamespace, givenNs)
 			if err == nil && matched {
 				return false
 			}
@@ -454,7 +454,7 @@ func (n *Namespaces) IsAllowed(givenNs string) bool {
 			}
 
 			// regexp
-			matched, err := regexp.MatchString(includeNamespace, givenNs)
+			matched, err := n.matchString(includeNamespace, givenNs)
 			if err == nil && matched {
 				return true
 			}
@@ -463,6 +463,20 @@ func (n *Namespaces) IsAllowed(givenNs string) bool {
 
 	// 2.1. If not included, return false
 	return false
+}
+
+func (n *Namespaces) matchString(regexStr, s string) (bool, error) {
+	regex, err := regexp2.Compile(regexStr, regexp2.None)
+	if err != nil {
+		return false, fmt.Errorf("while compiling regex: %w", err)
+	}
+
+	match, err := regex.MatchString(s)
+	if err != nil {
+		return false, fmt.Errorf("while matching regex: %w", err)
+	}
+
+	return match, nil
 }
 
 // Notification holds notification configuration.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -445,17 +445,17 @@ func TestRegexConstraints_IsAllowed(t *testing.T) {
 		isAllowed          bool
 		expectedErrMessage string
 	}{
-		"should watch all except ignored ones": {
+		"should match all except ignored ones": {
 			nsConfig:  config.RegexConstraints{Include: []string{".*"}, Exclude: []string{"demo", "abc"}},
 			givenNs:   "demo",
 			isAllowed: false,
 		},
-		"should watch all when ignore has empty items only": {
+		"should match all when ignore has empty items only": {
 			nsConfig:  config.RegexConstraints{Include: []string{".*"}, Exclude: []string{""}},
 			givenNs:   "demo",
 			isAllowed: true,
 		},
-		"should watch all when ignore is a nil slice": {
+		"should match all when ignore is a nil slice": {
 			nsConfig:  config.RegexConstraints{Include: []string{".*"}, Exclude: nil},
 			givenNs:   "demo",
 			isAllowed: true,
@@ -470,9 +470,19 @@ func TestRegexConstraints_IsAllowed(t *testing.T) {
 			givenNs:   "ignored-42-ns",
 			isAllowed: false,
 		},
-		"should watch all if regexp is not matching given namespace": {
+		"should match all if regexp is not matching given namespace": {
 			nsConfig:  config.RegexConstraints{Include: []string{".*"}, Exclude: []string{"demo-.*"}},
 			givenNs:   "demo",
+			isAllowed: true,
+		},
+		"should match empty value": {
+			nsConfig:  config.RegexConstraints{Include: []string{".*"}, Exclude: []string{"demo-.*"}},
+			givenNs:   "",
+			isAllowed: true,
+		},
+		"should match only empty value": {
+			nsConfig:  config.RegexConstraints{Include: []string{"^$"}, Exclude: []string{}},
+			givenNs:   "",
 			isAllowed: true,
 		},
 		"invalid exclude regex": {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -440,37 +440,37 @@ func readTestdataFile(t *testing.T, name string) []byte {
 
 func TestIsNamespaceAllowed(t *testing.T) {
 	tests := map[string]struct {
-		nsConfig  config.Namespaces
+		nsConfig  config.RegexConstraints
 		givenNs   string
 		isAllowed bool
 	}{
 		"should watch all except ignored ones": {
-			nsConfig:  config.Namespaces{Include: []string{".*"}, Exclude: []string{"demo", "abc"}},
+			nsConfig:  config.RegexConstraints{Include: []string{".*"}, Exclude: []string{"demo", "abc"}},
 			givenNs:   "demo",
 			isAllowed: false,
 		},
 		"should watch all when ignore has empty items only": {
-			nsConfig:  config.Namespaces{Include: []string{".*"}, Exclude: []string{""}},
+			nsConfig:  config.RegexConstraints{Include: []string{".*"}, Exclude: []string{""}},
 			givenNs:   "demo",
 			isAllowed: true,
 		},
 		"should watch all when ignore is a nil slice": {
-			nsConfig:  config.Namespaces{Include: []string{".*"}, Exclude: nil},
+			nsConfig:  config.RegexConstraints{Include: []string{".*"}, Exclude: nil},
 			givenNs:   "demo",
 			isAllowed: true,
 		},
 		"should ignore matched by regex": {
-			nsConfig:  config.Namespaces{Include: []string{".*"}, Exclude: []string{"my-.*"}},
+			nsConfig:  config.RegexConstraints{Include: []string{".*"}, Exclude: []string{"my-.*"}},
 			givenNs:   "my-ns",
 			isAllowed: false,
 		},
 		"should ignore matched by regexp even if exact name is mentioned too": {
-			nsConfig:  config.Namespaces{Include: []string{".*"}, Exclude: []string{"demo", "ignored-.*-ns"}},
+			nsConfig:  config.RegexConstraints{Include: []string{".*"}, Exclude: []string{"demo", "ignored-.*-ns"}},
 			givenNs:   "ignored-42-ns",
 			isAllowed: false,
 		},
 		"should watch all if regexp is not matching given namespace": {
-			nsConfig:  config.Namespaces{Include: []string{".*"}, Exclude: []string{"demo-.*"}},
+			nsConfig:  config.RegexConstraints{Include: []string{".*"}, Exclude: []string{"demo-.*"}},
 			givenNs:   "demo",
 			isAllowed: true,
 		},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -316,8 +316,8 @@ func TestLoadedConfigValidationWarnings(t *testing.T) {
 			name: "executor specifies all and exact namespace in include property",
 			expWarnMsg: heredoc.Doc(`
 				2 errors occurred:
-					* Key: 'Config.Sources[k8s-events].Kubernetes.Resources[0].Namespaces.Include' Include matches both all and exact namespaces
-					* Key: 'Config.Executors[kubectl-read-only].Kubectl.Namespaces.Include' Include matches both all and exact namespaces`),
+					* Key: 'Config.Sources[k8s-events].Kubernetes.Resources[0].Namespaces.Include' Include contains multiple constraints, but it does already include a regex pattern for all values
+					* Key: 'Config.Executors[kubectl-read-only].Kubectl.Namespaces.Include' Include contains multiple constraints, but it does already include a regex pattern for all values`),
 			configs: [][]byte{
 				readTestdataFile(t, "executors-include-warning.yaml"),
 			},

--- a/pkg/config/testdata/TestLoadConfigSuccess/config-all.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config-all.yaml
@@ -119,8 +119,10 @@ sources:
           - ".*"
         exclude: [ ]
       event:
-        reason: ".*"
-        message: "^Error .*"
+        reason:
+          include: ".*"
+        message:
+          include: "^Error .*"
         types:
           - create
           - delete
@@ -136,8 +138,12 @@ sources:
         - type: networking.k8s.io/v1/ingresses
         - type: v1/nodes
           event:
-            reason: NodeNotReady
-            message: "status .*"
+            reason:
+              include:
+                - NodeNotReady
+            message:
+              include:
+                - "status .*"
         - type: v1/namespaces
         - type: v1/persistentvolumes
         - type: v1/persistentvolumeclaims
@@ -174,7 +180,8 @@ sources:
             my-own-annotation: "true"
           labels: # Overrides 'source'.kubernetes.labels
             my-own-label: "true"
-          name: "my-.*"
+          name:
+            include: "my-.*"
           updateSetting:
             includeDiff: true
             fields:

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -20,106 +20,134 @@ sources:
                     noLatestImageTag: false
                     labelsSet: true
             event:
-                reason: .*
-                message: ^Error .*
+                reason:
+                    include:
+                        - .*
+                message:
+                    include:
+                        - ^Error .*
                 types:
                     - create
                     - delete
                     - error
             resources:
                 - type: v1/pods
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: v1/services
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: networking.k8s.io/v1/ingresses
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: v1/nodes
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: NodeNotReady
-                    message: status .*
+                    reason:
+                        include:
+                            - NodeNotReady
+                    message:
+                        include:
+                            - status .*
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: v1/namespaces
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: v1/persistentvolumes
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: v1/persistentvolumeclaims
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: v1/configmaps
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include:
                         - default
@@ -128,73 +156,90 @@ sources:
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: rbac.authorization.k8s.io/v1/roles
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: rbac.authorization.k8s.io/v1/rolebindings
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: rbac.authorization.k8s.io/v1/clusterrolebindings
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: rbac.authorization.k8s.io/v1/clusterroles
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types: []
                   updateSetting:
                     fields: []
                     includeDiff: false
                 - type: apps/v1/daemonsets
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types:
                         - create
                         - update
@@ -206,7 +251,9 @@ sources:
                         - status.numberReady
                     includeDiff: true
                 - type: batch/v1/jobs
-                  name: my-.*
+                  name:
+                    include:
+                        - my-.*
                   namespaces:
                     include: []
                   annotations:
@@ -214,8 +261,10 @@ sources:
                   labels:
                     my-own-label: "true"
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types:
                         - create
                         - update
@@ -227,14 +276,17 @@ sources:
                         - status.conditions[*].type
                     includeDiff: true
                 - type: apps/v1/deployments
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types:
                         - create
                         - update
@@ -246,14 +298,17 @@ sources:
                         - status.availableReplicas
                     includeDiff: true
                 - type: apps/v1/statefulsets
-                  name: ""
+                  name:
+                    include: []
                   namespaces:
                     include: []
                   annotations: {}
                   labels: {}
                   event:
-                    reason: ""
-                    message: ""
+                    reason:
+                        include: []
+                    message:
+                        include: []
                     types:
                         - create
                         - update

--- a/pkg/config/testdata/TestLoadConfigWithPlugins/config-all.yaml
+++ b/pkg/config/testdata/TestLoadConfigWithPlugins/config-all.yaml
@@ -26,7 +26,7 @@ sources:
       namespaces:
         include: [ ".*" ]
       resources:
-        - name: v1/pods
+        - type: v1/pods
 
     botkube/keptn:
       enabled: true

--- a/pkg/config/testdata/TestLoadedConfigValidationWarnings/executors-include-warning.yaml
+++ b/pkg/config/testdata/TestLoadedConfigValidationWarnings/executors-include-warning.yaml
@@ -15,10 +15,11 @@ sources:
   k8s-events:
     kubernetes:
       resources:
-        - name: v1/pods
+        - type: v1/pods
           namespaces:
             include: [ ".*", "kube-system" ]
-          events:
+          event:
+            types:
             - create
             - delete
             - error

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	nsIncludeTag                = "ns-include-regex"
+	regexConstraintsIncludeTag  = "rs-include-regex"
 	invalidBindingTag           = "invalid_binding"
 	conflictingPluginRepoTag    = "conflicting_plugin_repo"
 	conflictingPluginVersionTag = "conflicting_plugin_version"
@@ -27,7 +27,7 @@ const (
 )
 
 var warnsOnlyTags = map[string]struct{}{
-	nsIncludeTag: {},
+	regexConstraintsIncludeTag: {},
 }
 
 // ValidateResult holds the validation results.
@@ -48,7 +48,7 @@ func ValidateStruct(in any) (ValidateResult, error) {
 	if err := registerCustomTranslations(validate, trans); err != nil {
 		return ValidateResult{}, err
 	}
-	if err := registerNamespaceValidator(validate, trans); err != nil {
+	if err := registerRegexConstraintsValidator(validate, trans); err != nil {
 		return ValidateResult{}, err
 	}
 	if err := registerBindingsValidator(validate, trans); err != nil {
@@ -97,13 +97,13 @@ func registerCustomTranslations(validate *validator.Validate, trans ut.Translato
 	})
 }
 
-func registerNamespaceValidator(validate *validator.Validate, trans ut.Translator) error {
-	// NOTE: only have to register a non-pointer type for 'Namespaces', validator
+func registerRegexConstraintsValidator(validate *validator.Validate, trans ut.Translator) error {
+	// NOTE: only have to register a non-pointer type for 'RegexConstraints', validator
 	// internally dereferences it.
-	validate.RegisterStructValidation(namespacesStructValidator, RegexConstraints{})
+	validate.RegisterStructValidation(regexConstraintsStructValidator, RegexConstraints{})
 
 	return registerTranslation(validate, trans, map[string]string{
-		nsIncludeTag: "{0} matches both all and exact namespaces",
+		regexConstraintsIncludeTag: "{0} contains multiple constraints, but it does already include a regex pattern for all values",
 	})
 }
 
@@ -172,27 +172,27 @@ func socketSlackStructTokenValidator(sl validator.StructLevel) {
 	}
 }
 
-func namespacesStructValidator(sl validator.StructLevel) {
-	ns, ok := sl.Current().Interface().(RegexConstraints)
+func regexConstraintsStructValidator(sl validator.StructLevel) {
+	rc, ok := sl.Current().Interface().(RegexConstraints)
 	if !ok {
 		return
 	}
 
-	if len(ns.Include) < 2 {
+	if len(rc.Include) < 2 {
 		return
 	}
 
-	foundAllNamespaceIndicator := func() bool {
-		for _, name := range ns.Include {
-			if name == AllNamespaceIndicator {
+	foundAllValuesPattern := func() bool {
+		for _, name := range rc.Include {
+			if name == allValuesPattern {
 				return true
 			}
 		}
 		return false
 	}
 
-	if foundAllNamespaceIndicator() {
-		sl.ReportError(ns.Include, "Include", "Include", nsIncludeTag, "")
+	if foundAllValuesPattern() {
+		sl.ReportError(rc.Include, "Include", "Include", regexConstraintsIncludeTag, "")
 	}
 }
 

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -100,7 +100,7 @@ func registerCustomTranslations(validate *validator.Validate, trans ut.Translato
 func registerNamespaceValidator(validate *validator.Validate, trans ut.Translator) error {
 	// NOTE: only have to register a non-pointer type for 'Namespaces', validator
 	// internally dereferences it.
-	validate.RegisterStructValidation(namespacesStructValidator, Namespaces{})
+	validate.RegisterStructValidation(namespacesStructValidator, RegexConstraints{})
 
 	return registerTranslation(validate, trans, map[string]string{
 		nsIncludeTag: "{0} matches both all and exact namespaces",
@@ -173,7 +173,7 @@ func socketSlackStructTokenValidator(sl validator.StructLevel) {
 }
 
 func namespacesStructValidator(sl validator.StructLevel) {
-	ns, ok := sl.Current().Interface().(Namespaces)
+	ns, ok := sl.Current().Interface().(RegexConstraints)
 	if !ok {
 		return
 	}

--- a/pkg/execute/kubectl/merger.go
+++ b/pkg/execute/kubectl/merger.go
@@ -39,7 +39,13 @@ func NewMerger(executors map[string]config.Executors) *Merger {
 // The order of merging is the same as the order of items specified in the includeBindings list.
 func (kc *Merger) MergeForNamespace(includeBindings []string, forNamespace string) EnabledKubectl {
 	enabledInNs := func(executor config.Kubectl) bool {
-		return executor.Enabled && executor.Namespaces.IsAllowed(forNamespace)
+		nsAllowed, err := executor.Namespaces.IsAllowed(forNamespace)
+		if err != nil {
+			// regex error
+			return false
+		}
+
+		return executor.Enabled && nsAllowed
 	}
 	return kc.merge(kc.collect(includeBindings, enabledInNs), includeBindings)
 }

--- a/pkg/execute/kubectl/merger.go
+++ b/pkg/execute/kubectl/merger.go
@@ -9,7 +9,7 @@ type EnabledKubectl struct {
 	AllowedKubectlVerb     map[string]struct{}
 	AllowedKubectlResource map[string]struct{}
 
-	AllowedNamespacesPerResource map[string]config.Namespaces
+	AllowedNamespacesPerResource map[string]config.RegexConstraints
 
 	DefaultNamespace string
 	RestrictAccess   bool
@@ -78,7 +78,7 @@ func (kc *Merger) merge(collectedKubectls map[string]config.Kubectl, mapKeyOrder
 
 		allowedResources     = map[string]struct{}{}
 		allowedVerbs         = map[string]struct{}{}
-		allowedNSPerResource = map[string]config.Namespaces{}
+		allowedNSPerResource = map[string]config.RegexConstraints{}
 	)
 	for _, name := range mapKeyOrder {
 		item, found := collectedKubectls[name]

--- a/pkg/execute/kubectl/merger_test.go
+++ b/pkg/execute/kubectl/merger_test.go
@@ -28,7 +28,7 @@ func TestKubectlMerger(t *testing.T) {
 			},
 			givenNamespace: "team-a",
 			expectKubectlConfig: kubectl.EnabledKubectl{
-				AllowedNamespacesPerResource: map[string]config.Namespaces{
+				AllowedNamespacesPerResource: map[string]config.RegexConstraints{
 					"deployments": {
 						Include: []string{
 							"team-a",
@@ -58,7 +58,7 @@ func TestKubectlMerger(t *testing.T) {
 			},
 			givenNamespace: config.AllNamespaceIndicator,
 			expectKubectlConfig: kubectl.EnabledKubectl{
-				AllowedNamespacesPerResource: map[string]config.Namespaces{},
+				AllowedNamespacesPerResource: map[string]config.RegexConstraints{},
 				AllowedKubectlVerb: map[string]struct{}{
 					"logs":         {},
 					"top":          {},
@@ -77,7 +77,7 @@ func TestKubectlMerger(t *testing.T) {
 			},
 			givenNamespace: "team-a",
 			expectKubectlConfig: kubectl.EnabledKubectl{
-				AllowedNamespacesPerResource: map[string]config.Namespaces{
+				AllowedNamespacesPerResource: map[string]config.RegexConstraints{
 					"deployments": {
 						Include: []string{
 							"team-a",
@@ -102,7 +102,7 @@ func TestKubectlMerger(t *testing.T) {
 			},
 			givenNamespace: "team-a",
 			expectKubectlConfig: kubectl.EnabledKubectl{
-				AllowedNamespacesPerResource: map[string]config.Namespaces{
+				AllowedNamespacesPerResource: map[string]config.RegexConstraints{
 					"deployments": {
 						Include: []string{
 							"team-a",
@@ -129,7 +129,7 @@ func TestKubectlMerger(t *testing.T) {
 			},
 			givenNamespace: "team-a",
 			expectKubectlConfig: kubectl.EnabledKubectl{
-				AllowedNamespacesPerResource: map[string]config.Namespaces{
+				AllowedNamespacesPerResource: map[string]config.RegexConstraints{
 					"deployments": {
 						Include: []string{
 							"team-a",
@@ -156,7 +156,7 @@ func TestKubectlMerger(t *testing.T) {
 			},
 			givenNamespace: "team-b",
 			expectKubectlConfig: kubectl.EnabledKubectl{
-				AllowedNamespacesPerResource: map[string]config.Namespaces{
+				AllowedNamespacesPerResource: map[string]config.RegexConstraints{
 					"deployments": {
 						Include: []string{
 							"team-b",

--- a/pkg/execute/kubectl_cmd_builder.go
+++ b/pkg/execute/kubectl_cmd_builder.go
@@ -327,7 +327,14 @@ func (e *KubectlCmdBuilder) tryToGetNamespaceSelect(ctx context.Context, botName
 	initialNamespace = e.appendNamespaceSuffixIfDefault(initialNamespace)
 
 	for _, item := range allClusterNamespaces.Items {
-		if !allowedNS.IsAllowed(item.Name) {
+		allowed, err := allowedNS.IsAllowed(item.Name)
+		if err != nil {
+			log.WithField("namespace", item.Name).
+				WithField("error", err.Error()).
+				Error("Cannot check if namespace is allowed, so skipping it.")
+			continue
+		}
+		if !allowed {
 			log.WithField("namespace", item.Name).Debug("Namespace is not allowed, so skipping it.")
 			continue
 		}

--- a/pkg/execute/kubectl_cmd_builder_test.go
+++ b/pkg/execute/kubectl_cmd_builder_test.go
@@ -493,9 +493,9 @@ func (r *fakeKcMerger) MergeAllEnabled(_ []string) kubectl.EnabledKubectl {
 	for _, name := range r.allowedResources {
 		resources[name] = struct{}{}
 	}
-	resourceNamespaces := map[string]config.Namespaces{}
+	resourceNamespaces := map[string]config.RegexConstraints{}
 	for _, name := range r.allowedResources {
-		resourceNamespaces[name] = config.Namespaces{
+		resourceNamespaces[name] = config.RegexConstraints{
 			Include: []string{"default"},
 		}
 	}
@@ -508,7 +508,7 @@ func (r *fakeKcMerger) MergeAllEnabled(_ []string) kubectl.EnabledKubectl {
 
 type fakeNamespaceLister struct{}
 
-func (f *fakeNamespaceLister) List(_ context.Context, opts metav1.ListOptions) (*corev1.NamespaceList, error) {
+func (f *fakeNamespaceLister) List(_ context.Context, _ metav1.ListOptions) (*corev1.NamespaceList, error) {
 	return &corev1.NamespaceList{
 		Items: []corev1.Namespace{
 			{

--- a/pkg/execute/kubectl_test.go
+++ b/pkg/execute/kubectl_test.go
@@ -32,7 +32,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 			channelNotAuthorized: true,
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{"default"},
 				},
 				RestrictAccess: ptr.Bool(true),
@@ -49,7 +49,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 			command: "kubectl get pod -n foo",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{"foo"},
 				},
 				Commands: config.Commands{
@@ -65,7 +65,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 			command: "kubectl get pod",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: nil, // no namespace allowed.
 				},
 				Commands: config.Commands{
@@ -83,7 +83,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 			kubectlCfg: config.Kubectl{
 				Enabled:          true,
 				DefaultNamespace: "from-config",
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: nil, // forbid `from-config` to get a suitable error message.
 				},
 				Commands: config.Commands{
@@ -100,7 +100,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 			command: "kubectl get pod",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: nil, // forbid `default` to get a suitable error message.
 				},
 				Commands: config.Commands{
@@ -117,7 +117,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 			command: "kubectl get pod -n team-b",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{"team-a"},
 				},
 				Commands: config.Commands{
@@ -134,7 +134,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 			command: "kubectl get pod -n team-b",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{config.AllNamespaceIndicator},
 					Exclude: []string{"team-b"},
 				},
@@ -152,7 +152,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 			command: "kubectl get pod -A",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{"team-a"},
 				},
 				Commands: config.Commands{
@@ -169,7 +169,7 @@ func TestKubectlExecuteErrors(t *testing.T) {
 			command: "kubectl get -n team-a pod",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{"team-a"},
 				},
 				Commands: config.Commands{
@@ -225,7 +225,7 @@ func TestKubectlExecute(t *testing.T) {
 			command: "kubectl get",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{"default"},
 				},
 				Commands: config.Commands{
@@ -241,7 +241,7 @@ func TestKubectlExecute(t *testing.T) {
 			command: "kubectl get pod",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{config.AllNamespaceIndicator},
 				},
 				Commands: config.Commands{
@@ -258,7 +258,7 @@ func TestKubectlExecute(t *testing.T) {
 			command: "kubectl get pod -n team-a",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{"team-a"},
 				},
 				Commands: config.Commands{
@@ -276,7 +276,7 @@ func TestKubectlExecute(t *testing.T) {
 			channelNotAuthorized: true,
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{"team-a"},
 				},
 				Commands: config.Commands{
@@ -294,7 +294,7 @@ func TestKubectlExecute(t *testing.T) {
 			channelNotAuthorized: true,
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{"team-a"},
 				},
 				Commands: config.Commands{
@@ -311,7 +311,7 @@ func TestKubectlExecute(t *testing.T) {
 			command: "kubectl get pod/name-foo-42 -n team-a",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{"team-a"},
 				},
 				Commands: config.Commands{
@@ -328,7 +328,7 @@ func TestKubectlExecute(t *testing.T) {
 			command: "kubectl get pod -A",
 			kubectlCfg: config.Kubectl{
 				Enabled: true,
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{".*"},
 				},
 				Commands: config.Commands{
@@ -372,7 +372,7 @@ func TestKubectlCanHandle(t *testing.T) {
 	command := "kubectl get pod --cluster-name test"
 	kubectlCfg := config.Kubectl{
 		Enabled: true,
-		Namespaces: config.Namespaces{
+		Namespaces: config.RegexConstraints{
 			Include: []string{"team-a"},
 		},
 		Commands: config.Commands{
@@ -419,7 +419,7 @@ func TestKubectlGetCommandPrefix(t *testing.T) {
 	}
 	kubectlCfg := config.Kubectl{
 		Enabled: true,
-		Namespaces: config.Namespaces{
+		Namespaces: config.RegexConstraints{
 			Include: []string{"team-a"},
 		},
 		Commands: config.Commands{
@@ -449,7 +449,7 @@ func TestKubectlGetArgsWithoutAlias(t *testing.T) {
 	expected := "get pods --cluster-name test"
 	kubectlCfg := config.Kubectl{
 		Enabled: true,
-		Namespaces: config.Namespaces{
+		Namespaces: config.RegexConstraints{
 			Include: []string{"team-a"},
 		},
 		Commands: config.Commands{

--- a/pkg/recommendation/resource_events_test.go
+++ b/pkg/recommendation/resource_events_test.go
@@ -231,7 +231,7 @@ func fixSources() map[string]config.Sources {
 				Resources: []config.Resource{
 					{
 						Type:       "v1/deployments",
-						Namespaces: config.Namespaces{},
+						Namespaces: config.RegexConstraints{},
 						Event: config.KubernetesEvent{
 							Types: []config.EventType{config.AllEvent},
 						},
@@ -244,7 +244,7 @@ func fixSources() map[string]config.Sources {
 				Resources: []config.Resource{
 					{
 						Type: recommendation.PodResourceType(),
-						Namespaces: config.Namespaces{
+						Namespaces: config.RegexConstraints{
 							Include: []string{".*"},
 						},
 						Event: config.KubernetesEvent{
@@ -256,7 +256,7 @@ func fixSources() map[string]config.Sources {
 		},
 		"pods-source-wide-ns": {
 			Kubernetes: config.KubernetesSource{
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{".*"},
 				},
 				Resources: []config.Resource{
@@ -271,13 +271,13 @@ func fixSources() map[string]config.Sources {
 		},
 		"pods-ns-override": {
 			Kubernetes: config.KubernetesSource{
-				Namespaces: config.Namespaces{
+				Namespaces: config.RegexConstraints{
 					Include: []string{"default"},
 				},
 				Resources: []config.Resource{
 					{
 						Type: recommendation.PodResourceType(),
-						Namespaces: config.Namespaces{
+						Namespaces: config.RegexConstraints{
 							Include: []string{"kube-system"},
 						},
 						Event: config.KubernetesEvent{
@@ -292,7 +292,7 @@ func fixSources() map[string]config.Sources {
 				Resources: []config.Resource{
 					{
 						Type: recommendation.PodResourceType(),
-						Namespaces: config.Namespaces{
+						Namespaces: config.RegexConstraints{
 							Include: []string{"kube-system"},
 						},
 						Event: config.KubernetesEvent{
@@ -307,7 +307,7 @@ func fixSources() map[string]config.Sources {
 				Resources: []config.Resource{
 					{
 						Type: recommendation.PodResourceType(),
-						Namespaces: config.Namespaces{
+						Namespaces: config.RegexConstraints{
 							Include: []string{".*"},
 						},
 						Event: config.KubernetesEvent{


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Support `include/exclude` regexes for `event.reason`, `event.message` and `resources[].name`.

## Breaking changes

_(To copy and paste in https://github.com/kubeshop/botkube/issues/972)_

- Kubernetes source constraints `event.reason`, `event.message` and `resources[].name` are now objects with two lists: `include` and `exclude`. Both take exact values or regex patterns. Exclude takes precedence over include.

   This allows you to set `exclude` patterns, and also unifies the configuration with `namespaces` constraints.

## Notes - open question
I didn't rename `namespaces` to `namespace` or `event.types` to `event.type` as I weren't sure if that's a good change. However, if you have any ideas, then please let me know - we're already doing a breaking change here, so I can unify the config properties more 🙂 

Maybe we should rename `namespaces` to `namespace` for consistency (as it is an object), and keep plural form for `event.types` as it is an array? Let me know 🙂 

## TODO

- [x] Update docs: https://github.com/kubeshop/botkube-docs/pull/211

## Testing

Check out the PR (`gh pr checkout 963`).

Use the configuration:
```
communications:
  "default-group":
    socketSlack:
      enabled: true
      appToken: "xapp-"
      botToken: "xoxb-"
      notification:
        type: "short"
      channels:
        "default":
          name: botkube-demo
          bindings:
            executors:
              - kubectl-read-only
              - helm
              - plugin-based
            sources:
              - k8s-all-events
              - k8s-recommendation-events
              - plugin-based
        "secondary":
          name: priv-channel
          bindings:
            executors: []
            sources:
              - k8s-all-events-except
sources:
  'k8s-all-events-except':
    displayName: "Kubernetes Info"
    kubernetes:
      namespaces:
        include:
          - ".*"
      event:
        types:
          - create
          - delete
          - error
        message:
          include: [".*"]
          exclude: ["^Readiness probe failed.*$"]
      resources:
        - type: v1/pods
        - type: v1/services
        - type: networking.k8s.io/v1/ingresses
        - type: v1/nodes
        - type: v1/namespaces
        - type: v1/persistentvolumes
        - type: v1/persistentvolumeclaims
        - type: v1/configmaps
        - type: rbac.authorization.k8s.io/v1/roles
        - type: rbac.authorization.k8s.io/v1/rolebindings
        - type: rbac.authorization.k8s.io/v1/clusterrolebindings
        - type: rbac.authorization.k8s.io/v1/clusterroles
        - type: apps/v1/daemonsets
          event:
            types:
              - create
              - update
              - delete
              - error
          updateSetting:
            includeDiff: true
            fields:
              - spec.template.spec.containers[*].image
              - status.numberReady
        - type: batch/v1/jobs
          event:
            types:
              - create
              - update
              - delete
              - error
          updateSetting:
            includeDiff: true
            fields:
              - spec.template.spec.containers[*].image
              - status.conditions[*].type
        - type: apps/v1/deployments
          event:
            types:
              - create
              - update
              - delete
              - error
          updateSetting:
            includeDiff: true
            fields:
              - spec.template.spec.containers[*].image
              - status.availableReplicas
        - type: apps/v1/statefulsets
          event:
            types:
              - create
              - update
              - delete
              - error
          updateSetting:
            includeDiff: true
            fields:
              - spec.template.spec.containers[*].image
              - status.readyReplicas

settings:
  clusterName: "dev"
  upgradeNotifier: false
```

Run Botkube:
```
export BOTKUBE_SETTINGS_LOG_LEVEL=info
export BOTKUBE_PLUGINS_CACHE__DIR="/tmp/plugins"
export BOTKUBE_SETTINGS_KUBECONFIG=$KUBECONFIG # optional
export BOTKUBE_CONFIG_PATHS="$(pwd)/helm/botkube/values.yaml,$(pwd)/comm_config.yaml"
go run cmd/botkube/main.go
```

Run the command to trigger events:
```
k delete po -n kube-system -l k8s-app=metrics-server
```

See events with `Readiness probe failed` message:
![image](https://user-images.githubusercontent.com/7155799/216093454-9c3d3882-54b7-44a2-b939-208a5c76c49c.png)

On `priv-channel`, they will be filtered out nicely:

![image](https://user-images.githubusercontent.com/7155799/216098905-b97d4438-e4bb-4fe6-87de-147126ed2ff6.png)



## Related issue(s)

#954 