### PR TITLE
Add tutorial message template for x plugin

### DIFF
--- a/cmd/executor/x/main.go
+++ b/cmd/executor/x/main.go
@@ -105,7 +105,7 @@ func (i *XExecutor) Execute(ctx context.Context, in executor.ExecuteInput) (exec
 		},
 	}
 	if err := pluginx.MergeExecutorConfigs(in.Configs, &cfg); err != nil {
-		return executor.ExecuteOutput{}, err
+		return executor.ExecuteOutput{}, fmt.Errorf("while merging configs: %v", err)
 	}
 
 	log := loggerx.New(cfg.Logger)
@@ -114,9 +114,10 @@ func (i *XExecutor) Execute(ctx context.Context, in executor.ExecuteInput) (exec
 	err = renderer.RegisterAll(map[string]x.Render{
 		"parser:table:.*": output.NewTableCommandParser(log),
 		"wrapper":         output.NewCommandWrapper(),
+		"tutorial":        output.NewTutorialWrapper(),
 	})
 	if err != nil {
-		return executor.ExecuteOutput{}, err
+		return executor.ExecuteOutput{}, fmt.Errorf("while registering message renderers: %v", err)
 	}
 
 	runner := x.NewRunner(log, renderer)
@@ -128,22 +129,25 @@ func (i *XExecutor) Execute(ctx context.Context, in executor.ExecuteInput) (exec
 		tool := Normalize(strings.Join(cmd.Run.Tool, " "))
 		log.WithField("tool", tool).Info("Running command...")
 
-		kubeConfigPath, deleteFn, err := i.getKubeconfig(ctx, log, in)
-		defer deleteFn()
-		if err != nil {
-			return executor.ExecuteOutput{}, err
-		}
-
 		command := x.Parse(tool)
-		out, err := x.RunInstalledCommand(ctx, cfg.TmpDir, command.ToExecute, map[string]string{
-			"KUBECONFIG": kubeConfigPath,
-		})
-		if err != nil {
-			log.WithError(err).WithField("command", command.ToExecute).Error("failed to run command")
-			return executor.ExecuteOutput{}, err
+		run := func() (string, error) {
+			kubeConfigPath, deleteFn, err := i.getKubeconfig(ctx, log, in)
+			defer deleteFn()
+			if err != nil {
+				return "", err
+			}
+
+			out, err := x.RunInstalledCommand(ctx, cfg.TmpDir, command.ToExecute, map[string]string{
+				"KUBECONFIG": kubeConfigPath,
+			})
+			if err != nil {
+				log.WithError(err).WithField("command", command.ToExecute).Error("failed to run command")
+				return "", err
+			}
+			return out, nil
 		}
 
-		return runner.Run(ctx, cfg, state, command, out)
+		return runner.Run(ctx, cfg, state, command, run)
 	case cmd.Install != nil:
 		var (
 			tool          = Normalize(strings.Join(cmd.Install.Tool, " "))
@@ -152,20 +156,24 @@ func (i *XExecutor) Execute(ctx context.Context, in executor.ExecuteInput) (exec
 			downloadCmd   = fmt.Sprintf("eget %s", tool)
 		)
 
-		log.WithFields(logrus.Fields{
-			"dir":         dir,
-			"isCustom":    isCustom,
-			"userCommand": command.ToExecute,
-			"runCommand":  downloadCmd,
-		}).Info("Installing binary...")
+		run := func() (string, error) {
+			log.WithFields(logrus.Fields{
+				"dir":         dir,
+				"isCustom":    isCustom,
+				"userCommand": command.ToExecute,
+				"runCommand":  downloadCmd,
+			}).Info("Installing binary...")
 
-		if _, err := pluginx.ExecuteCommand(ctx, downloadCmd, pluginx.ExecuteCommandEnvs(map[string]string{
-			"EGET_BIN": dir,
-		})); err != nil {
-			return executor.ExecuteOutput{}, err
+			if _, err := pluginx.ExecuteCommand(ctx, downloadCmd, pluginx.ExecuteCommandEnvs(map[string]string{
+				"EGET_BIN": dir,
+			})); err != nil {
+				return "", err
+			}
+
+			return "Binary was installed successfully 🎉", nil
 		}
 
-		return runner.Run(ctx, cfg, state, command, "Binary was installed successfully 🎉")
+		return runner.Run(ctx, cfg, state, command, run)
 	}
 	return executor.ExecuteOutput{
 		Message: api.NewPlaintextMessage("Command not supported", false),

--- a/cmd/executor/x/main.go
+++ b/cmd/executor/x/main.go
@@ -134,7 +134,7 @@ func (i *XExecutor) Execute(ctx context.Context, in executor.ExecuteInput) (exec
 			kubeConfigPath, deleteFn, err := i.getKubeconfig(ctx, log, in)
 			defer deleteFn()
 			if err != nil {
-				return "", err
+				return "", fmt.Errorf("while creating kubeconfig: %v", err)
 			}
 
 			out, err := x.RunInstalledCommand(ctx, cfg.TmpDir, command.ToExecute, map[string]string{
@@ -142,7 +142,7 @@ func (i *XExecutor) Execute(ctx context.Context, in executor.ExecuteInput) (exec
 			})
 			if err != nil {
 				log.WithError(err).WithField("command", command.ToExecute).Error("failed to run command")
-				return "", err
+				return "", fmt.Errorf("while running command: %v", err)
 			}
 			return out, nil
 		}

--- a/cmd/executor/x/templates/argo.yaml
+++ b/cmd/executor/x/templates/argo.yaml
@@ -1,12 +1,13 @@
 templates:
-  - command:
-      prefix: "argo list"
-      parser: "table"
+  - trigger:
+      command:
+        prefix: "argo list"
+    type: "parser:table:space"
     message:
-      select:
-        name: "Workflows"
-        itemKey: "{{ .Namespace }}/{{ .Name }}"
+      selects:
+        - name: "Workflows"
+          keyTpl: "{{ .Namespace }}/{{ .Name }}"
       actions:
-        logs:     "argo logs   {{ .Name }} -n {{ .Namespace }}"
-        describe: "argo get    {{ .Name }} -n {{ .Namespace }}"
-        delete:   "argo delete {{ .Name }} -n {{ .Namespace }}"
+        logs: "argo logs {{ .Name }} -n {{ .Namespace }}"
+        describe: "argo get {{ .Name }} -n {{ .Namespace }}"
+        delete: "argo delete {{ .Name }} -n {{ .Namespace }}"

--- a/cmd/executor/x/templates/flux.yaml
+++ b/cmd/executor/x/templates/flux.yaml
@@ -1,6 +1,7 @@
 templates:
   - trigger:
-      command: "flux get sources git"
+      command:
+        prefix: "flux get sources git"
     type: "parser:table:space"
     message:
       selects:
@@ -16,12 +17,93 @@ templates:
         Message:     {{ .Message}}
 
   - trigger:
-      command: "x install github.com/fluxcd/flux2"
+      command:
+        prefix: "x install github.com/fluxcd/flux2"
     type: "wrapper"
     message:
       buttons:
-        - name: "Get Help"
-          command: "{{BotName}} x run flux --help"
-        - name: "Initialize"
-          command: "{{BotName}} x run flux install"
+        - name: "Quickstart"
+          command: "{{BotName}} x run quickstart flux"
           style: "primary"
+
+  - trigger:
+      command:
+        prefix: "quickstart flux"
+    type: "tutorial"
+    message:
+      paginate:
+        page: 5
+      header: "Flux Quick Start tutorial"
+      buttons:
+        - name: "Check prerequisites"
+          command: "{{BotName}} x run flux check --pre"
+          description: "{{BotName}} flux check --pre"
+        - name: "Install Flux"
+          command: "{{BotName}} x run flux install"
+          description: "{{BotName}} flux install"
+        - name: "Create Git source"
+          command: |
+            {{BotName}} x run flux create source git webapp-latest
+               --url=https://github.com/stefanprodan/podinfo 
+               --branch=master 
+               --interval=3m
+          description: |
+            {{BotName}} flux create source git webapp-latest
+               --url=https://github.com/stefanprodan/podinfo 
+               --branch=master 
+               --interval=3m
+        - name: "List Git sources"
+          command: "{{BotName}} x run flux get sources git"
+          description: "{{BotName}} flux get sources git"
+        - name: "Reconcile Git source"
+          command: "{{BotName}} x run flux reconcile source git flux-system"
+          description: "{{BotName}} flux reconcile source git flux-system"
+        - name: "Export Git sources"
+          command: "{{BotName}} x run flux export source git --all"
+          description: "{{BotName}} flux export source git --all"
+        - name: "Create Kustomization"
+          command: |
+            {{BotName}} x run flux create kustomization webapp-dev
+               --source=webapp-latest 
+               --path='./deploy/webapp/'
+               --prune=true 
+               --interval=5m 
+               --health-check='Deployment/backend.webapp' 
+               --health-check='Deployment/frontend.webapp'
+               --health-check-timeout=2m
+          description: |
+            {{BotName}} x run flux create kustomization webapp-dev
+               --source=webapp-latest 
+               --path='./deploy/webapp/'
+               --prune=true
+               --interval=5m 
+               --health-check='Deployment/backend.webapp' 
+               --health-check='Deployment/frontend.webapp'
+               --health-check-timeout=2m
+        - name: "Reconcile Kustomization"
+          command: "{{BotName}} x run flux reconcile kustomization webapp-dev --with-source"
+          description: "{{BotName}} flux reconcile kustomization webapp-dev --with-source"
+        - name: "Suspend Kustomization"
+          command: "{{BotName}} x run flux suspend kustomization webapp-dev"
+          description: "{{BotName}} flux suspend kustomization webapp-dev"
+        - name: "Export Kustomizations"
+          command: "{{BotName}} x run flux export kustomization --all"
+          description: "{{BotName}} flux export kustomization --all"
+        - name: "Resume Kustomization"
+          command: "{{BotName}} x run flux resume kustomization webapp-dev"
+          description: "{{BotName}} flux resume kustomization webapp-dev"
+        - name: "Delete Kustomization"
+          command: "{{BotName}} x run flux delete kustomization webapp-dev"
+          description: "{{BotName}} flux delete kustomization webapp-dev"
+        - name: "Delete Git source"
+          command: "{{BotName}} x run flux delete source git webapp-latest"
+          description: "{{BotName}} flux delete source"
+        - name: "Delete Kustomization"
+          command: "{{BotName}} x run flux delete kustomization webapp-dev"
+          description: "{{BotName}} flux delete kustomization webapp-dev"
+        - name: "Delete Git source"
+          command: "{{BotName}} x run flux delete source git webapp-latest --silent"
+          description: "{{BotName}} flux delete source git webapp-latest --silent"
+        - name: "Uninstall Flux"
+          command: "{{BotName}} x run flux uninstall"
+          description: "{{BotName}} flux uninstall"

--- a/cmd/executor/x/templates/helm.yaml
+++ b/cmd/executor/x/templates/helm.yaml
@@ -1,13 +1,14 @@
 templates:
   - trigger:
-      command: "helm list"
+      command:
+        regex: '^helm list(?:\s+(-A|-a))*\s?$'
     type: "parser:table:space"
     message:
       selects:
         - name: "Release"
           keyTpl: "{{ .Namespace }}/{{ .Name }}"
       actions:
-        notes:  "helm get notes  {{ .Name }} -n {{ .Namespace }}"
+        notes: "helm get notes  {{ .Name }} -n {{ .Namespace }}"
         values: "helm get values {{ .Name }} -n {{ .Namespace }}"
         delete: "helm delete     {{ .Name }} -n {{ .Namespace }}"
       preview: |
@@ -15,3 +16,53 @@ templates:
         Namespace:   {{ .Namespace }}
         Status:      {{ .Status }}
         Chart:       {{ .Chart }}
+
+  - trigger:
+      command:
+        prefix: "x install https://get.helm.sh/helm-v"
+    type: "wrapper"
+    message:
+      buttons:
+        - name: "Quickstart"
+          command: "{{BotName}} x run quickstart helm"
+          style: "primary"
+
+  - trigger:
+      command:
+        prefix: "quickstart helm"
+    type: "tutorial"
+    message:
+      paginate:
+        page: 5
+      header: "Helm Quick Start tutorial"
+      buttons:
+        - name: "Global Help"
+          description: "{{BotName}} helm help"
+          command: "{{BotName}} x run helm help"
+        - name: "Version"
+          description: "{{BotName}} helm version"
+          command: "{{BotName}} x run helm version"
+        - name: "Install help"
+          description: "{{BotName}} helm install -h"
+          command: "{{BotName}} x run helm install -h"
+        - name: "Install by absolute URL"
+          description: "{{BotName}} helm install\n--repo https://charts.bitnami.com/bitnami psql postgresql\n--set clusterDomain='testing.local'"
+          command: "{{BotName}} x run helm install\n--repo https://charts.bitnami.com/bitnami psql postgresql\n--set clusterDomain='testing.local'"
+        - name: "Install by chart reference:"
+          description: "{{BotName}} helm install https://charts.bitnami.com/bitnami/postgresql-12.1.0.tgz --create-namespace -n test --generate-name"
+          command: "{{BotName}} x run helm install https://charts.bitnami.com/bitnami/postgresql-12.1.0.tgz --create-namespace -n test --generate-name"
+        - name: "List"
+          description: "{{BotName}} helm list -A"
+          command: "{{BotName}} x run helm list -A"
+        - name: "List with filter"
+          description: "{{BotName}} helm list -f 'p' -A"
+          command: "{{BotName}} x run helm list -f 'p' -A"
+        - name: "Status"
+          description: "{{BotName}} helm status psql"
+          command: "{{BotName}} x run helm status psql"
+        - name: "Upgrade"
+          description: "{{BotName}} helm upgrade --repo https://charts.bitnami.com/bitnami psql postgresql --set clusterDomain='cluster.local'"
+          command: "{{BotName}} x run helm upgrade --repo https://charts.bitnami.com/bitnami psql postgresql --set clusterDomain='cluster.local'"
+        - name: "History"
+          description: "{{BotName}} helm history psql"
+          command: "{{BotName}} x run helm history psql"

--- a/internal/executor/x/getter/load.go
+++ b/internal/executor/x/getter/load.go
@@ -2,6 +2,7 @@ package getter
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -16,6 +17,10 @@ type Source struct {
 
 // Load downloads defined sources and read them from the FS.
 func Load[T any](ctx context.Context, tmpDir string, templateSources []Source) ([]T, error) {
+	if len(templateSources) == 0 {
+		return nil, nil
+	}
+
 	err := EnsureDownloaded(ctx, templateSources, tmpDir)
 	if err != nil {
 		return nil, err
@@ -36,7 +41,7 @@ func Load[T any](ctx context.Context, tmpDir string, templateSources []Source) (
 
 		file, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
-			return err
+			return fmt.Errorf("while reading file %q: %v", path, err)
 		}
 
 		var cfg struct {
@@ -44,7 +49,7 @@ func Load[T any](ctx context.Context, tmpDir string, templateSources []Source) (
 		}
 		err = yaml.Unmarshal(file, &cfg)
 		if err != nil {
-			return err
+			return fmt.Errorf("while unmarshaling file %q: %v", path, err)
 		}
 		out = append(out, cfg.Templates...)
 		return nil

--- a/internal/executor/x/mathx/int.go
+++ b/internal/executor/x/mathx/int.go
@@ -17,3 +17,11 @@ func DecreaseWithMin(in, min int) int {
 	}
 	return in
 }
+
+// Max returns the largest of a or b.
+func Max(a, b int) int {
+	if a > b {
+		return b
+	}
+	return a
+}

--- a/internal/executor/x/output/message_tutorial.go
+++ b/internal/executor/x/output/message_tutorial.go
@@ -1,0 +1,64 @@
+package output
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/botkube/internal/executor/x/mathx"
+	"github.com/kubeshop/botkube/internal/executor/x/state"
+	"github.com/kubeshop/botkube/internal/executor/x/template"
+	"github.com/kubeshop/botkube/pkg/api"
+)
+
+// TutorialWrapper allows constructing interactive message with predefined steps.
+type TutorialWrapper struct{}
+
+// NewTutorialWrapper returns a new TutorialWrapper instance.
+func NewTutorialWrapper() *TutorialWrapper {
+	return &TutorialWrapper{}
+}
+
+// RenderMessage returns  interactive message with predefined steps.
+func (p *TutorialWrapper) RenderMessage(cmd, _ string, _ *state.Container, msgCtx *template.Template) (api.Message, error) {
+	var (
+		msg   = msgCtx.TutorialMessage
+		start = mathx.Max(msg.Paginate.CurrentPage*msg.Paginate.Page, len(msg.Buttons)-2)
+		stop  = mathx.Max(start+msg.Paginate.Page, len(msg.Buttons))
+	)
+
+	return api.Message{
+		OnlyVisibleForYou: true,
+		ReplaceOriginal:   msg.Paginate.CurrentPage > 0,
+		Sections: []api.Section{
+			{
+				Base: api.Base{
+					Header: msg.Header,
+				},
+			},
+			{
+				Buttons: msg.Buttons[start:stop],
+			},
+			{
+				Buttons: p.getPaginationButtons(msg, msg.Paginate.CurrentPage, cmd),
+			},
+		},
+	}, nil
+}
+
+func (p *TutorialWrapper) getPaginationButtons(msg template.TutorialMessage, pageIndex int, cmd string) []api.Button {
+	allItems := len(msg.Buttons)
+	if allItems <= msg.Paginate.Page {
+		return nil
+	}
+
+	btnsBuilder := api.NewMessageButtonBuilder()
+
+	var out []api.Button
+	if pageIndex > 0 {
+		out = append(out, btnsBuilder.ForCommandWithoutDesc("Prev", fmt.Sprintf("x run %s @page:%d", cmd, mathx.DecreaseWithMin(pageIndex, 0))))
+	}
+
+	if pageIndex*msg.Paginate.Page < allItems-1 {
+		out = append(out, btnsBuilder.ForCommandWithoutDesc("Next", fmt.Sprintf("x run %s @page:%d", cmd, mathx.IncreaseWithMax(pageIndex, allItems-1)), api.ButtonStylePrimary))
+	}
+	return out
+}

--- a/internal/executor/x/run_test.go
+++ b/internal/executor/x/run_test.go
@@ -1,0 +1,130 @@
+package x
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/botkube/internal/executor/x/getter"
+	"github.com/kubeshop/botkube/internal/executor/x/state"
+	"github.com/kubeshop/botkube/internal/executor/x/template"
+	"github.com/kubeshop/botkube/internal/loggerx"
+	"github.com/kubeshop/botkube/internal/plugin"
+	"github.com/kubeshop/botkube/pkg/api"
+	"github.com/kubeshop/botkube/pkg/config"
+)
+
+func TestRunnerRawOutput(t *testing.T) {
+	// given
+	cmd := Command{
+		ToExecute:     "test command",
+		IsRawRequired: true,
+	}
+	runExecuted := false
+	runFn := func() (string, error) {
+		runExecuted = true
+		return "command output", nil
+	}
+	expMsg := api.NewCodeBlockMessage("command output", true)
+
+	runner := NewRunner(loggerx.NewNoop(), nil)
+
+	// when
+	output, err := runner.Run(context.Background(), Config{}, nil, cmd, runFn)
+
+	// then
+	assert.NoError(t, err)
+	assert.True(t, runExecuted)
+	assert.Equal(t, expMsg, output.Message)
+}
+
+func TestRunnerNoTemplates(t *testing.T) {
+	// given
+	cmd := Command{
+		ToExecute: "test command",
+	}
+	runExecuted := false
+	runFn := func() (string, error) {
+		runExecuted = true
+		return "command output", nil
+	}
+	expMsg := api.NewCodeBlockMessage("command output", true)
+
+	runner := NewRunner(loggerx.NewNoop(), nil)
+
+	// when
+	output, err := runner.Run(context.Background(), Config{}, nil, cmd, runFn)
+
+	// then
+	assert.NoError(t, err)
+	assert.True(t, runExecuted)
+	assert.Equal(t, expMsg, output.Message)
+}
+
+func TestRunnerNoExecuteTemplate(t *testing.T) {
+	// given
+	cmd := Command{
+		ToExecute: "quickstart helm",
+	}
+	cfg := Config{
+		Templates: []getter.Source{
+			{
+				Ref: filepath.Join("./testdata/", t.Name()),
+			},
+		},
+		TmpDir: plugin.TmpDir(t.TempDir()),
+		Logger: config.Logger{},
+	}
+
+	runExecuted := false
+	runFn := func() (string, error) {
+		runExecuted = true
+		return "command output", nil
+	}
+
+	expMsg := api.NewCodeBlockMessage(cmd.ToExecute, false)
+
+	renderer := NewRenderer()
+	err := renderer.Register("tutorial", &MockRenderer{})
+	require.NoError(t, err)
+
+	runner := NewRunner(loggerx.NewNoop(), renderer)
+
+	// when
+	output, err := runner.Run(context.Background(), cfg, nil, cmd, runFn)
+
+	// then
+	assert.NoError(t, err)
+	assert.False(t, runExecuted)
+	assert.Equal(t, expMsg, output.Message)
+}
+
+func TestRunnerExecuteError(t *testing.T) {
+	// given
+	cmd := Command{
+		ToExecute: "test command",
+	}
+	fixErr := errors.New("fix error")
+	runFn := func() (string, error) {
+		return "", fixErr
+	}
+
+	runner := NewRunner(loggerx.NewNoop(), nil)
+
+	// when
+	output, err := runner.Run(context.Background(), Config{}, nil, cmd, runFn)
+
+	// then
+	assert.EqualError(t, err, fixErr.Error())
+	assert.Empty(t, output)
+}
+
+type MockRenderer struct{}
+
+func (r *MockRenderer) RenderMessage(cmd, output string, state *state.Container, msgCtx *template.Template) (api.Message, error) {
+	return api.NewCodeBlockMessage(cmd, false), nil
+}

--- a/internal/executor/x/testdata/TestRunnerNoExecuteTemplate/helm.yaml
+++ b/internal/executor/x/testdata/TestRunnerNoExecuteTemplate/helm.yaml
@@ -1,0 +1,34 @@
+templates:
+  - trigger:
+      command:
+        prefix: "helm list"
+    type: "parser:table:space"
+    message:
+      selects:
+        - name: "Release"
+          keyTpl: "{{ .Namespace }}/{{ .Name }}"
+      actions:
+        notes: "helm get notes  {{ .Name }} -n {{ .Namespace }}"
+        values: "helm get values {{ .Name }} -n {{ .Namespace }}"
+        delete: "helm delete     {{ .Name }} -n {{ .Namespace }}"
+      preview: |
+        Name:        {{ .Name }}
+        Namespace:   {{ .Namespace }}
+        Status:      {{ .Status }}
+        Chart:       {{ .Chart }}
+
+  - trigger:
+      command:
+        prefix: "quickstart helm"
+    type: "tutorial"
+    message:
+      paginate:
+        page: 5
+      header: "Helm Quick Start tutorial"
+      buttons:
+        - name: "Global Help"
+          description: "{{Botkube}} helm help"
+          command: "{{Botkube}} helm help"
+        - name: "Version"
+          description: "{{Botkube}} helm version -h"
+          command: "{{Botkube}} helm version -h"


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add tutorial message template for x plugin

## Testing



1. Create k3d cluster
2. Start plugin server: `env PLUGIN_SERVER_HOST=http://host.k3d.internal go run test/helpers/plugin_server.go`
3. Build x plugin: ` PLUGIN_TARGETS="x" make build-plugins`
4. Install Botkube with such example config:
    
    <details><summary>config yaml</summary>
    <p>
    
    ```yaml
    communications:
      default-group:
        socketSlack:
          enabled: true
          channels:
            default:
              name: general
              bindings:
                sources: [ ]
                executors:
                  - bins-management
          appToken: "xapp-1"
          botToken: "xoxb-"
    
    executors:
      bins-management:
        local-repo/x:
          enabled: true
          context:
            rbac:
              group:
                type: Static
                static:
                  values: [ "system:masters" ]
          config:
            templates:
              - ref: github.com/mszostok/botkube//cmd/executor/x/templates?ref=334eb4321e793a5d7107d000cba4a2c39da286c3
    
    extraEnv:
      - name: LOG_LEVEL_EXECUTOR_LOCAL-REPO_X
        value: "debug"
    
    plugins:
      repositories:
        local-repo:
          url: http://host.k3d.internal:3000/botkube.yaml
    
    settings:
      log:
        level: "debug"
      clusterName: "labs"
      upgradeNotifier: false
    
    analytics:
      disable: true
    
    configWatcher:
      enabled: false
    ```
    
    </p>
    </details> 


### Example Flux

1. Install Flux CLI
    ```
    @Botkube x install github.com/fluxcd/flux2
    ```
2. Click Quickstart
3. Follow tutorial steps.


You can do the same for Helm by running: `@Botkube x install https://get.helm.sh/helm-v3.10.3-linux-amd64.tar.gz --file helm`
## Demo


https://github.com/kubeshop/botkube/assets/17568639/d3827a47-92b4-4acf-9b13-ce505ef026b3





## Related issue(s)

- #1111 
