### PR TITLE
Respect Mattermost websocket subpath URLs

### DIFF
--- a/pkg/bot/mattermost.go
+++ b/pkg/bot/mattermost.go
@@ -84,9 +84,9 @@ func NewMattermost(log logrus.FieldLogger, commGroupName string, cfg config.Matt
 	}
 
 	// Create WebSocketClient and handle messages
-	webSocketURL := WebSocketProtocol + checkURL.Host
+	webSocketURL := WebSocketProtocol + checkURL.Host + checkURL.Path
 	if checkURL.Scheme == httpsScheme {
-		webSocketURL = WebSocketSecureProtocol + checkURL.Host
+		webSocketURL = WebSocketSecureProtocol + checkURL.Host + checkURL.Path
 	}
 
 	client := model.NewAPIv4Client(cfg.URL)


### PR DESCRIPTION

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

Whenever a subpath is passed on the Mattermost.URL, we should use the same path for its websocket connection string.


## Testing

<!-- Describe necessary steps to test the changes.
You can refer to the existing documentation if some steps are already described. -->

## Related issue(s)

Fixes: https://github.com/kubeshop/botkube/issues/1037

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
