### PR TITLE
Add Slack notifications for E2E tests

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - notify-slack # TODO: To remove
 
 env:
   HELM_VERSION: v3.9.0
@@ -90,7 +91,7 @@ jobs:
       - name: Download k3d
         run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
       - name: Create k3d cluster
-        run: "k3d cluster create migration-test-cluster --wait --timeout=5m"
+        run: "k3d-invalid cluster create migration-test-cluster --wait --timeout=5m"
       - name: Run e2e tests for botkube client
         env:
           DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-      - notify-slack # TODO: To remove
+  repository_dispatch:
+    types: [trigger-e2e-tests]
 
 env:
   HELM_VERSION: v3.9.0
@@ -56,6 +57,9 @@ jobs:
     name: Migration e2e test
     runs-on: ubuntu-latest
     needs: [ build ]
+    concurrency:
+      group: e2e-migration
+      cancel-in-progress: false
     permissions:
       contents: read
       packages: read
@@ -91,7 +95,7 @@ jobs:
       - name: Download k3d
         run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
       - name: Create k3d cluster
-        run: "k3d-invalid cluster create migration-test-cluster --wait --timeout=5m"
+        run: "k3d cluster create migration-test-cluster --wait --timeout=5m"
       - name: Run e2e tests for botkube client
         env:
           DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
@@ -109,7 +113,7 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     needs: [ build ]
-
+    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
     permissions:
       contents: read
       packages: read
@@ -189,7 +193,7 @@ jobs:
   slackNotification:
     name: Slack Notification
     runs-on: ubuntu-latest
-    needs: [ migration-e2e-test, integration-tests ]
+    needs: [ migration-e2e-test ]
     if: failure()
     steps:
       - name: Slack Notification

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -184,3 +184,21 @@ jobs:
         run: |
           KUBECONFIG=$(k3d kubeconfig write ${{ matrix.integration }}-test-cluster) \
             make test-integration-${{ matrix.integration }}
+
+  slackNotification:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    needs: [ migration-e2e-test, integration-tests ]
+    if: failure()
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: Botkube Cloud CI
+          SLACK_COLOR: 'red'
+          SLACK_TITLE: 'Message'
+          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
+          SLACK_MESSAGE: 'CLI Migration E2E tests failed :scream:'
+          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
+          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
+      - notify-slack # TODO: To remove
   repository_dispatch:
-    types: [trigger-e2e-tests]
+    types: [ trigger-e2e-tests ]
 
 env:
   HELM_VERSION: v3.9.0
@@ -24,34 +25,34 @@ jobs:
       GOBIN: /home/runner/work/botkube/bin
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Setup Go
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Docker Login
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install GoReleaser
-      uses: goreleaser/goreleaser-action@v2
-      with:
-        install-only: true
-        version: latest
-    - name: Run GoReleaser
-      run: make release-snapshot
-      env:
-        ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
-    - name: Install Helm
-      uses: azure/setup-helm@v1
-      with:
-        version: ${{ env.HELM_VERSION }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Docker Login
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          install-only: true
+          version: latest
+      - name: Run GoReleaser
+        run: make release-snapshot
+        env:
+          ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
 
   migration-e2e-test:
     name: Migration e2e test

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - notify-slack # TODO: To remove
   repository_dispatch:
     types: [ trigger-e2e-tests ]
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add Slack notifications for E2E migration tests pipeline
- Add ability to trigger this pipeline via dispatch events

## Notes
I thought about running also integration tests on dispatch event + getting Slack notificactions about integration tests, but I think that would be too much. WDYT?

## Testing

Sample alert: https://kubeshop.slack.com/archives/C05E6GU80E7/p1689068842786839

## Related issue(s)

Resolves #1125 
