### PR TITLE
Fix scheduling messages for Cloud Slack (#1108)

### DIFF
--- a/internal/source/scheduler.go
+++ b/internal/source/scheduler.go
@@ -53,6 +53,14 @@ func NewScheduler(log logrus.FieldLogger, cfg *config.Config, dispatcher pluginD
 // Start starts all sources and dispatch received events.
 func (d *Scheduler) Start(ctx context.Context) error {
 	for _, commGroupCfg := range d.cfg.Communications {
+		if commGroupCfg.CloudSlack.Enabled {
+			for _, channel := range commGroupCfg.CloudSlack.Channels {
+				if err := d.schedule(ctx, config.CloudSlackCommPlatformIntegration.IsInteractive(), channel.Bindings.Sources); err != nil {
+					return err
+				}
+			}
+		}
+
 		if commGroupCfg.Slack.Enabled {
 			for _, channel := range commGroupCfg.Slack.Channels {
 				if err := d.schedule(ctx, config.SlackCommPlatformIntegration.IsInteractive(), channel.Bindings.Sources); err != nil {

--- a/pkg/bot/cloudslack.go
+++ b/pkg/bot/cloudslack.go
@@ -317,7 +317,6 @@ func (b *CloudSlack) SendMessage(ctx context.Context, msg interactive.CoreMessag
 			Channel:         channelName,
 			ThreadTimeStamp: "",
 			BlockID:         uuid.New().String(),
-			CommandOrigin:   command.AutomationOrigin,
 		}
 		err := b.send(ctx, msgMetadata, msg)
 		if err != nil {

--- a/pkg/bot/socketslack.go
+++ b/pkg/bot/socketslack.go
@@ -458,7 +458,6 @@ func (b *SocketSlack) SendMessage(ctx context.Context, msg interactive.CoreMessa
 			Channel:         channelName,
 			ThreadTimeStamp: "",
 			BlockID:         uuid.New().String(),
-			CommandOrigin:   command.AutomationOrigin,
 		}
 		err := b.send(ctx, msgMetadata, msg)
 		if err != nil {


### PR DESCRIPTION
* Fix scheduling messages for Cloud Slack
* Remove unused command origin when sending message

(cherry picked from commit 2e9c13f32666d99265326fe2738a6d1f4b2f239a)

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix scheduling messages for Cloud Slack (#1108)

