### PR TITLE
configurable probes added

### DIFF
--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -46,34 +46,34 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [actions.show-logs-on-error.bindings.executors](./values.yaml#L105) | list | `["k8s-default-tools"]` | Executors configuration used to execute a configured command. |
 | [sources](./values.yaml#L114) | object | See the `values.yaml` file for full object. | Map of sources. Source contains configuration for Kubernetes events and sending recommendations. The property name under `sources` object is an alias for a given configuration. You can define multiple sources configuration with different names. Key name is used as a binding reference.   |
 | [sources.k8s-recommendation-events.botkube/kubernetes](./values.yaml#L119) | object | See the `values.yaml` file for full object. | Describes Kubernetes source configuration. |
-| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-create-events.botkube/kubernetes.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [executors.k8s-default-tools.botkube/kubectl.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [executors.k8s-default-tools.botkube/helm.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [sources.k8s-create-events.botkube/kubernetes.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [executors.k8s-default-tools.botkube/helm.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [sources.k8s-err-events.botkube/kubernetes.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [executors.k8s-default-tools.botkube/helm.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [executors.k8s-default-tools.botkube/kubectl.context.rbac](./values.yaml#L123) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [executors.k8s-default-tools.botkube/helm.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L126) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L128) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L128) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.k8s-default-tools.botkube/helm.context.rbac.group.prefix](./values.yaml#L128) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L128) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L128) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L128) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L128) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L128) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L128) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.prefix](./values.yaml#L128) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L131) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.static.values](./values.yaml#L131) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L131) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L131) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L131) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L131) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L131) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [executors.k8s-default-tools.botkube/helm.context.rbac.group.static.values](./values.yaml#L131) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L131) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L131) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.static.values](./values.yaml#L131) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations](./values.yaml#L145) | object | `{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}}` | Describes configuration for various recommendation insights. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations.pod](./values.yaml#L147) | object | `{"labelsSet":true,"noLatestImageTag":true}` | Recommendations for Pod Kubernetes resource. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations.pod.noLatestImageTag](./values.yaml#L149) | bool | `true` | If true, notifies about Pod containers that use `latest` tag for images. |
@@ -87,9 +87,9 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [sources.k8s-all-events.botkube/kubernetes.config.filters.nodeEventsChecker](./values.yaml#L173) | bool | `true` | If true, filters out Node-related events that are not important. |
 | [sources.k8s-all-events.botkube/kubernetes.config.namespaces](./values.yaml#L177) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
 | [sources.k8s-err-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L181) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [sources.k8s-all-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L181) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-create-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L181) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-err-with-logs-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L181) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
-| [sources.k8s-all-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L181) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-all-events.botkube/kubernetes.config.event](./values.yaml#L191) | object | `{"message":{"exclude":[],"include":[]},"reason":{"exclude":[],"include":[]},"types":["create","delete","error"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
 | [sources.k8s-all-events.botkube/kubernetes.config.event.types](./values.yaml#L193) | list | `["create","delete","error"]` | Lists all event types to be watched. |
 | [sources.k8s-all-events.botkube/kubernetes.config.event.reason](./values.yaml#L199) | object | `{"exclude":[],"include":[]}` | Optional list of exact values or regex patterns to filter events by event reason. Skipped, if both include/exclude lists are empty. |
@@ -194,39 +194,51 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [ingress](./values.yaml#L776) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
 | [serviceMonitor](./values.yaml#L787) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
 | [deployment.annotations](./values.yaml#L797) | object | `{}` | Extra annotations to pass to the Botkube Deployment. |
-| [extraAnnotations](./values.yaml#L804) | object | `{}` | Extra annotations to pass to the Botkube Pod. |
-| [extraLabels](./values.yaml#L806) | object | `{}` | Extra labels to pass to the Botkube Pod. |
-| [priorityClassName](./values.yaml#L808) | string | `""` | Priority class name for the Botkube Pod. |
-| [nameOverride](./values.yaml#L811) | string | `""` | Fully override "botkube.name" template. |
-| [fullnameOverride](./values.yaml#L813) | string | `""` | Fully override "botkube.fullname" template. |
-| [resources](./values.yaml#L819) | object | `{}` | The Botkube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
-| [extraEnv](./values.yaml#L831) | list | `[{"name":"LOG_LEVEL_SOURCE_BOTKUBE_KUBERNETES","value":"debug"}]` | Extra environment variables to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
-| [extraVolumes](./values.yaml#L845) | list | `[]` | Extra volumes to pass to the Botkube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
-| [extraVolumeMounts](./values.yaml#L860) | list | `[]` | Extra volume mounts to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
-| [nodeSelector](./values.yaml#L878) | object | `{}` | Node labels for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
-| [tolerations](./values.yaml#L882) | list | `[]` | Tolerations for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
-| [affinity](./values.yaml#L886) | object | `{}` | Affinity for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
-| [serviceAccount.create](./values.yaml#L890) | bool | `true` | If true, a ServiceAccount is automatically created. |
-| [serviceAccount.name](./values.yaml#L893) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
-| [serviceAccount.annotations](./values.yaml#L895) | object | `{}` | Extra annotations for the ServiceAccount. |
-| [extraObjects](./values.yaml#L898) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
-| [analytics.disable](./values.yaml#L926) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://docs.botkube.io/privacy#privacy-policy). |
-| [configWatcher.enabled](./values.yaml#L931) | bool | `true` | If true, restarts the Botkube Pod on config changes. |
-| [configWatcher.tmpDir](./values.yaml#L933) | string | `"/tmp/watched-cfg/"` | Directory, where watched configuration resources are stored. |
-| [configWatcher.initialSyncTimeout](./values.yaml#L936) | int | `0` | Timeout for the initial Config Watcher sync. If set to 0, waiting for Config Watcher sync will be skipped. In a result, configuration changes may not reload Botkube app during the first few seconds after Botkube startup. |
-| [configWatcher.image.registry](./values.yaml#L939) | string | `"ghcr.io"` | Config watcher image registry. |
-| [configWatcher.image.repository](./values.yaml#L941) | string | `"kubeshop/k8s-sidecar"` | Config watcher image repository. |
-| [configWatcher.image.tag](./values.yaml#L943) | string | `"ignore-initial-events"` | Config watcher image tag. |
-| [configWatcher.image.pullPolicy](./values.yaml#L945) | string | `"IfNotPresent"` | Config watcher image pull policy. |
-| [plugins](./values.yaml#L948) | object | `{"cacheDir":"/tmp","repositories":{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}}` | Configuration for Botkube executors and sources plugins. |
-| [plugins.cacheDir](./values.yaml#L950) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
-| [plugins.repositories](./values.yaml#L952) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}` | List of plugins repositories. |
-| [plugins.repositories.botkube](./values.yaml#L954) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
-| [config](./values.yaml#L958) | object | `{"provider":{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}}` | Configuration for synchronizing Botkube configuration. |
-| [config.provider](./values.yaml#L960) | object | `{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}` | Base provider definition. |
-| [config.provider.identifier](./values.yaml#L963) | string | `""` | Unique identifier for remote Botkube settings. If set to an empty string, Botkube won't fetch remote configuration. |
-| [config.provider.endpoint](./values.yaml#L965) | string | `"https://api.botkube.io/graphql"` | Endpoint to fetch Botkube settings from. |
-| [config.provider.apiKey](./values.yaml#L967) | string | `""` | Key passed as a `X-API-Key` header to the provider's endpoint. |
+| [deployment.livenessProbe](./values.yaml#L799) | object | `{"failureThreshold":3,"initialDelaySeconds":1,"periodSeconds":30,"successThreshold":1,"timeoutSeconds":1}` | Liveness probe |
+| [deployment.livenessProbe.initialDelaySeconds](./values.yaml#L801) | int | `1` | The liveness probe initial delay seconds |
+| [deployment.livenessProbe.periodSeconds](./values.yaml#L803) | int | `30` | The liveness probe period seconds |
+| [deployment.livenessProbe.timeoutSeconds](./values.yaml#L805) | int | `1` | The liveness probe timeout seconds |
+| [deployment.livenessProbe.failureThreshold](./values.yaml#L807) | int | `3` | The liveness probe failure threshold |
+| [deployment.livenessProbe.successThreshold](./values.yaml#L809) | int | `1` | The liveness probe success threshold |
+| [deployment.readinessProbe](./values.yaml#L812) | object | `{"failureThreshold":3,"initialDelaySeconds":1,"periodSeconds":30,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe |
+| [deployment.readinessProbe.initialDelaySeconds](./values.yaml#L814) | int | `1` | The readiness probe initial delay seconds |
+| [deployment.readinessProbe.periodSeconds](./values.yaml#L816) | int | `30` | The readiness probe period seconds |
+| [deployment.readinessProbe.timeoutSeconds](./values.yaml#L818) | int | `1` | The readiness probe timeout seconds |
+| [deployment.readinessProbe.failureThreshold](./values.yaml#L820) | int | `3` | The readiness probe failure threshold |
+| [deployment.readinessProbe.successThreshold](./values.yaml#L822) | int | `1` | The readiness probe success threshold |
+| [extraAnnotations](./values.yaml#L829) | object | `{}` | Extra annotations to pass to the Botkube Pod. |
+| [extraLabels](./values.yaml#L831) | object | `{}` | Extra labels to pass to the Botkube Pod. |
+| [priorityClassName](./values.yaml#L833) | string | `""` | Priority class name for the Botkube Pod. |
+| [nameOverride](./values.yaml#L836) | string | `""` | Fully override "botkube.name" template. |
+| [fullnameOverride](./values.yaml#L838) | string | `""` | Fully override "botkube.fullname" template. |
+| [resources](./values.yaml#L844) | object | `{}` | The Botkube Pod resource request and limits. We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube. [Ref docs](https://kubernetes.io/docs/user-guide/compute-resources/) |
+| [extraEnv](./values.yaml#L856) | list | `[{"name":"LOG_LEVEL_SOURCE_BOTKUBE_KUBERNETES","value":"debug"}]` | Extra environment variables to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables). |
+| [extraVolumes](./values.yaml#L870) | list | `[]` | Extra volumes to pass to the Botkube container. Mount it later with extraVolumeMounts. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume/#Volume). |
+| [extraVolumeMounts](./values.yaml#L885) | list | `[]` | Extra volume mounts to pass to the Botkube container. [Ref docs](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1). |
+| [nodeSelector](./values.yaml#L903) | object | `{}` | Node labels for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/user-guide/node-selection/). |
+| [tolerations](./values.yaml#L907) | list | `[]` | Tolerations for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/). |
+| [affinity](./values.yaml#L911) | object | `{}` | Affinity for Botkube Pod assignment. [Ref doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity). |
+| [serviceAccount.create](./values.yaml#L915) | bool | `true` | If true, a ServiceAccount is automatically created. |
+| [serviceAccount.name](./values.yaml#L918) | string | `""` | The name of the service account to use. If not set, a name is generated using the fullname template. |
+| [serviceAccount.annotations](./values.yaml#L920) | object | `{}` | Extra annotations for the ServiceAccount. |
+| [extraObjects](./values.yaml#L923) | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |
+| [analytics.disable](./values.yaml#L951) | bool | `false` | If true, sending anonymous analytics is disabled. To learn what date we collect, see [Privacy Policy](https://docs.botkube.io/privacy#privacy-policy). |
+| [configWatcher.enabled](./values.yaml#L956) | bool | `true` | If true, restarts the Botkube Pod on config changes. |
+| [configWatcher.tmpDir](./values.yaml#L958) | string | `"/tmp/watched-cfg/"` | Directory, where watched configuration resources are stored. |
+| [configWatcher.initialSyncTimeout](./values.yaml#L961) | int | `0` | Timeout for the initial Config Watcher sync. If set to 0, waiting for Config Watcher sync will be skipped. In a result, configuration changes may not reload Botkube app during the first few seconds after Botkube startup. |
+| [configWatcher.image.registry](./values.yaml#L964) | string | `"ghcr.io"` | Config watcher image registry. |
+| [configWatcher.image.repository](./values.yaml#L966) | string | `"kubeshop/k8s-sidecar"` | Config watcher image repository. |
+| [configWatcher.image.tag](./values.yaml#L968) | string | `"ignore-initial-events"` | Config watcher image tag. |
+| [configWatcher.image.pullPolicy](./values.yaml#L970) | string | `"IfNotPresent"` | Config watcher image pull policy. |
+| [plugins](./values.yaml#L973) | object | `{"cacheDir":"/tmp","repositories":{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}}` | Configuration for Botkube executors and sources plugins. |
+| [plugins.cacheDir](./values.yaml#L975) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
+| [plugins.repositories](./values.yaml#L977) | object | `{"botkube":{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}}` | List of plugins repositories. |
+| [plugins.repositories.botkube](./values.yaml#L979) | object | `{"url":"https://github.com/kubeshop/botkube/releases/download/v9.99.9-dev/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
+| [config](./values.yaml#L983) | object | `{"provider":{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}}` | Configuration for synchronizing Botkube configuration. |
+| [config.provider](./values.yaml#L985) | object | `{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}` | Base provider definition. |
+| [config.provider.identifier](./values.yaml#L988) | string | `""` | Unique identifier for remote Botkube settings. If set to an empty string, Botkube won't fetch remote configuration. |
+| [config.provider.endpoint](./values.yaml#L990) | string | `"https://api.botkube.io/graphql"` | Endpoint to fetch Botkube settings from. |
+| [config.provider.apiKey](./values.yaml#L992) | string | `""` | Key passed as a `X-API-Key` header to the provider's endpoint. |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -194,18 +194,18 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [ingress](./values.yaml#L776) | object | `{"annotations":{"kubernetes.io/ingress.class":"nginx"},"create":false,"host":"HOST","tls":{"enabled":false,"secretName":""}}` | Configures Ingress settings that exposes MS Teams endpoint. [Ref doc](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). |
 | [serviceMonitor](./values.yaml#L787) | object | `{"enabled":false,"interval":"10s","labels":{},"path":"/metrics","port":"metrics"}` | Configures ServiceMonitor settings. [Ref doc](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor). |
 | [deployment.annotations](./values.yaml#L797) | object | `{}` | Extra annotations to pass to the Botkube Deployment. |
-| [deployment.livenessProbe](./values.yaml#L799) | object | `{"failureThreshold":3,"initialDelaySeconds":1,"periodSeconds":30,"successThreshold":1,"timeoutSeconds":1}` | Liveness probe |
-| [deployment.livenessProbe.initialDelaySeconds](./values.yaml#L801) | int | `1` | The liveness probe initial delay seconds |
-| [deployment.livenessProbe.periodSeconds](./values.yaml#L803) | int | `30` | The liveness probe period seconds |
-| [deployment.livenessProbe.timeoutSeconds](./values.yaml#L805) | int | `1` | The liveness probe timeout seconds |
-| [deployment.livenessProbe.failureThreshold](./values.yaml#L807) | int | `3` | The liveness probe failure threshold |
-| [deployment.livenessProbe.successThreshold](./values.yaml#L809) | int | `1` | The liveness probe success threshold |
-| [deployment.readinessProbe](./values.yaml#L812) | object | `{"failureThreshold":3,"initialDelaySeconds":1,"periodSeconds":30,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe |
-| [deployment.readinessProbe.initialDelaySeconds](./values.yaml#L814) | int | `1` | The readiness probe initial delay seconds |
-| [deployment.readinessProbe.periodSeconds](./values.yaml#L816) | int | `30` | The readiness probe period seconds |
-| [deployment.readinessProbe.timeoutSeconds](./values.yaml#L818) | int | `1` | The readiness probe timeout seconds |
-| [deployment.readinessProbe.failureThreshold](./values.yaml#L820) | int | `3` | The readiness probe failure threshold |
-| [deployment.readinessProbe.successThreshold](./values.yaml#L822) | int | `1` | The readiness probe success threshold |
+| [deployment.livenessProbe](./values.yaml#L799) | object | `{"failureThreshold":5,"initialDelaySeconds":1,"periodSeconds":15,"successThreshold":1,"timeoutSeconds":1}` | Liveness probe. |
+| [deployment.livenessProbe.initialDelaySeconds](./values.yaml#L801) | int | `1` | The liveness probe initial delay seconds. |
+| [deployment.livenessProbe.periodSeconds](./values.yaml#L803) | int | `15` | The liveness probe period seconds. |
+| [deployment.livenessProbe.timeoutSeconds](./values.yaml#L805) | int | `1` | The liveness probe timeout seconds. |
+| [deployment.livenessProbe.failureThreshold](./values.yaml#L807) | int | `5` | The liveness probe failure threshold. |
+| [deployment.livenessProbe.successThreshold](./values.yaml#L809) | int | `1` | The liveness probe success threshold. |
+| [deployment.readinessProbe](./values.yaml#L812) | object | `{"failureThreshold":5,"initialDelaySeconds":1,"periodSeconds":15,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe. |
+| [deployment.readinessProbe.initialDelaySeconds](./values.yaml#L814) | int | `1` | The readiness probe initial delay seconds. |
+| [deployment.readinessProbe.periodSeconds](./values.yaml#L816) | int | `15` | The readiness probe period seconds. |
+| [deployment.readinessProbe.timeoutSeconds](./values.yaml#L818) | int | `1` | The readiness probe timeout seconds. |
+| [deployment.readinessProbe.failureThreshold](./values.yaml#L820) | int | `5` | The readiness probe failure threshold. |
+| [deployment.readinessProbe.successThreshold](./values.yaml#L822) | int | `1` | The readiness probe success threshold. |
 | [extraAnnotations](./values.yaml#L829) | object | `{}` | Extra annotations to pass to the Botkube Pod. |
 | [extraLabels](./values.yaml#L831) | object | `{}` | Extra labels to pass to the Botkube Pod. |
 | [priorityClassName](./values.yaml#L833) | string | `""` | Priority class name for the Botkube Pod. |

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -54,20 +54,20 @@ spec:
           {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{ end }}
           readinessProbe:
-            successThreshold: 1
-            failureThreshold: 3
-            periodSeconds: 5
-            initialDelaySeconds: 1
-            timeoutSeconds: 1
+            successThreshold: {{ .Values.deployment.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.deployment.readinessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.deployment.readinessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.deployment.readinessProbe.timeoutSeconds }}
             httpGet:
               path: /healthz
               port: {{ .Values.settings.healthPort }}
           livenessProbe:
-            successThreshold: 1
-            failureThreshold: 3
-            periodSeconds: 10
-            initialDelaySeconds: 1
-            timeoutSeconds: 1
+            successThreshold: {{ .Values.deployment.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.deployment.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.deployment.livenessProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.deployment.livenessProbe.timeoutSeconds }}
             httpGet:
               path: /healthz
               port: {{ .Values.settings.healthPort }}

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -795,30 +795,30 @@ serviceMonitor:
 deployment:
   # -- Extra annotations to pass to the Botkube Deployment.
   annotations: {}
-  # -- Liveness probe
+  # -- Liveness probe.
   livenessProbe:
-    # -- The liveness probe initial delay seconds
+    # -- The liveness probe initial delay seconds.
     initialDelaySeconds: 1
-    # -- The liveness probe period seconds
+    # -- The liveness probe period seconds.
     periodSeconds: 30
-    # -- The liveness probe timeout seconds
+    # -- The liveness probe timeout seconds.
     timeoutSeconds: 1
-    # -- The liveness probe failure threshold
+    # -- The liveness probe failure threshold.
     failureThreshold: 3
-    # -- The liveness probe success threshold
+    # -- The liveness probe success threshold.
     successThreshold: 1
 
-  # -- Readiness probe
+  # -- Readiness probe.
   readinessProbe:
-    # -- The readiness probe initial delay seconds
+    # -- The readiness probe initial delay seconds.
     initialDelaySeconds: 1
-    # -- The readiness probe period seconds
+    # -- The readiness probe period seconds.
     periodSeconds: 30
-    # -- The readiness probe timeout seconds
+    # -- The readiness probe timeout seconds.
     timeoutSeconds: 1
-    # -- The readiness probe failure threshold
+    # -- The readiness probe failure threshold.
     failureThreshold: 3
-    # -- The readiness probe success threshold
+    # -- The readiness probe success threshold.
     successThreshold: 1
 
 # -- Number of Botkube pods to load balance between.

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -800,11 +800,11 @@ deployment:
     # -- The liveness probe initial delay seconds.
     initialDelaySeconds: 1
     # -- The liveness probe period seconds.
-    periodSeconds: 30
+    periodSeconds: 15
     # -- The liveness probe timeout seconds.
     timeoutSeconds: 1
     # -- The liveness probe failure threshold.
-    failureThreshold: 3
+    failureThreshold: 5
     # -- The liveness probe success threshold.
     successThreshold: 1
 
@@ -813,11 +813,11 @@ deployment:
     # -- The readiness probe initial delay seconds.
     initialDelaySeconds: 1
     # -- The readiness probe period seconds.
-    periodSeconds: 30
+    periodSeconds: 15
     # -- The readiness probe timeout seconds.
     timeoutSeconds: 1
     # -- The readiness probe failure threshold.
-    failureThreshold: 3
+    failureThreshold: 5
     # -- The readiness probe success threshold.
     successThreshold: 1
 

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -795,6 +795,31 @@ serviceMonitor:
 deployment:
   # -- Extra annotations to pass to the Botkube Deployment.
   annotations: {}
+  # -- Liveness probe
+  livenessProbe:
+    # -- The liveness probe initial delay seconds
+    initialDelaySeconds: 1
+    # -- The liveness probe period seconds
+    periodSeconds: 30
+    # -- The liveness probe timeout seconds
+    timeoutSeconds: 1
+    # -- The liveness probe failure threshold
+    failureThreshold: 3
+    # -- The liveness probe success threshold
+    successThreshold: 1
+
+  # -- Readiness probe
+  readinessProbe:
+    # -- The readiness probe initial delay seconds
+    initialDelaySeconds: 1
+    # -- The readiness probe period seconds
+    periodSeconds: 30
+    # -- The readiness probe timeout seconds
+    timeoutSeconds: 1
+    # -- The readiness probe failure threshold
+    failureThreshold: 3
+    # -- The readiness probe success threshold
+    successThreshold: 1
 
 # -- Number of Botkube pods to load balance between.
 # Currently, Botkube doesn't support HA.


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Added configurable liveness+readiness probe

## Testing

<!-- Describe necessary steps to test the changes.
You can refer to the existing documentation if some steps are already described. -->
```sh
helm upgrade --install botkube \
  --version v1.0.0 \
  --namespace botkube \
  --create-namespace \
  --wait \
  --set config.provider.endpoint=https://api-dev.botkube.io/graphql \
  --set config.provider.identifier=... \
  --set config.provider.apiKey=... \
  ./helm/botkube
```
And check liveness + readiness probe, they should have default values as described in values.yaml. You can also customize it as shown below

```yaml
deployment:
  livenessProbe:
    periodSeconds: 120
  readinessProbe:
    periodSeconds: 120

```

```sh
helm upgrade --install botkube \
  --version v1.0.0 \
  --namespace botkube \
  --create-namespace \
  --wait \
  --set config.provider.endpoint=https://api-dev.botkube.io/graphql \
  --set config.provider.identifier=... \
  --set config.provider.apiKey=... \
  ./helm/botkube -f /tmp/bk-cfg.yaml
```
## Related issue(s)
Fixes #1055 

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
