### PR TITLE
Block actions with ChannelName executors

### DIFF
--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -370,10 +370,11 @@ func validateActionExecutors(sl validator.StructLevel, executors map[string]Exec
 			if !plugin.Enabled {
 				continue
 			}
-			if plugin.Context.RBAC != nil {
-				if plugin.Context.RBAC.Group.Type == ChannelNamePolicySubjectType {
-					sl.ReportError(bindings, pluginKey, executor, invalidActionRBACTag, "")
-				}
+			if plugin.Context.RBAC == nil {
+				continue
+			}
+			if plugin.Context.RBAC.Group.Type == ChannelNamePolicySubjectType {
+				sl.ReportError(bindings, pluginKey, executor, invalidActionRBACTag, "")
 			}
 		}
 	}

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -125,7 +125,7 @@ func registerBindingsValidator(validate *validator.Validate, trans ut.Translator
 		conflictingPluginVersionTag: "{0}{1}",
 		invalidPluginDefinitionTag:  "{0}{1}",
 		invalidPluginRBACTag:        "Binding is referencing plugins of same kind with different RBAC. '{0}' and '{1}' bindings must be identical when used together.",
-		invalidActionRBACTag:        "Plugin {0} has 'ChannelName' RBAC policy. This is not supported for actions.",
+		invalidActionRBACTag:        "Plugin {0} has 'ChannelName' RBAC policy. This is not supported for actions. See https://docs.botkube.io/configuration/action#rbac",
 	})
 }
 

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -23,6 +23,7 @@ const (
 	invalidPluginDefinitionTag  = "invalid_plugin_definition"
 	invalidAliasCommandTag      = "invalid_alias_command"
 	invalidPluginRBACTag        = "invalid_plugin_rbac"
+	invalidActionRBACTag        = "invalid_action_tag"
 	appTokenPrefix              = "xapp-"
 	botTokenPrefix              = "xoxb-"
 )
@@ -124,6 +125,7 @@ func registerBindingsValidator(validate *validator.Validate, trans ut.Translator
 		conflictingPluginVersionTag: "{0}{1}",
 		invalidPluginDefinitionTag:  "{0}{1}",
 		invalidPluginRBACTag:        "Binding is referencing plugins of same kind with different RBAC. '{0}' and '{1}' bindings must be identical when used together.",
+		invalidActionRBACTag:        "Plugin {0} has 'ChannelName' RBAC policy. This is not supported for actions.",
 	})
 }
 
@@ -245,6 +247,7 @@ func actionBindingsStructValidator(sl validator.StructLevel) {
 	}
 	validateSourceBindings(sl, conf.Sources, bindings.Sources)
 	validateExecutorBindings(sl, conf.Executors, bindings.Executors)
+	validateActionExecutors(sl, conf.Executors, bindings.Executors)
 }
 
 func aliasesStructValidator(sl validator.StructLevel) {
@@ -355,6 +358,22 @@ func validatePluginRBAC[P pluginProvider](sl validator.StructLevel, pluginConfig
 
 			if !reflect.DeepEqual(firstRBAC, nextCfg.Context.RBAC) {
 				sl.ReportError(bindings, p1, p1, invalidPluginRBACTag, nextIdx)
+			}
+		}
+	}
+}
+
+func validateActionExecutors(sl validator.StructLevel, executors map[string]Executors, bindings []string) {
+	for _, executor := range bindings {
+		execConf := executors[executor]
+		for pluginKey, plugin := range execConf.Plugins {
+			if !plugin.Enabled {
+				continue
+			}
+			if plugin.Context.RBAC != nil {
+				if plugin.Context.RBAC.Group.Type == ChannelNamePolicySubjectType {
+					sl.ReportError(bindings, pluginKey, executor, invalidActionRBACTag, "")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Block actions with ChannelName executors

## Testing

<!-- Describe necessary steps to test the changes.
You can refer to the existing documentation if some steps are already described. -->

Define a executor with `ChannelName` RBAC policy:

```yaml
executors:
  k8s-default-tools:
    botkube/helm:
      enabled: true
      config:
        defaultNamespace: "default"
        helmDriver: "secret"
        helmConfigDir: "/tmp/helm/"
        helmCacheDir: "/tmp/helm/.cache"
      context: &default-plugin-context
        defaultNamespace: "default"
        rbac:
          group:
            type: ChannelName

actions:
  'describe-created-resource':
    enabled: true
    displayName: "Describe created resource"
    command: "kubectl describe {{ .Event.Kind | lower }}{{ if .Event.Namespace }} -n {{ .Event.Namespace }}{{ end }} {{ .Event.Name }}"
    bindings:
      sources:
        - k8s-create-events
      executors:
        - k8s-default-tools
```

Such action config should be blocked by config validator.

## Related issue(s)

https://github.com/kubeshop/botkube/issues/1045
