### PR TITLE
Include API Key when fetching remote Botkube configuration

### DIFF
--- a/cmd/botkube/main.go
+++ b/cmd/botkube/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/google/go-github/v44/github"
@@ -29,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/kubeshop/botkube/internal/analytics"
-	intconfig "github.com/kubeshop/botkube/internal/config"
 	"github.com/kubeshop/botkube/internal/lifecycle"
 	"github.com/kubeshop/botkube/internal/loggerx"
 	"github.com/kubeshop/botkube/internal/plugin"
@@ -74,8 +72,8 @@ func main() {
 func run(ctx context.Context) error {
 	// Load configuration
 	config.RegisterFlags(pflag.CommandLine)
-	var gqlClient intconfig.GqlClient = intconfig.NewGqlClient(intconfig.WithAPIURL(os.Getenv("CONFIG_PROVIDER_ENDPOINT")))
-	configs, err := config.FromProvider(ctx, &gqlClient)
+	cfgProvider := config.GetProvider()
+	configs, err := cfgProvider.Configs(ctx)
 	if err != nil {
 		return fmt.Errorf("while loading configuration files: %w", err)
 	}

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -210,10 +210,11 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [plugins.cacheDir](./values.yaml#L949) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
 | [plugins.repositories](./values.yaml#L951) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}` | List of plugins repositories. |
 | [plugins.repositories.botkube](./values.yaml#L953) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
-| [config](./values.yaml#L957) | object | `{"provider":{"endpoint":"","identifier":""}}` | Configuration for remote Botkube settings |
-| [config.provider](./values.yaml#L959) | object | `{"endpoint":"","identifier":""}` | Base provider definition |
-| [config.provider.identifier](./values.yaml#L961) | string | `""` | Unique identifier for remote Botkube settings |
-| [config.provider.endpoint](./values.yaml#L963) | string | `""` | Endpoint to fetch Botkube settings from |
+| [config](./values.yaml#L957) | object | `{"provider":{"apiKey":"","endpoint":"","identifier":""}}` | Configuration for fetching Botkube configuration. |
+| [config.provider](./values.yaml#L959) | object | `{"apiKey":"","endpoint":"","identifier":""}` | Base provider definition. |
+| [config.provider.identifier](./values.yaml#L961) | string | `""` | Unique identifier for remote Botkube settings. |
+| [config.provider.endpoint](./values.yaml#L963) | string | `""` | Endpoint to fetch Botkube settings from. |
+| [config.provider.apiKey](./values.yaml#L965) | string | `""` | Key passed as a `X-API-Key` header to the provider's endpoint. |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -121,6 +121,10 @@ spec:
             - name: CONFIG_PROVIDER_IDENTIFIER
               value: "{{ .Values.config.provider.identifier }}"
             {{- end }}
+            {{- if .Values.config.provider.apiKey }}
+            - name: CONFIG_PROVIDER_API_KEY
+              value: "{{ .Values.config.provider.apiKey }}"
+            {{- end }}
           {{- with .Values.extraEnv }}
             {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -953,11 +953,13 @@ plugins:
     botkube:
       url: https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml
 
-# -- Configuration for remote Botkube settings
+# -- Configuration for fetching Botkube configuration.
 config:
-  # -- Base provider definition
+  # -- Base provider definition.
   provider:
-    # -- Unique identifier for remote Botkube settings
+    # -- Unique identifier for remote Botkube settings.
     identifier: ""
-    # -- Endpoint to fetch Botkube settings from
+    # -- Endpoint to fetch Botkube settings from.
     endpoint: ""
+    # -- Key passed as a `X-API-Key` header to the provider's endpoint.
+    apiKey: ""

--- a/internal/config/env_provider.go
+++ b/internal/config/env_provider.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 )
 
+const (
+	EnvProviderConfigPathsEnvKey = "BOTKUBE_CONFIG_PATHS"
+)
+
 // EnvProvider environment config source provider
 type EnvProvider struct {
 }
@@ -17,7 +21,7 @@ func NewEnvProvider() *EnvProvider {
 
 // Configs returns list of config file locations
 func (e *EnvProvider) Configs(ctx context.Context) (YAMLFiles, error) {
-	envCfgs := os.Getenv("BOTKUBE_CONFIG_PATHS")
+	envCfgs := os.Getenv(EnvProviderConfigPathsEnvKey)
 	configPaths := strings.Split(envCfgs, ",")
 
 	return NewFileSystemProvider(configPaths).Configs(ctx)

--- a/internal/config/gql_client.go
+++ b/internal/config/gql_client.go
@@ -2,58 +2,107 @@ package config
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/hasura/go-graphql-client"
 )
 
-// GqlClient GraphQL client
+const (
+	defaultTimeout = 30 * time.Second
+	//nolint:gosec // warns us about 'Potential hardcoded credentials' but there is no security issue here
+	apiKeyHeaderName = "X-API-Key"
+)
+
+// GqlClient defines GraphQL client.
 type GqlClient interface {
-	GetDeployment(ctx context.Context, id string) (Deployment, error)
+	GetDeployment(ctx context.Context) (Deployment, error)
 }
 
-// Option GraphQL client options
+// Option define GraphQL client option.
 type Option func(*Gql)
 
-// WithAPIURL configures ApiURL for GraphQL endpoint
-func WithAPIURL(url string) Option {
+// WithEndpoint configures ApiURL for GraphQL endpoint.
+func WithEndpoint(url string) Option {
 	return func(client *Gql) {
-		client.APIURL = url
+		client.Endpoint = url
 	}
 }
 
-// Gql GraphQL client data structure
-type Gql struct {
-	Gql    *graphql.Client
-	APIURL string
+// WithAPIKey configures API key for GraphQL endpoint.
+func WithAPIKey(apiKey string) Option {
+	return func(client *Gql) {
+		client.APIKey = apiKey
+	}
 }
 
-// NewGqlClient initializes GraphQL client
+// WithDeploymentID configures deployment id for GraphQL endpoint.
+func WithDeploymentID(id string) Option {
+	return func(client *Gql) {
+		client.DeploymentID = id
+	}
+}
+
+// Gql defines GraphQL client data structure.
+type Gql struct {
+	Cli          *graphql.Client
+	Endpoint     string
+	APIKey       string
+	DeploymentID string
+}
+
+// NewGqlClient initializes GraphQL client.
 func NewGqlClient(options ...Option) *Gql {
 	c := &Gql{}
 	for _, opt := range options {
 		opt(c)
 	}
-	return &Gql{
-		Gql: graphql.NewClient(c.APIURL, nil),
+
+	httpCli := &http.Client{
+		Transport: newAPIKeySecuredTransport(c.APIKey),
+		Timeout:   defaultTimeout,
 	}
+
+	c.Cli = graphql.NewClient(c.Endpoint, httpCli)
+	return c
 }
 
-// Deployment returns deployment with Botkube configuration
+// Deployment returns deployment with Botkube configuration.
 type Deployment struct {
 	BotkubeConfig string
 }
 
-// GetDeployment retrieves deployment by id
-func (c *Gql) GetDeployment(ctx context.Context, id string) (Deployment, error) {
+// GetDeployment retrieves deployment by id.
+func (c *Gql) GetDeployment(ctx context.Context) (Deployment, error) {
 	var query struct {
 		Deployment Deployment `graphql:"deployment(id: $id)"`
 	}
 	variables := map[string]interface{}{
-		"id": graphql.ID(id),
+		"id": graphql.ID(c.DeploymentID),
 	}
-	err := c.Gql.Query(ctx, &query, variables)
+	err := c.Cli.Query(ctx, &query, variables)
 	if err != nil {
-		return Deployment{}, err
+		return Deployment{}, fmt.Errorf("while querying deployment details for %q: %w", c.DeploymentID, err)
 	}
 	return query.Deployment, nil
+}
+
+type apiKeySecuredTransport struct {
+	apiKey    string
+	transport *http.Transport
+}
+
+func newAPIKeySecuredTransport(apiKey string) *apiKeySecuredTransport {
+	return &apiKeySecuredTransport{
+		apiKey:    apiKey,
+		transport: http.DefaultTransport.(*http.Transport).Clone(),
+	}
+}
+
+func (t *apiKeySecuredTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.apiKey != "" {
+		req.Header.Set(apiKeyHeaderName, t.apiKey)
+	}
+	return t.transport.RoundTrip(req)
 }

--- a/internal/config/gql_client_test.go
+++ b/internal/config/gql_client_test.go
@@ -3,24 +3,46 @@ package config
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGql_GetDeployment(t *testing.T) {
+	expectedBody := fmt.Sprintf(`{"query":"query ($id:ID!){deployment(id: $id){botkubeConfig}}","variables":{"id":"my-id"}}%s`, "\n")
 	file, err := os.ReadFile("testdata/gql_get_deployment_success.json")
 	assert.NoError(t, err)
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != "api-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer r.Body.Close()
+		t.Log("body", string(bodyBytes))
+		t.Log("expected body", expectedBody)
+
+		if !strings.EqualFold(string(bodyBytes), expectedBody) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
 		fmt.Fprint(w, string(file))
 	}))
 	defer svr.Close()
 
-	g := NewGqlClient(WithAPIURL(svr.URL))
-	deployment, err := g.GetDeployment(context.Background(), "16")
+	g := NewGqlClient(WithEndpoint(svr.URL), WithDeploymentID("my-id"), WithAPIKey("api-key"))
+	deployment, err := g.GetDeployment(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, deployment.BotkubeConfig)
 }

--- a/internal/config/gql_provider.go
+++ b/internal/config/gql_provider.go
@@ -2,10 +2,16 @@ package config
 
 import (
 	"context"
-	"os"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
+)
+
+const (
+	GqlProviderEndpointEnvKey   = "CONFIG_PROVIDER_ENDPOINT"
+	GqlProviderIdentifierEnvKey = "CONFIG_PROVIDER_IDENTIFIER"
+	//nolint:gosec // warns us about 'Potential hardcoded credentials' but there is no security issue here
+	GqlProviderAPIKeyEnvKey = "CONFIG_PROVIDER_API_KEY"
 )
 
 // GqlProvider is GraphQL provider
@@ -20,17 +26,13 @@ func NewGqlProvider(gql GqlClient) *GqlProvider {
 
 // Configs returns list of config files
 func (g *GqlProvider) Configs(ctx context.Context) (YAMLFiles, error) {
-	d := os.Getenv("CONFIG_PROVIDER_IDENTIFIER")
-	if d == "" {
-		return nil, nil
-	}
-	deployment, err := g.GqlClient.GetDeployment(ctx, d)
+	deployment, err := g.GqlClient.GetDeployment(ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "while getting deployment with id %s", d)
+		return nil, errors.Wrapf(err, "while getting deployment")
 	}
 	conf, err := yaml.JSONToYAML([]byte(deployment.BotkubeConfig))
 	if err != nil {
-		return nil, errors.Wrapf(err, "while converting json to yaml for deployment with id %s", d)
+		return nil, errors.Wrapf(err, "while converting json to yaml for deployment")
 	}
 
 	return [][]byte{

--- a/internal/config/gql_provider_test.go
+++ b/internal/config/gql_provider_test.go
@@ -13,7 +13,7 @@ var _ GqlClient = &fakeGqlClient{}
 type fakeGqlClient struct {
 }
 
-func (f *fakeGqlClient) GetDeployment(ctx context.Context, id string) (Deployment, error) {
+func (f *fakeGqlClient) GetDeployment(ctx context.Context) (Deployment, error) {
 	return Deployment{
 		BotkubeConfig: "{\"settings\":{\"clusterName\":\"qa\"},\"sources\":{\"kubernetes-info\":{\"displayName\":\"Kubernetes Information\",\"kubernetes\":{\"recommendations\":{\"pod\":{\"noLatestImageTag\":true,\"labelsSet\":true},\"ingress\":{\"backendServiceValid\":true,\"tlsSecretValid\":true}}}}},\"executors\":{\"kubectl-read-only\":{\"kubectl\":{\"namespaces\":{\"include\":[\".*\"]},\"enabled\":true,\"commands\":{\"verbs\":[\"api-resources\",\"api-versions\",\"cluster-info\",\"describe\",\"diff\",\"explain\",\"get\",\"logs\",\"top\",\"auth\"],\"resources\":[\"deployments\",\"pods\",\"namespaces\",\"daemonsets\",\"statefulsets\",\"storageclasses\",\"nodes\"]},\"defaultNamespace\":\"default\",\"restrictAccess\":false}}},\"communications\":{\"default-group\":{\"socketSlack\":{\"enabled\":true,\"channels\":{\"botkube-demo\":{\"name\":\"botkube-demo\",\"notification\":{\"disabled\":false},\"bindings\":{\"sources\":[\"kubernetes-info\"],\"executors\":[\"kubectl-read-only\"]}}},\"botToken\":\"xoxb-3933899240838\",\"appToken\":\"xapp-1-A047D1ZJ03B-4262138376928\"}}}}",
 	}, nil
@@ -22,7 +22,6 @@ func (f *fakeGqlClient) GetDeployment(ctx context.Context, id string) (Deploymen
 func TestGqlProviderSuccess(t *testing.T) {
 	//given
 	f := fakeGqlClient{}
-	t.Setenv("CONFIG_PROVIDER_IDENTIFIER", "16")
 	p := NewGqlProvider(&f)
 
 	// when

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -93,7 +93,8 @@ func TestFromProvider(t *testing.T) {
 		t.Setenv("BOTKUBE_CONFIG_PATHS", "testdata/TestFromProvider/first.yaml,testdata/TestFromProvider/second.yaml,testdata/TestFromProvider/third.yaml")
 
 		// when
-		gotConfigs, err := config.FromProvider(context.Background(), nil)
+		provider := config.GetProvider()
+		gotConfigs, err := provider.Configs(context.Background())
 		assert.NoError(t, err)
 
 		// then
@@ -110,7 +111,8 @@ func TestFromProvider(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		gotConfigs, err := config.FromProvider(context.Background(), nil)
+		provider := config.GetProvider()
+		gotConfigs, err := provider.Configs(context.Background())
 		assert.NoError(t, err)
 
 		// then
@@ -130,7 +132,8 @@ func TestFromProvider(t *testing.T) {
 		t.Setenv("BOTKUBE_CONFIG_PATHS", "testdata/TestFromProvider/first.yaml,testdata/TestFromProvider/second.yaml,testdata/TestFromProvider/third.yaml")
 
 		// when
-		gotConfigs, err := config.FromProvider(context.Background(), nil)
+		provider := config.GetProvider()
+		gotConfigs, err := provider.Configs(context.Background())
 		assert.NoError(t, err)
 
 		// then


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Include API Key when fetching remote Botkube configuration

## Testing

On your Kubernetes cluster:

Install echo server:
```bash
helm repo add ealenn https://ealenn.github.io/charts
helm repo update ealenn
helm install echo-server ealenn/echo-server --set application.logs.ignore.ping=true --set application.enable.environment=false --wait
```

Checkout PR and install botkube:

```bash
gh pr checkout 980
helm install botkube -n botkube --create-namespace \
--set image.repository=kubeshop/pr/botkube \
--set image.tag=980-PR --set config.provider.endpoint="http://echo-server.default" --set config.provider.identifier="123" --set config.provider.apiKey="my-api-key" ./helm/botkube
```

See the logs of echo server 🙂 

```
k logs echo-server-d54559dfc-z6x8j
(node:1) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Listening on port 80.
Mon, 13 Feb 2023 16:40:41 GMT express deprecated res.status("200"): use res.status(200) instead at webserver.js:1:661489
{"name":"echo-server","hostname":"echo-server-d54559dfc-z6x8j","pid":1,"level":30,"host":{"hostname":"echo-server.default","ip":"::ffff:10.42.0.35","ips":[]},"http":{"method":"POST","baseUrl":"","originalUrl":"/","protocol":"http"},"request":{"params":{},"query":{},"cookies":{},"body":{"query":"query ($id:ID!){deployment(id: $id){botkubeConfig}}","variables":{"id":"123"}},"headers":{"host":"echo-server.default","user-agent":"Go-http-client/1.1","content-length":"89","content-type":"application/json","x-api-key":"my-api-key","accept-encoding":"gzip"}},"msg":"Mon, 13 Feb 2023 16:45:48 GMT | [POST] - http://echo-server.default/","time":"2023-02-13T16:45:48.199Z","v":0}
{"name":"echo-server","hostname":"echo-server-d54559dfc-z6x8j","pid":1,"level":30,"host":{"hostname":"echo-server.default","ip":"::ffff:10.42.0.35","ips":[]},"http":{"method":"POST","baseUrl":"","originalUrl":"/","protocol":"http"},"request":{"params":{},"query":{},"cookies":{},"body":{"query":"query ($id:ID!){deployment(id: $id){botkubeConfig}}","variables":{"id":"123"}},"headers":{"host":"echo-server.default","user-agent":"Go-http-client/1.1","content-length":"89","content-type":"application/json","x-api-key":"my-api-key","accept-encoding":"gzip"}},"msg":"Mon, 13 Feb 2023 16:45:58 GMT | [POST] - http://echo-server.default/","time":"2023-02-13T16:45:58.397Z","v":0}
```