### PR TITLE
Send the cluster name for all interactive commands

### DIFF
--- a/cmd/botkube/main.go
+++ b/cmd/botkube/main.go
@@ -239,7 +239,7 @@ func run(ctx context.Context) error {
 		}
 
 		if commGroupCfg.CloudSlack.Enabled {
-			sb, err := bot.NewCloudSlack(commGroupLogger.WithField(botLogFieldKey, "CloudSlack"), commGroupName, commGroupCfg.CloudSlack, executorFactory, reporter)
+			sb, err := bot.NewCloudSlack(commGroupLogger.WithField(botLogFieldKey, "CloudSlack"), commGroupName, commGroupCfg.CloudSlack, conf.Settings.ClusterName, executorFactory, reporter)
 			if err != nil {
 				return reportFatalError("while creating CloudSlack bot", err)
 			}

--- a/internal/executor/kubectl/builder/kubectl.go
+++ b/internal/executor/kubectl/builder/kubectl.go
@@ -97,6 +97,7 @@ func (e *Kubectl) Handle(ctx context.Context, cmd string, isInteractivitySupport
 		"resourceName": stateDetails.resourceName,
 		"resourceType": stateDetails.resourceType,
 		"verb":         stateDetails.verb,
+		"cmd":          cmd,
 	}).Debug("Extracted Slack state")
 
 	cmds := executorsRunner{

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -287,9 +287,9 @@ func appendByUserOnlyIfNeeded(cmd, user string, origin command.Origin) string {
 	return fmt.Sprintf("%s by %s", cmd, user)
 }
 
-func filterInput(id string) api.LabelInput {
+func filterInput(cmd string) api.LabelInput {
 	return api.LabelInput{
-		Command:          fmt.Sprintf("%s %s --filter=", api.MessageBotNamePlaceholder, id),
+		Command:          fmt.Sprintf("%s %s --filter=", api.MessageBotNamePlaceholder, cmd),
 		DispatchedAction: api.DispatchInputActionOnEnter,
 		Placeholder:      "String pattern to filter by",
 		Text:             "Filter output",


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

-Send the cluster name for all interactive commands


The current implementation is quite hacky. The main problem is that only buttons are easily to handle as we know the whole command up front and we can simply add `--cluster-name` flag.

For all others, like selects, inputs, etc. the command is constructed either via https://github.com/kubeshop/botkube/blob/428e62405e9002a0b3b02ad9697e254521cbbb7c/pkg/bot/socketslack.go#L517-L544

or by using state https://github.com/kubeshop/botkube/blob/428e62405e9002a0b3b02ad9697e254521cbbb7c/internal/executor/kubectl/builder/kubectl.go#L393. 

This introduces additional complexity that we need to handle when we are injecting the `--cluster-name` flag as otherwise we will break the parsing on the plugin side.

### Notes

I tried to use a new field, use ids, and slack message metadata, none of them worked for me 😞 So I ended up with this kinda ugly solution.

### Future

Because of the current architecture, I cannot normalize it in a more straightforward way. IMO we should decouple slack commands and slack state. I would see sth like:

- clean cmd that is always passed to the plugin
- optional `metadata` which is `map[string]string` that holds the data that we extract from the Slack state. This way our plugins won't parse the initial slack state and as a result we can hold more details in the state that will be only handled in the core code.

## Testing

- Install and play with the interactive kubectl or help message.
