### PR TITLE
Report executor and source actions to backend

### DIFF
--- a/internal/audit/gql_reporter.go
+++ b/internal/audit/gql_reporter.go
@@ -27,7 +27,7 @@ func newGraphQLAuditReporter(logger logrus.FieldLogger, client *gql.Gql) *GraphQ
 }
 
 // ReportExecutorAuditEvent reports executor audit event using graphql interface
-func (r *GraphQLAuditReporter) ReportExecutorAuditEvent(ctx context.Context, e AuditEvent) error {
+func (r *GraphQLAuditReporter) ReportExecutorAuditEvent(ctx context.Context, e ExecutorAuditEvent) error {
 	r.log.Debugf("Reporting executor audit event for ID: %s", r.gql.DeploymentID)
 	var mutation struct {
 		CreateAuditEvent struct {
@@ -53,7 +53,7 @@ func (r *GraphQLAuditReporter) ReportExecutorAuditEvent(ctx context.Context, e A
 }
 
 // ReportSourceAuditEvent reports source audit event using graphql interface
-func (r *GraphQLAuditReporter) ReportSourceAuditEvent(ctx context.Context, e AuditEvent) error {
+func (r *GraphQLAuditReporter) ReportSourceAuditEvent(ctx context.Context, e SourceAuditEvent) error {
 	r.log.Debugf("Reporting source audit event for ID: %s", r.gql.DeploymentID)
 	var mutation struct {
 		CreateAuditEvent struct {
@@ -120,7 +120,7 @@ func NewBotPlatform(s string) (BotPlatform, error) {
 	case "SLACK":
 		fallthrough
 	case "SOCKETSLACK":
-		return BotPlatformSLACk, nil
+		return BotPlatformSlack, nil
 	case "DISCORD":
 		return BotPlatformDiscord, nil
 	case "MATTERMOST":

--- a/internal/audit/gql_reporter.go
+++ b/internal/audit/gql_reporter.go
@@ -104,8 +104,8 @@ type AuditEventSourceCreateInput struct {
 type BotPlatform string
 
 const (
-	// BotPlatformSLACk is the slack platform
-	BotPlatformSLACk BotPlatform = "SLACK"
+	// BotPlatformSlack is the slack platform
+	BotPlatformSlack BotPlatform = "SLACK"
 	// BotPlatformDiscord is the discord platform
 	BotPlatformDiscord BotPlatform = "DISCORD"
 	// BotPlatformMattermost is the mattermost platform

--- a/internal/audit/gql_reporter.go
+++ b/internal/audit/gql_reporter.go
@@ -1,0 +1,130 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hasura/go-graphql-client"
+	"github.com/sirupsen/logrus"
+
+	gql "github.com/kubeshop/botkube/internal/graphql"
+)
+
+var _ AuditReporter = (*GraphQLAuditReporter)(nil)
+
+type GraphQLAuditReporter struct {
+	log logrus.FieldLogger
+	gql *gql.Gql
+}
+
+func newGraphQLAuditReporter(logger logrus.FieldLogger, client *gql.Gql) *GraphQLAuditReporter {
+	return &GraphQLAuditReporter{
+		log: logger,
+		gql: client,
+	}
+}
+
+func (r *GraphQLAuditReporter) ReportExecutorAuditEvent(ctx context.Context, e AuditEvent) error {
+	r.log.Debugf("Reporting executor audit event for ID: %s", r.gql.DeploymentID)
+	var mutation struct {
+		CreateAuditEvent struct {
+			ID graphql.ID
+		} `graphql:"createAuditEvent(input: $input)"`
+	}
+	variables := map[string]interface{}{
+		"input": AuditEventCreateInput{
+			PlatformUser: &e.PlatformUser,
+			CreatedAt:    e.CreatedAt,
+			PluginName:   e.PluginName,
+			Channel:      e.Channel,
+			DeploymentID: r.gql.DeploymentID,
+			Type:         AuditEventTypeCommandExecuted,
+			CommandExecuted: &AuditEventCommandCreateInput{
+				BotPlatform: e.BotPlatform,
+				Command:     e.Command,
+			},
+		},
+	}
+
+	return r.gql.Cli.Mutate(ctx, &mutation, variables)
+}
+
+func (r *GraphQLAuditReporter) ReportSourceAuditEvent(ctx context.Context, e AuditEvent) error {
+	r.log.Debugf("Reporting source audit event for ID: %s", r.gql.DeploymentID)
+	var mutation struct {
+		CreateAuditEvent struct {
+			ID graphql.ID
+		} `graphql:"createAuditEvent(input: $input)"`
+	}
+	variables := map[string]interface{}{
+		"input": AuditEventCreateInput{
+			PlatformUser: &e.PlatformUser,
+			CreatedAt:    e.CreatedAt,
+			PluginName:   e.PluginName,
+			Channel:      e.Channel,
+			DeploymentID: r.gql.DeploymentID,
+			Type:         AuditEventTypeSourceEventEmitted,
+			SourceEventEmitted: &AuditEventSourceCreateInput{
+				Event: e.Event,
+			},
+		},
+	}
+
+	return r.gql.Cli.Mutate(ctx, &mutation, variables)
+}
+
+type AuditEventCreateInput struct {
+	PlatformUser       *string                       `json:"platformUser"`
+	Type               AuditEventType                `json:"type"`
+	CreatedAt          string                        `json:"createdAt"`
+	DeploymentID       string                        `json:"deploymentId"`
+	Channel            string                        `json:"channel"`
+	PluginName         string                        `json:"pluginName"`
+	SourceEventEmitted *AuditEventSourceCreateInput  `json:"sourceEventEmitted"`
+	CommandExecuted    *AuditEventCommandCreateInput `json:"commandExecuted"`
+}
+
+type AuditEventCommandCreateInput struct {
+	BotPlatform BotPlatform `json:"botPlatform"`
+	Command     string      `json:"command"`
+}
+
+type AuditEventSourceCreateInput struct {
+	Event interface{} `json:"event"`
+}
+
+type BotPlatform string
+
+const (
+	BotPlatformSLACk      BotPlatform = "SLACK"
+	BotPlatformDiscord    BotPlatform = "DISCORD"
+	BotPlatformMattermost BotPlatform = "MATTERMOST"
+	BotPlatformMsTeams    BotPlatform = "MS_TEAMS"
+)
+
+func NewBotPlatform(s string) (BotPlatform, error) {
+	switch strings.ToUpper(s) {
+	case "SLACK":
+		fallthrough
+	case "SOCKETSLACK":
+		return BotPlatformSLACk, nil
+	case "DISCORD":
+		return BotPlatformDiscord, nil
+	case "MATTERMOST":
+		return BotPlatformMattermost, nil
+	case "TEAMS":
+		fallthrough
+	case "MS_TEAMS":
+		return BotPlatformMsTeams, nil
+	default:
+		return "", fmt.Errorf("given BotPlatform %s is not supported", s)
+	}
+}
+
+type AuditEventType string
+
+const (
+	AuditEventTypeCommandExecuted    AuditEventType = "COMMAND_EXECUTED"
+	AuditEventTypeSourceEventEmitted AuditEventType = "SOURCE_EVENT_EMITTED"
+)

--- a/internal/audit/noop_reporter.go
+++ b/internal/audit/noop_reporter.go
@@ -8,6 +8,7 @@ import (
 
 var _ AuditReporter = (*NoopAuditReporter)(nil)
 
+// NoopAuditReporter is the NOOP audit reporter
 type NoopAuditReporter struct {
 	log logrus.FieldLogger
 }
@@ -17,11 +18,14 @@ func newNoopAuditReporter(logger logrus.FieldLogger) *NoopAuditReporter {
 		log: logger,
 	}
 }
+
+// ReportExecutorAuditEvent is a NOOP
 func (r *NoopAuditReporter) ReportExecutorAuditEvent(ctx context.Context, e AuditEvent) error {
 	r.log.Debug("ReportExecutorAuditEvent")
 	return nil
 }
 
+// ReportSourceAuditEvent is a NOOP
 func (r *NoopAuditReporter) ReportSourceAuditEvent(ctx context.Context, e AuditEvent) error {
 	r.log.Debug("ReportSourceAuditEvent")
 	return nil

--- a/internal/audit/noop_reporter.go
+++ b/internal/audit/noop_reporter.go
@@ -21,12 +21,12 @@ func newNoopAuditReporter(logger logrus.FieldLogger) *NoopAuditReporter {
 
 // ReportExecutorAuditEvent is a NOOP
 func (r *NoopAuditReporter) ReportExecutorAuditEvent(ctx context.Context, e AuditEvent) error {
-	r.log.Debug("ReportExecutorAuditEvent")
+	r.log.Debug("ReportExecutorAuditEvent", "event", e)
 	return nil
 }
 
 // ReportSourceAuditEvent is a NOOP
 func (r *NoopAuditReporter) ReportSourceAuditEvent(ctx context.Context, e AuditEvent) error {
-	r.log.Debug("ReportSourceAuditEvent")
+	r.log.Debug("ReportSourceAuditEvent", "event", e)
 	return nil
 }

--- a/internal/audit/noop_reporter.go
+++ b/internal/audit/noop_reporter.go
@@ -20,11 +20,11 @@ func newNoopAuditReporter(logger logrus.FieldLogger) *NoopAuditReporter {
 }
 
 // ReportExecutorAuditEvent is a NOOP
-func (r *NoopAuditReporter) ReportExecutorAuditEvent(ctx context.Context, e AuditEvent) error {
+func (r *NoopAuditReporter) ReportExecutorAuditEvent(ctx context.Context, e ExecutorAuditEvent) error {
 	return nil
 }
 
 // ReportSourceAuditEvent is a NOOP
-func (r *NoopAuditReporter) ReportSourceAuditEvent(ctx context.Context, e AuditEvent) error {
+func (r *NoopAuditReporter) ReportSourceAuditEvent(ctx context.Context, e SourceAuditEvent) error {
 	return nil
 }

--- a/internal/audit/noop_reporter.go
+++ b/internal/audit/noop_reporter.go
@@ -1,0 +1,28 @@
+package audit
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+var _ AuditReporter = (*NoopAuditReporter)(nil)
+
+type NoopAuditReporter struct {
+	log logrus.FieldLogger
+}
+
+func newNoopAuditReporter(logger logrus.FieldLogger) *NoopAuditReporter {
+	return &NoopAuditReporter{
+		log: logger,
+	}
+}
+func (r *NoopAuditReporter) ReportExecutorAuditEvent(ctx context.Context, e AuditEvent) error {
+	r.log.Debug("ReportExecutorAuditEvent")
+	return nil
+}
+
+func (r *NoopAuditReporter) ReportSourceAuditEvent(ctx context.Context, e AuditEvent) error {
+	r.log.Debug("ReportSourceAuditEvent")
+	return nil
+}

--- a/internal/audit/noop_reporter.go
+++ b/internal/audit/noop_reporter.go
@@ -21,12 +21,10 @@ func newNoopAuditReporter(logger logrus.FieldLogger) *NoopAuditReporter {
 
 // ReportExecutorAuditEvent is a NOOP
 func (r *NoopAuditReporter) ReportExecutorAuditEvent(ctx context.Context, e AuditEvent) error {
-	r.log.Debug("ReportExecutorAuditEvent", "event", e)
 	return nil
 }
 
 // ReportSourceAuditEvent is a NOOP
 func (r *NoopAuditReporter) ReportSourceAuditEvent(ctx context.Context, e AuditEvent) error {
-	r.log.Debug("ReportSourceAuditEvent", "event", e)
 	return nil
 }

--- a/internal/audit/reporter.go
+++ b/internal/audit/reporter.go
@@ -11,20 +11,26 @@ import (
 
 // AuditReporter defines interface for reporting audit events
 type AuditReporter interface {
-	ReportExecutorAuditEvent(ctx context.Context, e AuditEvent) error
-	ReportSourceAuditEvent(ctx context.Context, e AuditEvent) error
+	ReportExecutorAuditEvent(ctx context.Context, e ExecutorAuditEvent) error
+	ReportSourceAuditEvent(ctx context.Context, e SourceAuditEvent) error
 }
 
-// AuditEvent contains audit event data
-type AuditEvent struct {
-	PlatformUser string
+// ExecutorAuditEvent contains audit event data
+type ExecutorAuditEvent struct {
 	CreatedAt    string
-	Channel      string
 	PluginName   string
+	PlatformUser string
 	BotPlatform  BotPlatform
 	Command      string
-	Event        string
-	Bindings     []string
+	Channel      string
+}
+
+// SourceAuditEvent contains audit event data
+type SourceAuditEvent struct {
+	CreatedAt  string
+	PluginName string
+	Event      string
+	Bindings   []string
 }
 
 // NewAuditReporter creates new AuditReporter
@@ -32,5 +38,5 @@ func NewAuditReporter(logger logrus.FieldLogger, gql *graphql.Gql) AuditReporter
 	if _, provided := os.LookupEnv(graphql.GqlProviderIdentifierEnvKey); provided {
 		return newGraphQLAuditReporter(logger.WithField("component", "GraphQLAuditReporter"), gql)
 	}
-	return newNoopAuditReporter(l)
+	return newNoopAuditReporter(nil)
 }

--- a/internal/audit/reporter.go
+++ b/internal/audit/reporter.go
@@ -32,5 +32,5 @@ func NewAuditReporter(logger logrus.FieldLogger, gql *graphql.Gql) AuditReporter
 	if _, provided := os.LookupEnv(graphql.GqlProviderIdentifierEnvKey); provided {
 		return newGraphQLAuditReporter(logger.WithField("component", "GraphQLAuditReporter"), gql)
 	}
-	return newNoopAuditReporter(logger.WithField("component", "NoopAuditReporter"))
+	return newNoopAuditReporter(l)
 }

--- a/internal/audit/reporter.go
+++ b/internal/audit/reporter.go
@@ -9,11 +9,13 @@ import (
 	"github.com/kubeshop/botkube/internal/graphql"
 )
 
+// AuditReporter defines interface for reporting audit events
 type AuditReporter interface {
 	ReportExecutorAuditEvent(ctx context.Context, e AuditEvent) error
 	ReportSourceAuditEvent(ctx context.Context, e AuditEvent) error
 }
 
+// AuditEvent contains audit event data
 type AuditEvent struct {
 	PlatformUser string
 	CreatedAt    string
@@ -22,8 +24,10 @@ type AuditEvent struct {
 	BotPlatform  BotPlatform
 	Command      string
 	Event        string
+	Bindings     []string
 }
 
+// NewAuditReporter creates new AuditReporter
 func NewAuditReporter(logger logrus.FieldLogger, gql *graphql.Gql) AuditReporter {
 	if _, provided := os.LookupEnv(graphql.GqlProviderIdentifierEnvKey); provided {
 		return newGraphQLAuditReporter(logger.WithField("component", "GraphQLAuditReporter"), gql)

--- a/internal/audit/reporter.go
+++ b/internal/audit/reporter.go
@@ -1,0 +1,32 @@
+package audit
+
+import (
+	"context"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/kubeshop/botkube/internal/graphql"
+)
+
+type AuditReporter interface {
+	ReportExecutorAuditEvent(ctx context.Context, e AuditEvent) error
+	ReportSourceAuditEvent(ctx context.Context, e AuditEvent) error
+}
+
+type AuditEvent struct {
+	PlatformUser string
+	CreatedAt    string
+	Channel      string
+	PluginName   string
+	BotPlatform  BotPlatform
+	Command      string
+	Event        string
+}
+
+func NewAuditReporter(logger logrus.FieldLogger, gql *graphql.Gql) AuditReporter {
+	if _, provided := os.LookupEnv(graphql.GqlProviderIdentifierEnvKey); provided {
+		return newGraphQLAuditReporter(logger.WithField("component", "GraphQLAuditReporter"), gql)
+	}
+	return newNoopAuditReporter(logger.WithField("component", "NoopAuditReporter"))
+}

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -87,7 +87,7 @@ func (d *Dispatcher) dispatch(ctx context.Context, event []byte, sources []strin
 }
 
 func (d *Dispatcher) reportAudit(ctx context.Context, pluginName, event string, sources []string) error {
-	e := audit.AuditEvent{
+	e := audit.SourceAuditEvent{
 		CreatedAt:  time.Now().Format(time.RFC3339),
 		PluginName: pluginName,
 		Event:      event,

--- a/pkg/execute/alias_test.go
+++ b/pkg/execute/alias_test.go
@@ -97,7 +97,7 @@ func TestAliasExecutor_List(t *testing.T) {
 				ExecutorFilter: newExecutorTextFilter(""),
 				Conversation:   Conversation{ExecutorBindings: tc.bindings},
 			}
-			e := NewAliasExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, tc.cfg)
+			e := NewAliasExecutor(loggerx.NewNoop(), tc.cfg)
 			msg, err := e.List(context.Background(), cmdCtx)
 			require.NoError(t, err)
 			require.Len(t, msg.Sections, 1)

--- a/pkg/execute/config.go
+++ b/pkg/execute/config.go
@@ -21,19 +21,16 @@ var (
 
 // ConfigExecutor executes all commands that are related to config
 type ConfigExecutor struct {
-	log               logrus.FieldLogger
-	analyticsReporter AnalyticsReporter
-
+	log logrus.FieldLogger
 	// Used for deprecated showControllerConfig function.
 	cfg config.Config
 }
 
 // NewConfigExecutor returns a new ConfigExecutor instance
-func NewConfigExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReporter, config config.Config) *ConfigExecutor {
+func NewConfigExecutor(log logrus.FieldLogger, config config.Config) *ConfigExecutor {
 	return &ConfigExecutor{
-		log:               log,
-		analyticsReporter: analyticsReporter,
-		cfg:               config,
+		log: log,
+		cfg: config,
 	}
 }
 
@@ -51,22 +48,11 @@ func (e *ConfigExecutor) Commands() map[command.Verb]CommandFn {
 
 // Show returns Config in yaml format
 func (e *ConfigExecutor) Show(_ context.Context, cmdCtx CommandContext) (interactive.CoreMessage, error) {
-	cmdVerb, cmdRes := parseCmdVerb(cmdCtx.Args)
-	defer e.reportCommand(cmdVerb, cmdRes, cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
-
 	cfg, err := e.renderBotkubeConfiguration()
 	if err != nil {
 		return interactive.CoreMessage{}, fmt.Errorf("while rendering Botkube configuration: %w", err)
 	}
 	return respond(cfg, cmdCtx), nil
-}
-
-func (e *ConfigExecutor) reportCommand(cmdVerb, cmdRes string, commandOrigin command.Origin, platform config.CommPlatformIntegration) {
-	cmdToReport := fmt.Sprintf("%s %s", cmdVerb, cmdRes)
-	err := e.analyticsReporter.ReportCommand(platform, cmdToReport, commandOrigin, false)
-	if err != nil {
-		e.log.Errorf("while reporting config command: %s", err.Error())
-	}
 }
 
 const redactedSecretStr = "*** REDACTED ***"

--- a/pkg/execute/config_test.go
+++ b/pkg/execute/config_test.go
@@ -83,7 +83,7 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			e := NewConfigExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, tc.Cfg)
+			e := NewConfigExecutor(loggerx.NewNoop(), tc.Cfg)
 			msg, err := e.Show(context.Background(), tc.CmdCtx)
 			require.NoError(t, err)
 			assert.Equal(t, tc.ExpectedResult, msg.BaseBody.CodeBlock)

--- a/pkg/execute/exec.go
+++ b/pkg/execute/exec.go
@@ -27,17 +27,15 @@ const kubectlBuiltinExecutorName = "kubectl"
 
 // ExecExecutor executes all commands that are related to executors.
 type ExecExecutor struct {
-	log               logrus.FieldLogger
-	analyticsReporter AnalyticsReporter
-	cfg               config.Config
+	log logrus.FieldLogger
+	cfg config.Config
 }
 
 // NewExecExecutor returns a new ExecExecutor instance.
-func NewExecExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReporter, cfg config.Config) *ExecExecutor {
+func NewExecExecutor(log logrus.FieldLogger, cfg config.Config) *ExecExecutor {
 	return &ExecExecutor{
-		log:               log,
-		analyticsReporter: analyticsReporter,
-		cfg:               cfg,
+		log: log,
+		cfg: cfg,
 	}
 }
 
@@ -55,8 +53,6 @@ func (e *ExecExecutor) FeatureName() FeatureName {
 
 // List returns a tabular representation of Executors
 func (e *ExecExecutor) List(_ context.Context, cmdCtx CommandContext) (interactive.CoreMessage, error) {
-	cmdVerb, cmdRes := parseCmdVerb(cmdCtx.Args)
-	defer e.reportCommand(cmdVerb, cmdRes, cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
 	e.log.Debug("Listing executors...")
 	return respond(e.TabularOutput(cmdCtx.Conversation.ExecutorBindings), cmdCtx), nil
 }
@@ -76,14 +72,6 @@ func (e *ExecExecutor) TabularOutput(bindings []string) string {
 
 	w.Flush()
 	return buf.String()
-}
-
-func (e *ExecExecutor) reportCommand(cmdVerb, cmdRes string, commandOrigin command.Origin, platform config.CommPlatformIntegration) {
-	cmdToReport := fmt.Sprintf("%s %s", cmdVerb, cmdRes)
-	err := e.analyticsReporter.ReportCommand(platform, cmdToReport, commandOrigin, false)
-	if err != nil {
-		e.log.Errorf("while reporting executor command: %s", err.Error())
-	}
 }
 
 func executorsForBindings(executors map[string]config.Executors, bindings []string) map[string]bool {

--- a/pkg/execute/exec_test.go
+++ b/pkg/execute/exec_test.go
@@ -113,7 +113,7 @@ func TestExecutorBindingsExecutor(t *testing.T) {
 				ExecutorFilter: newExecutorTextFilter(""),
 				Conversation:   Conversation{ExecutorBindings: tc.bindings},
 			}
-			e := NewExecExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, tc.cfg)
+			e := NewExecExecutor(loggerx.NewNoop(), tc.cfg)
 			msg, err := e.List(context.Background(), cmdCtx)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expOutput, msg.BaseBody.CodeBlock)

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -298,7 +298,7 @@ func (e *DefaultExecutor) reportAuditEvent(ctx context.Context, cmdCtx CommandCo
 	if err != nil {
 		return err
 	}
-	event := audit.AuditEvent{
+	event := audit.ExecutorAuditEvent{
 		PlatformUser: cmdCtx.User,
 		CreatedAt:    time.Now().Format(time.RFC3339),
 		PluginName:   cmdCtx.Args[0],

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/kubeshop/botkube/internal/audit"
 	"github.com/kubeshop/botkube/pkg/api"
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
 	"github.com/kubeshop/botkube/pkg/config"
@@ -60,6 +62,7 @@ type DefaultExecutor struct {
 	user                  string
 	kubectlCmdBuilder     *KubectlCmdBuilder
 	cmdsMapping           *CommandMapping
+	auditReporter         audit.AuditReporter
 }
 
 // CommandFlags creates custom type for flags in botkube
@@ -139,7 +142,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.CoreMessage {
 	isPluginCmd := e.pluginExecutor.CanHandle(e.conversation.ExecutorBindings, cmdCtx.Args)
 
 	if e.kubectlExecutor.CanHandle(cmdCtx.Args) && !isPluginCmd {
-		e.reportCommand(e.kubectlExecutor.GetCommandPrefix(cmdCtx.Args), cmdCtx.ExecutorFilter.IsActive())
+		e.reportCommand(ctx, e.kubectlExecutor.GetCommandPrefix(cmdCtx.Args), cmdCtx.ExecutorFilter.IsActive(), cmdCtx)
 		out, err := e.kubectlExecutor.Execute(e.conversation.ExecutorBindings, cmdCtx.CleanCmd, e.conversation.IsAuthenticated, cmdCtx)
 		switch {
 		case err == nil:
@@ -159,7 +162,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.CoreMessage {
 	}
 
 	if e.kubectlCmdBuilder.CanHandle(cmdCtx.Args) && !isPluginCmd {
-		e.reportCommand(e.kubectlCmdBuilder.GetCommandPrefix(cmdCtx.Args), false)
+		e.reportCommand(ctx, e.kubectlCmdBuilder.GetCommandPrefix(cmdCtx.Args), false, cmdCtx)
 		out, err := e.kubectlCmdBuilder.Do(ctx, cmdCtx.Args, e.platform, e.conversation.ExecutorBindings, e.conversation.SlackState, header(cmdCtx), cmdCtx)
 		if err != nil {
 			// TODO: Return error when the DefaultExecutor is refactored as a part of https://github.com/kubeshop/botkube/issues/589
@@ -173,7 +176,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.CoreMessage {
 		if isHelpCmd(cmdCtx.Args) {
 			return e.ExecuteHelp(ctx, cmdCtx)
 		}
-		e.reportCommand(e.pluginExecutor.GetCommandPrefix(cmdCtx.Args), cmdCtx.ExecutorFilter.IsActive())
+		e.reportCommand(ctx, e.pluginExecutor.GetCommandPrefix(cmdCtx.Args), cmdCtx.ExecutorFilter.IsActive(), cmdCtx)
 		out, err := e.pluginExecutor.Execute(ctx, e.conversation.ExecutorBindings, e.conversation.SlackState, cmdCtx)
 		switch {
 		case err == nil:
@@ -195,7 +198,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.CoreMessage {
 
 	fn, foundRes, foundFn := e.cmdsMapping.FindFn(cmdVerb, cmdRes)
 	if !foundRes {
-		e.reportCommand(anonymizedInvalidVerb, false)
+		e.reportCommand(ctx, anonymizedInvalidVerb, false, cmdCtx)
 		e.log.Infof("received unsupported command: %q", cmdCtx.CleanCmd)
 		return respond(unsupportedCmdMsg, cmdCtx)
 	}
@@ -206,7 +209,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.CoreMessage {
 			e.log.Infof("received unsupported resource: %q", cmdCtx.CleanCmd)
 			reportedCmd = fmt.Sprintf("%s {invalid feature}", reportedCmd)
 		}
-		e.reportCommand(reportedCmd, false)
+		e.reportCommand(ctx, reportedCmd, false, cmdCtx)
 		msg := e.cmdsMapping.HelpMessageForVerb(cmdVerb)
 		return respond(msg, cmdCtx)
 	}
@@ -230,7 +233,7 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.CoreMessage {
 }
 
 func (e *DefaultExecutor) ExecuteHelp(ctx context.Context, cmdCtx CommandContext) interactive.CoreMessage {
-	e.reportCommand(e.pluginExecutor.GetCommandPrefix(cmdCtx.Args), cmdCtx.ExecutorFilter.IsActive())
+	e.reportCommand(ctx, e.pluginExecutor.GetCommandPrefix(cmdCtx.Args), cmdCtx.ExecutorFilter.IsActive(), cmdCtx)
 	msg, err := e.pluginExecutor.Help(ctx, e.conversation.ExecutorBindings, cmdCtx)
 	if err != nil {
 		e.log.Errorf("while executing help command %q: %s", cmdCtx.CleanCmd, err.Error())
@@ -281,11 +284,29 @@ func removeMultipleSpaces(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
-func (e *DefaultExecutor) reportCommand(verb string, withFilter bool) {
-	err := e.analyticsReporter.ReportCommand(e.platform, verb, e.conversation.CommandOrigin, withFilter)
-	if err != nil {
+func (e *DefaultExecutor) reportCommand(ctx context.Context, verb string, withFilter bool, cmdCtx CommandContext) {
+	if err := e.analyticsReporter.ReportCommand(e.platform, verb, e.conversation.CommandOrigin, withFilter); err != nil {
 		e.log.Errorf("while reporting %s command: %s", verb, err.Error())
 	}
+	if err := e.reportAuditEvent(ctx, cmdCtx); err != nil {
+		e.log.Errorf("while reporting executor audit event for %s: %s", verb, err.Error())
+	}
+}
+
+func (e *DefaultExecutor) reportAuditEvent(ctx context.Context, cmdCtx CommandContext) error {
+	platform, err := audit.NewBotPlatform(cmdCtx.Platform.String())
+	if err != nil {
+		return err
+	}
+	event := audit.AuditEvent{
+		PlatformUser: cmdCtx.User,
+		CreatedAt:    time.Now().Format(time.RFC3339),
+		PluginName:   cmdCtx.Args[0],
+		Channel:      cmdCtx.CommGroupName,
+		Command:      cmdCtx.ExpandedRawCmd,
+		BotPlatform:  platform,
+	}
+	return e.auditReporter.ReportExecutorAuditEvent(ctx, event)
 }
 
 // appendByUserOnlyIfNeeded returns the "by Foo" only if the command was executed via button.

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -212,6 +212,12 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.CoreMessage {
 		e.reportCommand(ctx, reportedCmd, false, cmdCtx)
 		msg := e.cmdsMapping.HelpMessageForVerb(cmdVerb)
 		return respond(msg, cmdCtx)
+	} else {
+		cmdToReport := string(cmdVerb)
+		if cmdRes != "" {
+			cmdToReport = fmt.Sprintf("%s %s", cmdVerb, cmdRes)
+		}
+		e.reportCommand(ctx, cmdToReport, false, cmdCtx)
 	}
 
 	msg, err := fn(ctx, cmdCtx)

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -100,59 +100,48 @@ func NewExecutorFactory(params DefaultExecutorFactoryParams) (*DefaultExecutorFa
 	)
 	sourceBindingExecutor := NewSourceBindingExecutor(
 		params.Log.WithField("component", "SourceBinding Executor"),
-		params.AnalyticsReporter,
 		params.CfgManager,
 		params.Cfg,
 	)
 	filterExecutor := NewFilterExecutor(
 		params.Log.WithField("component", "Filter Executor"),
-		params.AnalyticsReporter,
 		params.CfgManager,
 		params.FilterEngine,
 	)
 	pingExecutor := NewPingExecutor(
 		params.Log.WithField("component", "Ping Executor"),
-		params.AnalyticsReporter,
 		params.BotKubeVersion,
 	)
 	versionExecutor := NewVersionExecutor(
 		params.Log.WithField("component", "Version Executor"),
-		params.AnalyticsReporter,
 		params.BotKubeVersion,
 	)
 	feedbackExecutor := NewFeedbackExecutor(
 		params.Log.WithField("component", "Feedback Executor"),
-		params.AnalyticsReporter,
 	)
 	notifierExecutor := NewNotifierExecutor(
 		params.Log.WithField("component", "Notifier Executor"),
-		params.AnalyticsReporter,
 		params.CfgManager,
 		params.Cfg,
 	)
 	helpExecutor := NewHelpExecutor(
 		params.Log.WithField("component", "Help Executor"),
-		params.AnalyticsReporter,
 		params.Cfg,
 	)
 	configExecutor := NewConfigExecutor(
 		params.Log.WithField("component", "Config Executor"),
-		params.AnalyticsReporter,
 		params.Cfg,
 	)
 	execExecutor := NewExecExecutor(
 		params.Log.WithField("component", "Executor Bindings Executor"),
-		params.AnalyticsReporter,
 		params.Cfg,
 	)
 	sourceExecutor := NewSourceExecutor(
 		params.Log.WithField("component", "Source Bindings Executor"),
-		params.AnalyticsReporter,
 		params.Cfg,
 	)
 	aliasExecutor := NewAliasExecutor(
 		params.Log.WithField("component", "Alias Executor"),
-		params.AnalyticsReporter,
 		params.Cfg,
 	)
 

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -95,7 +95,6 @@ func NewExecutorFactory(params DefaultExecutorFactoryParams) (*DefaultExecutorFa
 	)
 	actionExecutor := NewActionExecutor(
 		params.Log.WithField("component", "Action Executor"),
-		params.AnalyticsReporter,
 		params.CfgManager,
 		params.Cfg,
 	)

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
 
+	"github.com/kubeshop/botkube/internal/audit"
 	"github.com/kubeshop/botkube/internal/plugin"
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
 	"github.com/kubeshop/botkube/pkg/config"
@@ -37,6 +38,7 @@ type DefaultExecutorFactory struct {
 	cfgManager            ConfigPersistenceManager
 	kubectlCmdBuilder     *KubectlCmdBuilder
 	cmdsMapping           *CommandMapping
+	auditReporter         audit.AuditReporter
 }
 
 // DefaultExecutorFactoryParams contains input parameters for DefaultExecutorFactory.
@@ -53,6 +55,7 @@ type DefaultExecutorFactoryParams struct {
 	CommandGuard      CommandGuard
 	PluginManager     *plugin.Manager
 	BotKubeVersion    string
+	AuditReporter     audit.AuditReporter
 }
 
 // Executor is an interface for processes to execute commands
@@ -204,6 +207,7 @@ func NewExecutorFactory(params DefaultExecutorFactoryParams) (*DefaultExecutorFa
 		cfgManager:            params.CfgManager,
 		kubectlExecutor:       kcExecutor,
 		cmdsMapping:           mappings,
+		auditReporter:         params.AuditReporter,
 	}, nil
 }
 
@@ -252,6 +256,7 @@ func (f *DefaultExecutorFactory) NewDefault(cfg NewDefaultInput) Executor {
 		cfgManager:            f.cfgManager,
 		kubectlCmdBuilder:     f.kubectlCmdBuilder,
 		cmdsMapping:           f.cmdsMapping,
+		auditReporter:         f.auditReporter,
 		user:                  cfg.User,
 		notifierHandler:       cfg.NotifierHandler,
 		conversation:          cfg.Conversation,

--- a/pkg/execute/feedback.go
+++ b/pkg/execute/feedback.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
-	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/execute/command"
 )
 
@@ -16,15 +15,13 @@ var (
 
 // FeedbackExecutor executes all commands that are related to feedback.
 type FeedbackExecutor struct {
-	log               logrus.FieldLogger
-	analyticsReporter AnalyticsReporter
+	log logrus.FieldLogger
 }
 
 // NewFeedbackExecutor returns a new FeedbackExecutor instance
-func NewFeedbackExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReporter) *FeedbackExecutor {
+func NewFeedbackExecutor(log logrus.FieldLogger) *FeedbackExecutor {
 	return &FeedbackExecutor{
-		log:               log,
-		analyticsReporter: analyticsReporter,
+		log: log,
 	}
 }
 
@@ -42,14 +39,5 @@ func (e *FeedbackExecutor) Commands() map[command.Verb]CommandFn {
 
 // Feedback responds with a feedback form URL
 func (e *FeedbackExecutor) Feedback(ctx context.Context, cmdCtx CommandContext) (interactive.CoreMessage, error) {
-	cmdVerb, _ := parseCmdVerb(cmdCtx.Args)
-	e.reportCommand(cmdVerb, cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
 	return interactive.Feedback(), nil
-}
-
-func (e *FeedbackExecutor) reportCommand(cmdToReport string, commandOrigin command.Origin, platform config.CommPlatformIntegration) {
-	err := e.analyticsReporter.ReportCommand(platform, cmdToReport, commandOrigin, false)
-	if err != nil {
-		e.log.Errorf("while reporting feedback command: %s", err.Error())
-	}
 }

--- a/pkg/execute/helper_test.go
+++ b/pkg/execute/helper_test.go
@@ -5,14 +5,7 @@ import (
 	"errors"
 
 	"github.com/kubeshop/botkube/pkg/config"
-	"github.com/kubeshop/botkube/pkg/execute/command"
 )
-
-type fakeAnalyticsReporter struct{}
-
-func (f *fakeAnalyticsReporter) ReportCommand(_ config.CommPlatformIntegration, _ string, _ command.Origin, _ bool) error {
-	return nil
-}
 
 type fakeCfgPersistenceManager struct {
 	expectedAlias string

--- a/pkg/execute/notifier_test.go
+++ b/pkg/execute/notifier_test.go
@@ -85,7 +85,7 @@ func TestNotifierExecutorStart(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			e := NewNotifierExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, &fakeCfgPersistenceManager{expectedAlias: channelAlias}, notifierTestCfg)
+			e := NewNotifierExecutor(loggerx.NewNoop(), &fakeCfgPersistenceManager{expectedAlias: channelAlias}, notifierTestCfg)
 			msg, err := e.Enable(context.Background(), tc.CmdCtx)
 			if err != nil {
 				assert.EqualError(t, err, tc.ExpectedError)
@@ -159,7 +159,7 @@ func TestNotifierExecutorStop(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			e := NewNotifierExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, &fakeCfgPersistenceManager{expectedAlias: channelAlias}, notifierTestCfg)
+			e := NewNotifierExecutor(loggerx.NewNoop(), &fakeCfgPersistenceManager{expectedAlias: channelAlias}, notifierTestCfg)
 			msg, err := e.Disable(context.Background(), tc.CmdCtx)
 			if err != nil {
 				assert.EqualError(t, err, tc.ExpectedError)
@@ -212,7 +212,7 @@ func TestNotifierExecutorStatus(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			e := NewNotifierExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, &fakeCfgPersistenceManager{expectedAlias: channelAlias}, notifierTestCfg)
+			e := NewNotifierExecutor(loggerx.NewNoop(), &fakeCfgPersistenceManager{expectedAlias: channelAlias}, notifierTestCfg)
 			mapping, err := NewCmdsMapping([]CommandExecutor{e})
 			require.NoError(t, err)
 			tc.CmdCtx.Mapping = mapping

--- a/pkg/execute/ping.go
+++ b/pkg/execute/ping.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
-	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/execute/command"
 )
 
@@ -17,17 +16,15 @@ var (
 
 // PingExecutor executes all commands that are related to ping.
 type PingExecutor struct {
-	log               logrus.FieldLogger
-	analyticsReporter AnalyticsReporter
-	botkubeVersion    string
+	log            logrus.FieldLogger
+	botkubeVersion string
 }
 
 // NewPingExecutor returns a new PingExecutor instance.
-func NewPingExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReporter, botkubeVersion string) *PingExecutor {
+func NewPingExecutor(log logrus.FieldLogger, botkubeVersion string) *PingExecutor {
 	return &PingExecutor{
-		log:               log,
-		analyticsReporter: analyticsReporter,
-		botkubeVersion:    botkubeVersion,
+		log:            log,
+		botkubeVersion: botkubeVersion,
 	}
 }
 
@@ -45,15 +42,6 @@ func (e *PingExecutor) Commands() map[command.Verb]CommandFn {
 
 // Ping responds with "pong" to the ping command
 func (e *PingExecutor) Ping(ctx context.Context, cmdCtx CommandContext) (interactive.CoreMessage, error) {
-	cmdVerb, _ := parseCmdVerb(cmdCtx.Args)
 	e.log.Debugf("Sending pong to %s", cmdCtx.Conversation.ID)
-	e.reportCommand(cmdVerb, cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
 	return respond(fmt.Sprintf("pong\n\n%s", e.botkubeVersion), cmdCtx), nil
-}
-
-func (e *PingExecutor) reportCommand(cmdToReport string, commandOrigin command.Origin, platform config.CommPlatformIntegration) {
-	err := e.analyticsReporter.ReportCommand(platform, cmdToReport, commandOrigin, false)
-	if err != nil {
-		e.log.Errorf("while reporting ping command: %s", err.Error())
-	}
 }

--- a/pkg/execute/source.go
+++ b/pkg/execute/source.go
@@ -26,17 +26,15 @@ const kubernetesBuiltinSourceName = "kubernetes"
 
 // SourceExecutor executes all commands that are related to sources.
 type SourceExecutor struct {
-	log               logrus.FieldLogger
-	analyticsReporter AnalyticsReporter
-	cfg               config.Config
+	log logrus.FieldLogger
+	cfg config.Config
 }
 
 // NewSourceExecutor returns a new SourceExecutor instance.
-func NewSourceExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReporter, cfg config.Config) *SourceExecutor {
+func NewSourceExecutor(log logrus.FieldLogger, cfg config.Config) *SourceExecutor {
 	return &SourceExecutor{
-		log:               log,
-		analyticsReporter: analyticsReporter,
-		cfg:               cfg,
+		log: log,
+		cfg: cfg,
 	}
 }
 
@@ -54,8 +52,6 @@ func (e *SourceExecutor) FeatureName() FeatureName {
 
 // List returns a tabular representation of Executors
 func (e *SourceExecutor) List(ctx context.Context, cmdCtx CommandContext) (interactive.CoreMessage, error) {
-	cmdVerb, cmdRes := parseCmdVerb(cmdCtx.Args)
-	defer e.reportCommand(cmdVerb, cmdRes, cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
 	e.log.Debug("List sources")
 	return respond(e.TabularOutput(cmdCtx.Conversation.SourceBindings), cmdCtx), nil
 }
@@ -88,12 +84,4 @@ func (e *SourceExecutor) TabularOutput(bindings []string) string {
 	}
 	w.Flush()
 	return buf.String()
-}
-
-func (e *SourceExecutor) reportCommand(cmdVerb, cmdRes string, commandOrigin command.Origin, platform config.CommPlatformIntegration) {
-	cmdToReport := fmt.Sprintf("%s %s", cmdVerb, cmdRes)
-	err := e.analyticsReporter.ReportCommand(platform, cmdToReport, commandOrigin, false)
-	if err != nil {
-		e.log.Errorf("while reporting source command: %s", err.Error())
-	}
 }

--- a/pkg/execute/source_test.go
+++ b/pkg/execute/source_test.go
@@ -110,7 +110,7 @@ func TestSourceExecutor(t *testing.T) {
 				ExecutorFilter: newExecutorTextFilter(""),
 				Conversation:   Conversation{SourceBindings: tc.bindings},
 			}
-			e := NewSourceExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, tc.cfg)
+			e := NewSourceExecutor(loggerx.NewNoop(), tc.cfg)
 			msg, err := e.List(context.Background(), cmdCtx)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expOutput, msg.BaseBody.CodeBlock)

--- a/pkg/execute/sourcebinding.go
+++ b/pkg/execute/sourcebinding.go
@@ -53,15 +53,14 @@ type BindingsStorage interface {
 
 // SourceBindingExecutor provides functionality to run all Botkube SourceBinding related commands.
 type SourceBindingExecutor struct {
-	log               logrus.FieldLogger
-	analyticsReporter AnalyticsReporter
-	cfgManager        BindingsStorage
-	sources           map[string]string
-	cfg               config.Config
+	log        logrus.FieldLogger
+	cfgManager BindingsStorage
+	sources    map[string]string
+	cfg        config.Config
 }
 
 // NewSourceBindingExecutor returns a new SourceBindingExecutor instance.
-func NewSourceBindingExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReporter, cfgManager BindingsStorage, cfg config.Config) *SourceBindingExecutor {
+func NewSourceBindingExecutor(log logrus.FieldLogger, cfgManager BindingsStorage, cfg config.Config) *SourceBindingExecutor {
 	normalizedSource := map[string]string{}
 	for key, item := range cfg.Sources {
 		displayName := item.DisplayName
@@ -72,11 +71,10 @@ func NewSourceBindingExecutor(log logrus.FieldLogger, analyticsReporter Analytic
 	}
 
 	return &SourceBindingExecutor{
-		log:               log,
-		analyticsReporter: analyticsReporter,
-		cfgManager:        cfgManager,
-		sources:           normalizedSource,
-		cfg:               cfg,
+		log:        log,
+		cfgManager: cfgManager,
+		sources:    normalizedSource,
+		cfg:        cfg,
 	}
 }
 
@@ -109,21 +107,7 @@ func (e *SourceBindingExecutor) Edit(ctx context.Context, cmdCtx CommandContext)
 	if len(cmdCtx.Args) < 2 {
 		return empty, errInvalidCommand
 	}
-
-	var (
-		cmdName = cmdCtx.Args[0]
-		cmdVerb = cmdCtx.Args[1]
-		cmdArgs = cmdCtx.Args[2:]
-	)
-
-	defer func() {
-		cmdToReport := fmt.Sprintf("%s %s", cmdName, cmdVerb)
-		err := e.analyticsReporter.ReportCommand(cmdCtx.Platform, cmdToReport, cmdCtx.Conversation.CommandOrigin, false)
-		if err != nil {
-			e.log.Errorf("while reporting edit command: %s", err.Error())
-		}
-	}()
-
+	cmdArgs := cmdCtx.Args[2:]
 	msg, err := e.editSourceBindingHandler(ctx, cmdArgs, cmdCtx.CommGroupName, cmdCtx.Platform, cmdCtx.Conversation, cmdCtx.User)
 	if err != nil {
 		return empty, err

--- a/pkg/execute/sourcebinding_test.go
+++ b/pkg/execute/sourcebinding_test.go
@@ -127,7 +127,7 @@ func TestSourceBindingsHappyPath(t *testing.T) {
 			// given
 			fakeStorage := &fakeBindingsStorage{}
 			args := strings.Fields(strings.TrimSpace(tc.command))
-			executor := NewSourceBindingExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, fakeStorage, tc.config)
+			executor := NewSourceBindingExecutor(loggerx.NewNoop(), fakeStorage, tc.config)
 			cmdCtx := CommandContext{
 				Args:          args,
 				CommGroupName: groupName,
@@ -182,7 +182,7 @@ func TestSourceBindingsErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
 			args := strings.Fields(strings.TrimSpace(tc.command))
-			executor := NewSourceBindingExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, nil, config.Config{})
+			executor := NewSourceBindingExecutor(loggerx.NewNoop(), nil, config.Config{})
 			cmdCtx := CommandContext{
 				Args:          args,
 				CommGroupName: groupName,
@@ -259,7 +259,7 @@ func TestSourceBindingsMultiSelectMessage(t *testing.T) {
 		},
 	}
 
-	executor := NewSourceBindingExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, nil, cfg)
+	executor := NewSourceBindingExecutor(loggerx.NewNoop(), nil, cfg)
 	cmdCtx := CommandContext{
 		Args:          args,
 		CommGroupName: groupName,
@@ -323,7 +323,7 @@ func TestSourceBindingsMultiSelectMessageWithIncorrectBindingConfig(t *testing.T
 		},
 	}
 
-	executor := NewSourceBindingExecutor(loggerx.NewNoop(), &fakeAnalyticsReporter{}, nil, cfg)
+	executor := NewSourceBindingExecutor(loggerx.NewNoop(), nil, cfg)
 	cmdCtx := CommandContext{
 		Args:          args,
 		CommGroupName: groupName,

--- a/pkg/execute/version.go
+++ b/pkg/execute/version.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/kubeshop/botkube/pkg/bot/interactive"
-	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/execute/command"
 )
 
@@ -16,17 +15,15 @@ var (
 
 // VersionExecutor executes all commands that are related to version.
 type VersionExecutor struct {
-	log               logrus.FieldLogger
-	analyticsReporter AnalyticsReporter
-	botkubeVersion    string
+	log            logrus.FieldLogger
+	botkubeVersion string
 }
 
 // NewVersionExecutor returns a new VersionExecutor instance
-func NewVersionExecutor(log logrus.FieldLogger, analyticsReporter AnalyticsReporter, botkubeVersion string) *VersionExecutor {
+func NewVersionExecutor(log logrus.FieldLogger, botkubeVersion string) *VersionExecutor {
 	return &VersionExecutor{
-		log:               log,
-		analyticsReporter: analyticsReporter,
-		botkubeVersion:    botkubeVersion,
+		log:            log,
+		botkubeVersion: botkubeVersion,
 	}
 }
 
@@ -44,14 +41,5 @@ func (e *VersionExecutor) Commands() map[command.Verb]CommandFn {
 
 // Version responds with k8s and botkube version string
 func (e *VersionExecutor) Version(ctx context.Context, cmdCtx CommandContext) (interactive.CoreMessage, error) {
-	cmdVerb, _ := parseCmdVerb(cmdCtx.Args)
-	e.reportCommand(cmdVerb, cmdCtx.Conversation.CommandOrigin, cmdCtx.Platform)
 	return respond(e.botkubeVersion, cmdCtx), nil
-}
-
-func (e *VersionExecutor) reportCommand(cmdToReport string, commandOrigin command.Origin, platform config.CommPlatformIntegration) {
-	err := e.analyticsReporter.ReportCommand(platform, cmdToReport, commandOrigin, false)
-	if err != nil {
-		e.log.Errorf("while reporting version command: %s", err.Error())
-	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Report executor and source actions to backend

Changes proposed in this pull request:

- Report events to the backend

## Testing

1. Deploy backend locally, guide [here](https://github.com/kubeshop/botkube-cloud/pull/158)
2. Create a Deployment and get API key/token
3. Use local botkube config and noop reporter by changing
```
if _, provided := os.LookupEnv(graphql.GqlProviderIdentifierEnvKey); provided {
```
to
```
if _, provided := os.LookupEnv(graphql.GqlProviderIdentifierEnvKey); !provided {
```
  * [reporter.go](https://github.com/kubeshop/botkube/blob/737503971fe0b1f8023362270465f8b79eca39ea/internal/audit/reporter.go#L32)
  * [config.go](https://github.com/kubeshop/botkube/blob/737503971fe0b1f8023362270465f8b79eca39ea/pkg/config/config.go#L781)

5. Add cm-watcher source:
```yaml
sources:
  'cm':
    displayName: "Events based on plugin"
    botkube/cm-watcher:
      enabled: true
      config:
        configMap:
          name: cm-watcher-trigger
          namespace: botkube
          event: ADDED
```

6. Enable debug logging `export BOTKUBE_SETTINGS_LOG_LEVEL=debug`
5. Start botkube with ENV with deployment and local backend URL
7. Run commands & emit source events

```
k create cm -n botkube cm-watcher-trigger
```

## Related issue(s)

https://github.com/kubeshop/botkube-cloud/issues/118
