### PR TITLE
Add validation that kubeconfig is specified

### DIFF
--- a/cmd/executor/gh/main.go
+++ b/cmd/executor/gh/main.go
@@ -63,7 +63,7 @@ func (*GHExecutor) Metadata(context.Context) (api.MetadataOutput, error) {
 
 // Execute returns a given command as a response.
 func (e *GHExecutor) Execute(ctx context.Context, in executor.ExecuteInput) (executor.ExecuteOutput, error) {
-	if err := pluginx.CheckKubeConfigProvided(pluginName, in.Context.KubeConfig); err != nil {
+	if err := pluginx.ValidateKubeConfigProvided(pluginName, in.Context.KubeConfig); err != nil {
 		return executor.ExecuteOutput{}, err
 	}
 

--- a/cmd/executor/gh/main.go
+++ b/cmd/executor/gh/main.go
@@ -63,6 +63,10 @@ func (*GHExecutor) Metadata(context.Context) (api.MetadataOutput, error) {
 
 // Execute returns a given command as a response.
 func (e *GHExecutor) Execute(ctx context.Context, in executor.ExecuteInput) (executor.ExecuteOutput, error) {
+	if err := pluginx.CheckKubeConfigProvided(pluginName, in.Context.KubeConfig); err != nil {
+		return executor.ExecuteOutput{}, err
+	}
+
 	var cfg Config
 	err := pluginx.MergeExecutorConfigs(in.Configs, &cfg)
 	if err != nil {

--- a/internal/executor/helm/executor.go
+++ b/internal/executor/helm/executor.go
@@ -84,7 +84,7 @@ func (e *Executor) Metadata(context.Context) (api.MetadataOutput, error) {
 // - history
 // - get [all|manifest|hooks|notes]
 func (e *Executor) Execute(ctx context.Context, in executor.ExecuteInput) (executor.ExecuteOutput, error) {
-	if err := pluginx.CheckKubeConfigProvided(PluginName, in.Context.KubeConfig); err != nil {
+	if err := pluginx.ValidateKubeConfigProvided(PluginName, in.Context.KubeConfig); err != nil {
 		return executor.ExecuteOutput{}, err
 	}
 

--- a/internal/executor/helm/executor.go
+++ b/internal/executor/helm/executor.go
@@ -84,6 +84,10 @@ func (e *Executor) Metadata(context.Context) (api.MetadataOutput, error) {
 // - history
 // - get [all|manifest|hooks|notes]
 func (e *Executor) Execute(ctx context.Context, in executor.ExecuteInput) (executor.ExecuteOutput, error) {
+	if err := pluginx.CheckKubeConfigProvided(PluginName, in.Context.KubeConfig); err != nil {
+		return executor.ExecuteOutput{}, err
+	}
+
 	cfg, err := MergeConfigs(in.Configs)
 	if err != nil {
 		return executor.ExecuteOutput{}, fmt.Errorf("while merging input configs: %w", err)

--- a/internal/executor/helm/executor_test.go
+++ b/internal/executor/helm/executor_test.go
@@ -226,6 +226,9 @@ func TestExecutorConfigMergingErrors(t *testing.T) {
 	// when
 	_, err := hExec.Execute(context.Background(), executor.ExecuteInput{
 		Command: "helm install",
+		Context: executor.ExecuteInputContext{
+			KubeConfig: []byte("fake config"),
+		},
 		Configs: []*executor.Config{
 			{
 				RawYAML: mustYAMLMarshal(t, configA),

--- a/internal/executor/kubectl/executor.go
+++ b/internal/executor/kubectl/executor.go
@@ -74,6 +74,10 @@ func (e *Executor) Metadata(context.Context) (api.MetadataOutput, error) {
 
 // Execute returns a given command as response.
 func (e *Executor) Execute(ctx context.Context, in executor.ExecuteInput) (executor.ExecuteOutput, error) {
+	if err := pluginx.CheckKubeConfigProvided(PluginName, in.Context.KubeConfig); err != nil {
+		return executor.ExecuteOutput{}, err
+	}
+
 	cfg, err := MergeConfigs(in.Configs)
 	if err != nil {
 		return executor.ExecuteOutput{}, fmt.Errorf("while merging input configs: %w", err)

--- a/internal/executor/kubectl/executor.go
+++ b/internal/executor/kubectl/executor.go
@@ -74,7 +74,7 @@ func (e *Executor) Metadata(context.Context) (api.MetadataOutput, error) {
 
 // Execute returns a given command as response.
 func (e *Executor) Execute(ctx context.Context, in executor.ExecuteInput) (executor.ExecuteOutput, error) {
-	if err := pluginx.CheckKubeConfigProvided(PluginName, in.Context.KubeConfig); err != nil {
+	if err := pluginx.ValidateKubeConfigProvided(PluginName, in.Context.KubeConfig); err != nil {
 		return executor.ExecuteOutput{}, err
 	}
 

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -121,10 +121,16 @@ func (d *Dispatcher) Dispatch(dispatch PluginDispatch) error {
 	go func() {
 		for {
 			select {
-			case event := <-out.Output:
+			case event, ok := <-out.Output:
+				if !ok {
+					return
+				}
 				log.WithField("event", string(event)).Debug("Dispatching received event...")
 				d.dispatch(ctx, event, dispatch)
-			case msg := <-out.Event:
+			case msg, ok := <-out.Event:
+				if !ok {
+					return
+				}
 				log.WithField("message", msg).Debug("Dispatching received message...")
 				d.dispatchMsg(ctx, msg, dispatch)
 			case <-ctx.Done():

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -115,7 +115,7 @@ func (d *Dispatcher) Dispatch(dispatch PluginDispatch) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("while opening stream for %s: %w", dispatch.pluginName, err)
+		return fmt.Errorf(`while opening stream for "%s.%s" source: %w`, dispatch.sourceName, dispatch.pluginName, err)
 	}
 
 	go func() {

--- a/internal/source/kubernetes/source.go
+++ b/internal/source/kubernetes/source.go
@@ -65,7 +65,7 @@ func NewSource(version string) *Source {
 
 // Stream streams Kubernetes events
 func (*Source) Stream(ctx context.Context, input source.StreamInput) (source.StreamOutput, error) {
-	if err := pluginx.CheckKubeConfigProvided(PluginName, input.Context.KubeConfig); err != nil {
+	if err := pluginx.ValidateKubeConfigProvided(PluginName, input.Context.KubeConfig); err != nil {
 		return source.StreamOutput{}, err
 	}
 

--- a/internal/source/kubernetes/source.go
+++ b/internal/source/kubernetes/source.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubeshop/botkube/pkg/api"
 	"github.com/kubeshop/botkube/pkg/api/source"
 	pkgConfig "github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/pluginx"
 )
 
 const (
@@ -64,6 +65,10 @@ func NewSource(version string) *Source {
 
 // Stream streams Kubernetes events
 func (*Source) Stream(ctx context.Context, input source.StreamInput) (source.StreamOutput, error) {
+	if err := pluginx.CheckKubeConfigProvided(PluginName, input.Context.KubeConfig); err != nil {
+		return source.StreamOutput{}, err
+	}
+
 	cfg, err := config.MergeConfigs(input.Configs)
 	if err != nil {
 		return source.StreamOutput{}, fmt.Errorf("while merging input configs: %w", err)

--- a/pkg/api/source/logger.go
+++ b/pkg/api/source/logger.go
@@ -1,0 +1,15 @@
+package source
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// NewLogger returns a new logger used internally. We should replace it in the near future, as we shouldn't be so opinionated.
+func NewLogger() logrus.FieldLogger {
+	logger := logrus.New()
+	logger.SetOutput(os.Stdout)
+	logger.SetLevel(logrus.InfoLevel)
+	return logger
+}

--- a/pkg/pluginx/kubeconfig.go
+++ b/pkg/pluginx/kubeconfig.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func PersistKubeConfig(ctx context.Context, kc []byte) (string, func(context.Context) error, error) {
+func PersistKubeConfig(_ context.Context, kc []byte) (string, func(context.Context) error, error) {
 	if len(kc) == 0 {
 		return "", nil, fmt.Errorf("received empty kube config")
 	}
@@ -33,4 +33,12 @@ func PersistKubeConfig(ctx context.Context, kc []byte) (string, func(context.Con
 	}
 
 	return abs, deleteFn, nil
+}
+
+// CheckKubeConfigProvided returns an error if a given kubeconfig is empty or nil.
+func CheckKubeConfigProvided(pluginName string, kubeconfig []byte) error {
+	if len(kubeconfig) != 0 {
+		return nil
+	}
+	return fmt.Errorf("The kubeconfig data is missing. Please make sure that you have specified a valid RBAC configuration for %q plugin. Learn more at https://docs.botkube.io/configuration/rbac.", pluginName)
 }

--- a/pkg/pluginx/kubeconfig.go
+++ b/pkg/pluginx/kubeconfig.go
@@ -35,8 +35,8 @@ func PersistKubeConfig(_ context.Context, kc []byte) (string, func(context.Conte
 	return abs, deleteFn, nil
 }
 
-// CheckKubeConfigProvided returns an error if a given kubeconfig is empty or nil.
-func CheckKubeConfigProvided(pluginName string, kubeconfig []byte) error {
+// ValidateKubeConfigProvided returns an error if a given kubeconfig is empty or nil.
+func ValidateKubeConfigProvided(pluginName string, kubeconfig []byte) error {
 	if len(kubeconfig) != 0 {
 		return nil
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add validation that kubeconfig is specified

## Testing

- remove the `context` property for `helm`,`kc` and `k8s` plugins
- for sources: nothing to do
- for executors: run `@Botkube helm` or `@Botkube kc`
- next, check the Botkube logs 

In the future, we should remove the internal logging and introduce an error feedback channel. Additionally, we can also consider posting errors on Slack/etc. Here we need to think whether post them directly or maybe introduce sth like `@Botkube check health` or sth similar.


Some time ago it was also mentioned here: https://github.com/kubeshop/botkube/issues/878

## Related issue(s)

Fix https://github.com/kubeshop/botkube/issues/1048
