### PR TITLE
Add SourceBindings built-in alias and fix filtering commands

### DIFF
--- a/pkg/execute/action.go
+++ b/pkg/execute/action.go
@@ -109,9 +109,9 @@ func (e *ActionExecutor) ActionsTabularOutput() string {
 
 	buf := new(bytes.Buffer)
 	w := tabwriter.NewWriter(buf, 5, 0, 1, ' ', 0)
-	fmt.Fprintln(w, "ACTION\tENABLED \tDISPLAY NAME")
+	fmt.Fprintf(w, "ACTION\tENABLED \tDISPLAY NAME")
 	for _, name := range keys {
-		fmt.Fprintf(w, "%s\t%v \t%s\n", name, e.actions[name].Enabled, e.actions[name].DisplayName)
+		fmt.Fprintf(w, "\n%s\t%v \t%s", name, e.actions[name].Enabled, e.actions[name].DisplayName)
 	}
 	w.Flush()
 	return buf.String()

--- a/pkg/execute/alias.go
+++ b/pkg/execute/alias.go
@@ -105,10 +105,10 @@ func (e *AliasExecutor) getTabularOutput(bindings []string) string {
 
 	buf := new(bytes.Buffer)
 	w := tabwriter.NewWriter(buf, 5, 0, 1, ' ', 0)
-	fmt.Fprintln(w, "ALIAS\tCOMMAND\tDISPLAY NAME")
+	fmt.Fprintf(w, "ALIAS\tCOMMAND\tDISPLAY NAME")
 	for _, aliasName := range maputil.SortKeys(aliasesToDisplay) {
 		aliasCfg := aliasesCfg[aliasName]
-		fmt.Fprintf(w, "%s\t%s\t%s\n", aliasName, aliasCfg.Command, aliasCfg.DisplayName)
+		fmt.Fprintf(w, "\n%s\t%s\t%s", aliasName, aliasCfg.Command, aliasCfg.DisplayName)
 	}
 
 	w.Flush()

--- a/pkg/execute/config.go
+++ b/pkg/execute/config.go
@@ -50,7 +50,7 @@ func (e *ConfigExecutor) Commands() map[command.Verb]CommandFn {
 }
 
 // Show returns Config in yaml format
-func (e *ConfigExecutor) Show(ctx context.Context, cmdCtx CommandContext) (interactive.Message, error) {
+func (e *ConfigExecutor) Show(_ context.Context, cmdCtx CommandContext) (interactive.Message, error) {
 	cmdVerb, cmdRes := parseCmdVerb(cmdCtx.Args)
 	defer e.reportCommand(cmdVerb, cmdRes, cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
 

--- a/pkg/execute/config_test.go
+++ b/pkg/execute/config_test.go
@@ -77,7 +77,8 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 						    tmpDir: ""
 						plugins:
 						    cacheDir: ""
-						    repositories: {}`),
+						    repositories: {}
+						`),
 		},
 	}
 	for _, tc := range testCases {
@@ -85,7 +86,7 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 			e := NewConfigExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, tc.Cfg)
 			msg, err := e.Show(context.Background(), tc.CmdCtx)
 			require.NoError(t, err)
-			assert.Equal(t, msg.Body.CodeBlock, tc.ExpectedResult)
+			assert.Equal(t, tc.ExpectedResult, msg.Body.CodeBlock)
 		})
 	}
 }

--- a/pkg/execute/exec.go
+++ b/pkg/execute/exec.go
@@ -67,11 +67,11 @@ func (e *ExecExecutor) TabularOutput(bindings []string) string {
 
 	buf := new(bytes.Buffer)
 	w := tabwriter.NewWriter(buf, 5, 0, 1, ' ', 0)
-	fmt.Fprintln(w, "EXECUTOR\tENABLED\tALIASES")
+	fmt.Fprintf(w, "EXECUTOR\tENABLED\tALIASES")
 	for _, name := range maputil.SortKeys(executors) {
 		enabled := executors[name]
 		aliases := alias.ListExactForExecutor(name, e.cfg.Aliases)
-		fmt.Fprintf(w, "%s\t%t\t%s\n", name, enabled, strings.Join(aliases, ", "))
+		fmt.Fprintf(w, "\n%s\t%t\t%s", name, enabled, strings.Join(aliases, ", "))
 	}
 
 	w.Flush()

--- a/pkg/execute/exec_test.go
+++ b/pkg/execute/exec_test.go
@@ -104,7 +104,7 @@ func TestExecutorBindingsExecutor(t *testing.T) {
 				EXECUTOR                  ENABLED ALIASES
 				botkube/echo@v1.0.1-devel true    e
 				botkube/helm              true    h
-				kubectl                   true    `),
+				kubectl                   true`),
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -205,8 +205,12 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.Message {
 	}
 
 	if !foundFn {
-		e.reportCommand(fmt.Sprintf("%s {invalid feature}", cmdVerb), false)
-		e.log.Infof("received unsupported resource: %q", cmdCtx.CleanCmd)
+		reportedCmd := string(cmdVerb)
+		if cmdRes != "" {
+			e.log.Infof("received unsupported resource: %q", cmdCtx.CleanCmd)
+			reportedCmd = fmt.Sprintf("%s {invalid feature}", reportedCmd)
+		}
+		e.reportCommand(reportedCmd, false)
 		msg := e.cmdsMapping.HelpMessageForVerb(cmdVerb, cmdCtx.BotName)
 		return respond(msg, cmdCtx)
 	}

--- a/pkg/execute/executor_filter.go
+++ b/pkg/execute/executor_filter.go
@@ -6,31 +6,7 @@ import (
 	"strings"
 )
 
-// executorFilter interface to implement to filter executor text based results
-type executorFilter interface {
-	Apply(string) string
-	IsActive() bool
-}
-
-// executorEchoFilter echos given text when asked to filter executor text results.
-// Mainly used when executor commands are missing a "--filter=xxx" flag.
-type executorEchoFilter struct {
-}
-
-// IsActive whether this filter will actually mutate the output or not.
-func (f *executorEchoFilter) IsActive() bool {
-	return false
-}
-
-// Apply implements executorFilter to apply filtering.
-func (f *executorEchoFilter) Apply(text string) string {
-	return text
-}
-
-// newExecutorEchoFilter creates a new executorEchoFilter.
-func newExecutorEchoFilter(command string) *executorEchoFilter {
-	return &executorEchoFilter{}
-}
+var _ executorFilter = &executorTextFilter{}
 
 // executorTextFilter filters executor text results by a given text value.
 type executorTextFilter struct {
@@ -39,7 +15,7 @@ type executorTextFilter struct {
 
 // IsActive whether this filter will actually mutate the output or not.
 func (f *executorTextFilter) IsActive() bool {
-	return true
+	return len(f.value) > 0
 }
 
 // newExecutorTextFilter creates a new executorTextFilter.
@@ -51,6 +27,10 @@ func newExecutorTextFilter(val string) *executorTextFilter {
 
 // Apply implements executorFilter to apply filtering.
 func (f *executorTextFilter) Apply(text string) string {
+	if !f.IsActive() {
+		return text
+	}
+
 	var out strings.Builder
 
 	scanner := bufio.NewScanner(strings.NewReader(text))

--- a/pkg/execute/executor_filter_test.go
+++ b/pkg/execute/executor_filter_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExecutorEchoFilter_Apply(t *testing.T) {
-	var filter executorFilter = newExecutorEchoFilter("")
+func TestExecutorTextFilter_Empty(t *testing.T) {
+	var filter executorFilter = newExecutorTextFilter("")
 
 	text := "Please return this same text."
 	assert.Equal(t, text, filter.Apply(text))
+	assert.False(t, filter.IsActive())
 }
 
 func TestExecutorTextFilter_Apply(t *testing.T) {

--- a/pkg/execute/filter.go
+++ b/pkg/execute/filter.go
@@ -124,9 +124,9 @@ func (e *FilterExecutor) TabularOutput() string {
 	buf := new(bytes.Buffer)
 	w := tabwriter.NewWriter(buf, 5, 0, 1, ' ', 0)
 
-	fmt.Fprintln(w, "FILTER\tENABLED\tDESCRIPTION")
+	fmt.Fprintf(w, "FILTER\tENABLED\tDESCRIPTION")
 	for _, filter := range e.filterEngine.RegisteredFilters() {
-		fmt.Fprintf(w, "%s\t%v\t%s\n", filter.Name(), filter.Enabled, filter.Describe())
+		fmt.Fprintf(w, "\n%s\t%v\t%s", filter.Name(), filter.Enabled, filter.Describe())
 	}
 
 	w.Flush()

--- a/pkg/execute/mapping.go
+++ b/pkg/execute/mapping.go
@@ -26,6 +26,12 @@ type CommandExecutor interface {
 	FeatureName() FeatureName
 }
 
+// executorFilter interface to implement to filter executor text based results
+type executorFilter interface {
+	Apply(string) string
+	IsActive() bool
+}
+
 // CommandFn is a single command (eg. List())
 type CommandFn func(ctx context.Context, cmdCtx CommandContext) (interactive.Message, error)
 

--- a/pkg/execute/source.go
+++ b/pkg/execute/source.go
@@ -81,10 +81,10 @@ func (e *SourceExecutor) TabularOutput(bindings []string) string {
 
 	buf := new(bytes.Buffer)
 	w := tabwriter.NewWriter(buf, 5, 0, 1, ' ', 0)
-	fmt.Fprintln(w, "SOURCE\tENABLED")
+	fmt.Fprintf(w, "SOURCE\tENABLED")
 	for _, key := range maputil.SortKeys(sources) {
 		enabled := sources[key]
-		fmt.Fprintf(w, "%s\t%t\n", key, enabled)
+		fmt.Fprintf(w, "\n%s\t%t", key, enabled)
 	}
 	w.Flush()
 	return buf.String()

--- a/pkg/execute/sourcebinding.go
+++ b/pkg/execute/sourcebinding.go
@@ -28,7 +28,7 @@ const (
 var (
 	sourceBindingFeatureName = FeatureName{
 		Name:    "sourcebinding",
-		Aliases: []string{"sourcebindings"},
+		Aliases: []string{"sourcebindings", "sb"},
 	}
 )
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Add SourceBindings alias (`sb`)
- Fix executing filtering for each command even if `--filter` is not passed
    - Filter reporting of filtered command
- Don't report invalid feature for command without provided one

## Screenshots

![obraz](https://user-images.githubusercontent.com/7155799/216561754-86d9e339-3249-4ba8-8ed3-c9fe54c3ea66.png)

## Testing

Checkout the PR and run Botkube locally with any config.
Edit `noop_reporter.go` and change `ReportCommand`

```go
// ReportCommand reports a new executed command. The command should be anonymized before using this method.
func (n NoopReporter) ReportCommand(plat config.CommPlatformIntegration, cmd string, org command.Origin, filtered bool) error {
	// print all input params to make sure they are passed correctly
	log.Println("ReportCommand", plat, cmd, org, filtered)
	return nil
}
```

Run `@Botkube edit` and see `sb` alias available.
See that there's no log like:
```
time="2023-02-03T08:32:05Z" level=info msg="received unsupported resource: \"get\"" component=Executor
``` 

Run a few more commands with `--filter` and without. See if the reported command is filtered.