### PR TITLE
Rename `--auto-upgrade` to `--auto-approve` flag for Migration CLI

### DIFF
--- a/cmd/cli/cmd/migrate.go
+++ b/cmd/cli/cmd/migrate.go
@@ -143,7 +143,7 @@ func NewMigrate() *cobra.Command {
 	flags.StringVarP(&opts.Namespace, "namespace", "n", "botkube", "Namespace of Botkube pod")
 	flags.BoolVarP(&opts.SkipConnect, "skip-connect", "q", false, "Skips connecting to Botkube Cloud after migration")
 	flags.BoolVar(&opts.SkipOpenBrowser, "skip-open-browser", false, "Skips opening web browser after migration")
-	flags.BoolVar(&opts.AutoUpgrade, "auto-upgrade", false, "Automatically upgrades Botkube instance without additional prompt")
+	flags.BoolVarP(&opts.AutoApprove, "auto-approve", "y", false, "Skips interactive approval for upgrading Botkube installation.")
 	flags.StringVar(&opts.ConfigExporter.Registry, "cfg-exporter-image-registry", "ghcr.io", "Config Exporter job image registry")
 	flags.StringVar(&opts.ConfigExporter.Repository, "cfg-exporter-image-repo", "kubeshop/botkube-config-exporter", "Config Exporter job image repository")
 	flags.StringVar(&opts.ConfigExporter.Tag, "cfg-exporter-image-tag", DefaultImageTag, "Config Exporter job image tag")

--- a/cmd/cli/docs/botkube_migrate.md
+++ b/cmd/cli/docs/botkube_migrate.md
@@ -35,7 +35,7 @@ botkube migrate [OPTIONS] [flags]
 ### Options
 
 ```
-      --auto-upgrade                         Automatically upgrades Botkube instance without additional prompt
+  -y, --auto-approve                         Skips interactive approval for upgrading Botkube installation.
       --cfg-exporter-image-registry string   Config Exporter job image registry (default "ghcr.io")
       --cfg-exporter-image-repo string       Config Exporter job image repository (default "kubeshop/botkube-config-exporter")
       --cfg-exporter-image-tag string        Config Exporter job image tag (default "v9.99.9-dev")

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -339,7 +339,7 @@ func errStateMessage(dashboardURL, instanceID string) string {
 }
 
 func shouldUpgradeInstallation(opts Options) (bool, error) {
-	if opts.AutoUpgrade {
+	if opts.AutoApprove {
 		return true, nil
 	}
 

--- a/internal/cli/migrate/opts.go
+++ b/internal/cli/migrate/opts.go
@@ -12,7 +12,7 @@ type Options struct {
 	Label             string
 	SkipConnect       bool
 	SkipOpenBrowser   bool
-	AutoUpgrade       bool
+	AutoApprove       bool
 	ConfigExporter    ConfigExporterOptions
 }
 

--- a/test/e2e/migration_test.go
+++ b/test/e2e/migration_test.go
@@ -120,7 +120,7 @@ func TestBotkubeMigration(t *testing.T) {
 
 	t.Run("Migrate Discord Botkube to Botkube Cloud", func(t *testing.T) {
 		cmd := exec.Command(appCfg.BotkubeBinaryPath, "migrate",
-			"--auto-upgrade",
+			"--auto-approve",
 			"--skip-open-browser",
 			"--verbose",
 			fmt.Sprintf("--token=%s", token),


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Rename `--auto-upgrade` to `--auto-approve` flag for Migration CLI

Just to unify the flags as install uses this 👍 
