### PR TITLE
use kubeconfig from exec input

### DIFF
--- a/internal/executor/kubectl/executor.go
+++ b/internal/executor/kubectl/executor.go
@@ -3,6 +3,7 @@ package kubectl
 import (
 	"context"
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"

--- a/internal/executor/kubectl/executor.go
+++ b/internal/executor/kubectl/executor.go
@@ -3,8 +3,6 @@ package kubectl
 import (
 	"context"
 	"fmt"
-	"os"
-
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
@@ -91,8 +89,18 @@ func (e *Executor) Execute(ctx context.Context, in executor.ExecuteInput) (execu
 		return executor.ExecuteOutput{}, err
 	}
 
+	kubeConfigPath, deleteFn, err := pluginx.PersistKubeConfig(ctx, in.Context.KubeConfig)
+	if err != nil {
+		return executor.ExecuteOutput{}, fmt.Errorf("while writing kubeconfig file: %w", err)
+	}
+	defer func() {
+		if deleteErr := deleteFn(ctx); deleteErr != nil {
+			log.Errorf("failed to delete kubeconfig file %s: %w", kubeConfigPath, deleteErr)
+		}
+	}()
+
 	if builder.ShouldHandle(cmd) {
-		guard, k8sCli, err := getBuilderDependencies(log, os.Getenv("KUBECONFIG")) // TODO: take kubeconfig from execution context
+		guard, k8sCli, err := getBuilderDependencies(log, kubeConfigPath)
 		if err != nil {
 			return executor.ExecuteOutput{}, fmt.Errorf("while creating builder dependecies: %w", err)
 		}
@@ -107,16 +115,6 @@ func (e *Executor) Execute(ctx context.Context, in executor.ExecuteInput) (execu
 			Message: msg,
 		}, nil
 	}
-
-	kubeConfigPath, deleteFn, err := pluginx.PersistKubeConfig(ctx, in.Context.KubeConfig)
-	if err != nil {
-		return executor.ExecuteOutput{}, fmt.Errorf("while writing kubeconfig file: %w", err)
-	}
-	defer func() {
-		if deleteErr := deleteFn(ctx); deleteErr != nil {
-			log.Errorf("failed to delete kubeconfig file %s: %w", kubeConfigPath, deleteErr)
-		}
-	}()
 
 	out, err := e.kcRunner.RunKubectlCommand(ctx, kubeConfigPath, cfg.DefaultNamespace, cmd)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Kubectl executor uses kubeconfig from exec input

## Testing

<!-- Describe necessary steps to test the changes.
You can refer to the existing documentation if some steps are already described. -->

- Build plugins 
- Run plugin server
- Run botkube with kubectl plugin enabled ( be aware you use local plugin server)

## Related issue(s)

Relates #1021 
<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
