### PR TITLE
Handle K8s empty resource list for K8s 1.26+

### DIFF
--- a/internal/command/guard_test.go
+++ b/internal/command/guard_test.go
@@ -82,6 +82,29 @@ func TestCommandGuard_GetAllowedResourcesForVerb(t *testing.T) {
 			ExpectedErrMessage: "",
 		},
 		{
+			Name:                   "Discovery API resource list ignored error 2",
+			SelectedVerb:           "get",
+			AllConfiguredResources: []string{"pods"},
+			FakeDiscoClient: &fakeDisco{
+				list: []*v1.APIResourceList{
+					{
+						GroupVersion: "v1",
+						APIResources: []v1.APIResource{
+							{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"}},
+						},
+					},
+				},
+				err: &discovery.ErrGroupDiscoveryFailed{
+					Groups: map[schema.GroupVersion]error{
+						{Group: "", Version: "external.metrics.k8s.io/v1beta1"}: errors.New("received empty response for: external.metrics.k8s.io/v1beta1"),
+					},
+				}},
+			ExpectedResult: []Resource{
+				{Name: "pods", Namespaced: true, SlashSeparatedInCommand: false},
+			},
+			ExpectedErrMessage: "",
+		},
+		{
 			Name:                   "Verb not supported",
 			SelectedVerb:           "create",
 			AllConfiguredResources: []string{"pods", "services", "nodes"},


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Handle K8s empty resource list for K8s 1.26+

**NOTE:** It should be cherry picked for 1.3.1 too.

## Testing

> NOTE: I tried to follow the instruction from previous similar PR: https://github.com/kubeshop/botkube/pull/834
Even with older KEDA 2.9 couldn't reproduce that on K8s 1.27. Maybe that was fixed on Kubernetes side too? 🤔 Anyway, I added a unit test to cover this.

Install Botkube with the following overrides:

```
--set image.repository=kubeshop/pr/botkube \
--set image.tag=1194-PR \
```

## Related issue(s)

Resolves https://github.com/kubeshop/botkube/issues/1173
