### PR TITLE
Fix panics in Kubernetes plugin

### DIFF
--- a/internal/source/kubernetes/router.go
+++ b/internal/source/kubernetes/router.go
@@ -29,7 +29,7 @@ type route struct {
 }
 
 func (r route) hasActionableUpdateSetting() bool {
-	return len(r.updateSetting.Fields) > 0
+	return r.updateSetting != nil && len(r.updateSetting.Fields) > 0
 }
 
 type entry struct {

--- a/test/e2e/migration_test.go
+++ b/test/e2e/migration_test.go
@@ -264,7 +264,7 @@ func assertAliases(t *testing.T, actual []*gqlModel.Alias) {
 		},
 	}
 
-	assert.Len(t, actual, 2)
+	assert.Len(t, actual, 4)
 
 	// trim ID and deployments
 	for i := range actual {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix panics in Kubernetes plugin
- Fix assertion in migration test

When I was testing Josef's PR I noticed the Kubernetes plugin panics with e.g.

<details><summary>Details</summary>
<p>

```
DEBU[2023-07-19T14:55:08+02:00] github.com/kubeshop/botkube/internal/source/kubernetes/config.(*RegexConstraints).AreConstraintsDefined(...)  plugin=botkube/kubernetes subsystem_name=botkube/kubernetes.source_v0.0.0-latest_kubernetes
DEBU[2023-07-19T14:55:08+02:00]         /home/runner/work/botkube/botkube/internal/source/kubernetes/config/config.go:97  plugin=botkube/kubernetes subsystem_name=botkube/kubernetes.source_v0.0.0-latest_kubernetes
DEBU[2023-07-19T14:55:08+02:00] github.com/kubeshop/botkube/internal/source/kubernetes.registration.matchEvent({{0x2f98920, 0xc000d30160}, {0x2fa3100, 0xc000448c80}, {0x2f94c80, 0xc000694270}, {0x2f782e0, 0xc0007927d0}, {0xc001173000, 0x1, ...}, ...}, ...)  plugin=botkube/kubernetes subsystem_name=botkube/kubernetes.source_v0.0.0-latest_kubernetes
DEBU[2023-07-19T14:55:08+02:00] received EOF, stopping recv loop              err="rpc error: code = Unavailable desc = error reading from server: EOF" plugin=botkube/kubernetes subsystem_name=botkube/kubernetes.stdio
DEBU[2023-07-19T14:55:08+02:00]         /home/runner/work/botkube/botkube/internal/source/kubernetes/registration.go:194 +0x23e  plugin=botkube/kubernetes subsystem_name=botkube/kubernetes.source_v0.0.0-latest_kubernetes
DEBU[2023-07-19T14:55:08+02:00] github.com/kubeshop/botkube/internal/source/kubernetes.registration.qualifyEvent({{0x2f98920, 0xc000d30160}, {0x2fa3100, 0xc000448c80}, {0x2f94c80, 0xc000694270}, {0x2f782e0, 0xc0007927d0}, {0xc001173000, 0x1, ...}, ...}, ...)  plugin=botkube/kubernetes subsystem_name=botkube/kubernetes.source_v0.0.0-latest_kubernetes
DEBU[2023-07-19T14:55:08+02:00]         /home/runner/work/botkube/botkube/internal/source/kubernetes/registration.go:262 +0xc5  plugin=botkube/kubernetes subsystem_name=botkube/kubernetes.source_v0.0.0-latest_kubernetes
DEBU[2023-07-19T14:55:08+02:00] github.com/kubeshop/botkube/internal/source/kubernetes.registration.handleEvent.func1({0x0, 0x0}, {0x2935ee0?, 0xc000966a80})  plugin=botkube/kubernetes subsystem_name=botkube/kubernetes.source_v0.0.0-latest_kubernetes

```

</p>
</details> 

This PR solves that.

## Testing

Provide configuration with no `namespaces` or `updateSetting` properties. This will result in panics.
