### PR TITLE
Plugins logger respect generic logger settings

### DIFF
--- a/cmd/botkube-agent/main.go
+++ b/cmd/botkube-agent/main.go
@@ -130,7 +130,7 @@ func run(ctx context.Context) error {
 
 	collector := plugin.NewCollector(logger)
 	enabledPluginExecutors, enabledPluginSources := collector.GetAllEnabledAndUsedPlugins(conf)
-	pluginManager := plugin.NewManager(logger, conf.Plugins, enabledPluginExecutors, enabledPluginSources)
+	pluginManager := plugin.NewManager(logger, conf.Settings.Log, conf.Plugins, enabledPluginExecutors, enabledPluginSources)
 
 	err = pluginManager.Start(ctx)
 	if err != nil {

--- a/internal/cli/install/logs/json_parser.go
+++ b/internal/cli/install/logs/json_parser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	charmlog "github.com/charmbracelet/log"
 	"golang.org/x/exp/maps"
@@ -23,7 +24,7 @@ func (j *JSONParser) ParseLineIntoCharm(line string) ([]any, charmlog.Level) {
 
 	var fields []any
 
-	lvl := charmlog.ParseLevel(fmt.Sprint(result["level"]))
+	lvl := parseLevel(fmt.Sprint(result["level"]))
 	fields = append(fields, charmlog.LevelKey, lvl)
 	fields = append(fields, charmlog.MessageKey, result["msg"])
 
@@ -51,4 +52,22 @@ func (*JSONParser) parseLine(line string) map[string]any {
 		return nil
 	}
 	return out
+}
+
+// parseLevel takes a string level and returns the charm log level constant.
+func parseLevel(lvl string) charmlog.Level {
+	switch strings.ToLower(lvl) {
+	case "panic", "fatal":
+		return charmlog.FatalLevel
+	case "error", "err":
+		return charmlog.ErrorLevel
+	case "warn", "warning":
+		return charmlog.WarnLevel
+	case "info":
+		return charmlog.InfoLevel
+	case "debug", "trace":
+		return charmlog.DebugLevel
+	default:
+		return charmlog.InfoLevel
+	}
 }

--- a/internal/plugin/index_builder.go
+++ b/internal/plugin/index_builder.go
@@ -16,6 +16,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/kubeshop/botkube/pkg/api"
+	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/multierror"
 )
 
@@ -170,7 +171,7 @@ func (i *IndexBuilder) getPluginMetadata(dir string, bins []pluginBinariesIndex)
 		bins := map[string]string{
 			item.Type.String(): filepath.Join(dir, item.BinaryPath),
 		}
-		clients, err := createGRPCClients[metadataGetter](i.log, bins, item.Type)
+		clients, err := createGRPCClients[metadataGetter](i.log, config.Logger{}, bins, item.Type)
 		if err != nil {
 			return nil, fmt.Errorf("while creating gRPC client: %w", err)
 		}

--- a/internal/plugin/logger.go
+++ b/internal/plugin/logger.go
@@ -23,11 +23,13 @@ var specialCharsPattern = regexp.MustCompile(`(?i:[^A-Z0-9_])`)
 // - hashicorp client logger always has the configured log level
 // - binary standard output is logged only if debug level is set, otherwise it is discarded
 // - binary standard error is logged always on error level
-func NewPluginLoggers(bkLogger logrus.FieldLogger, pluginKey string, pluginType Type) (hclog.Logger, io.Writer, io.Writer) {
+func NewPluginLoggers(bkLogger logrus.FieldLogger, logConfig config.Logger, pluginKey string, pluginType Type) (hclog.Logger, io.Writer, io.Writer) {
 	pluginLogLevel := getPluginLogLevel(bkLogger, pluginKey, pluginType)
 
 	cfg := config.Logger{
-		Level: pluginLogLevel.String(),
+		Level:         pluginLogLevel.String(),
+		DisableColors: logConfig.DisableColors,
+		Formatter:     logConfig.Formatter,
 	}
 	log := loggerx.New(cfg).WithField("plugin", pluginKey)
 

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -69,7 +69,7 @@ func TestCollectEnabledRepositories(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
-			manager := NewManager(loggerx.NewNoop(), config.PluginManagement{
+			manager := NewManager(loggerx.NewNoop(), config.Logger{}, config.PluginManagement{
 				Repositories: tc.definedRepositories,
 			}, tc.enabledExecutors, tc.enabledSources)
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Plugins logger respect generic logger settings
- Update botkube CLI log parser to respect logrus level strings

## Testing

Install Botkube, you should see a change in logs from:

```bash
WARN[2023-07-14T12:48:24Z] plugin configured with a nil SecureConfig     plugin=botkube/kubernetes
DEBU[2023-07-14T12:48:24Z] starting plugin                               args="[/tmp/botkube/source_v0.0.0-latest_kubernetes]" path=/tmp/botkube/source_v0.0.0-latest_kubernetes plugin=botkube/kubernetes
```

to 

```bash
{"level":"warning","msg":"plugin configured with a nil SecureConfig","plugin":"botkube/kubectl","time":"2023-07-14T12:59:27Z"}
{"args":["/tmp/botkube/source_v0.0.0-latest_kubernetes"],"level":"debug","msg":"starting plugin","path":"/tmp/botkube/source_v0.0.0-latest_kubernetes","plugin":"botkube/kubernetes","time":"2023-07-14T12:59:30Z"}
```
