### PR TITLE
add human friendly error messages

### DIFF
--- a/pkg/bot/discord.go
+++ b/pkg/bot/discord.go
@@ -380,14 +380,13 @@ func discordBotMentionRegex(botID string) (*regexp.Regexp, error) {
 }
 
 func discordError(err error, channel string) error {
-	switch err.(type) {
+	switch err := err.(type) {
 	case *discordgo.RESTError:
-		restErr := err.(*discordgo.RESTError)
-		switch restErr.Response.StatusCode {
+		switch err.Response.StatusCode {
 		case http.StatusUnauthorized:
-			err = errors.New("invalid discord credentials")
+			return errors.New("invalid discord credentials")
 		case http.StatusNotFound:
-			err = fmt.Errorf("channel %q not found", channel)
+			return fmt.Errorf("channel %q not found", channel)
 		}
 	}
 	return err

--- a/pkg/bot/slack_shared.go
+++ b/pkg/bot/slack_shared.go
@@ -42,6 +42,18 @@ func slackBotMentionRegex(botID string) (*regexp.Regexp, error) {
 	return botMentionRegex, nil
 }
 
+func slackError(err error, channel string) error {
+	switch err.Error() {
+	case "channel_not_found":
+		err = fmt.Errorf("channel %q not found", channel)
+	case "not_in_channel":
+		err = fmt.Errorf("botkube is not in channel %q", channel)
+	case "invalid_auth":
+		err = fmt.Errorf("invalid slack credentials")
+	}
+	return err
+}
+
 // slackMessage contains message details to execute command and send back the result
 type slackMessage struct {
 	Text            string

--- a/pkg/bot/slack_socket.go
+++ b/pkg/bot/slack_socket.go
@@ -60,7 +60,7 @@ func NewSocketSlack(log logrus.FieldLogger, commGroupName string, cfg config.Soc
 
 	authResp, err := client.AuthTest()
 	if err != nil {
-		return nil, fmt.Errorf("while testing the ability to do auth Slack request: %w", err)
+		return nil, fmt.Errorf("while testing the ability to do auth Slack request: %w", slackError(err, ""))
 	}
 	botID := authResp.UserID
 
@@ -422,7 +422,7 @@ func (b *SocketSlack) send(ctx context.Context, event slackMessage, resp interac
 		}
 	} else {
 		if _, _, err := b.client.PostMessageContext(ctx, event.Channel, options...); err != nil {
-			return fmt.Errorf("while posting Slack message: %w", err)
+			return fmt.Errorf("while posting Slack message: %w", slackError(err, event.Channel))
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Mapped error messages in bot packages
- There is no need to add error mapping for mattermost since they already send readable error descriptions, we use them.

Here are the screenshots for testing results for different scenarios for Slack, Discord, and Mattermost
### Slack
![Screenshot 2023-07-21 at 13 36 39](https://github.com/kubeshop/botkube/assets/1237982/1e5b5a14-84e1-4304-a42e-dad123a9fe59)



### Discord
![Screenshot 2023-07-21 at 13 29 34](https://github.com/kubeshop/botkube/assets/1237982/e6335da6-0d44-4890-915f-937039b8dd14)



## Testing
You can create an instance on Botkube Cloud Dev, and provide wrong creds, wrong channel, or not invited channel for each platform. You need to see human-friendly messages as shown above. 

You need to run botkube deployment via `go run ...` on this branch after exporting 
```bash
export CONFIG_PROVIDER_API_KEY=...
export CONFIG_PROVIDER_ENDPOINT=https://api-dev.botkube.io/graphql
export CONFIG_PROVIDER_IDENTIFIER=...
```

<!-- Describe necessary steps to test the changes.
You can refer to the existing documentation if some steps are already described. -->

## Related issue(s)
https://github.com/kubeshop/botkube-cloud/issues/520
<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
