### PR TITLE
Modified formatting of errs

### DIFF
--- a/pkg/multierror/multierror.go
+++ b/pkg/multierror/multierror.go
@@ -29,12 +29,32 @@ func listFormatFunc(es []error) string {
 		return fmt.Sprintf("1 error occurred:\n\t* %s", es[0])
 	}
 
-	points := make([]string, len(es))
-	for i, err := range es {
-		points[i] = fmt.Sprintf("* %s", err)
-	}
+	// points := make([]string, len(es))
+	// for i, err := range es {
+	// 	points[i] = fmt.Sprintf("* %s", err)
+	// }
 
-	return fmt.Sprintf(
-		"%d errors occurred:\n\t%s",
-		len(es), strings.Join(points, "\n\t"))
+	// return fmt.Sprintf(
+	// 	"%d errors occurred:\n\t%s",
+	// 	len(es), strings.Join(points, "\n\t"))
+
+	formatString := "* %s"
+
+	formatterResult := strings.Join(formatElements(formatString,es),"\n\t")
+
+	return formatterResult
+}
+
+//Added a way to format the strings in a better way 
+func formatElements(formatStr string, errs []error) []string {
+	errStrings := make([]string, len(errs))
+	for i, err := range errs {
+		errStrings[i] = err.Error()
+	}
+	var formattedSlice []string
+	for _, element := range errStrings {
+		formattedElement := fmt.Sprintf(formatStr, element)
+		formattedSlice = append(formattedSlice, formattedElement)
+	}
+	return formattedSlice
 }

--- a/pkg/multierror/multierror.go
+++ b/pkg/multierror/multierror.go
@@ -29,15 +29,6 @@ func listFormatFunc(es []error) string {
 		return fmt.Sprintf("1 error occurred:\n\t* %s", es[0])
 	}
 
-	// points := make([]string, len(es))
-	// for i, err := range es {
-	// 	points[i] = fmt.Sprintf("* %s", err)
-	// }
-
-	// return fmt.Sprintf(
-	// 	"%d errors occurred:\n\t%s",
-	// 	len(es), strings.Join(points, "\n\t"))
-
 	formatString := "* %s"
 
 	formatterResult := strings.Join(formatElements(formatString,es),"\n\t")


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description
I though that the way of formatting the errs was a bit inefficient so i added a new way to do so. Just a small change by adding a function and then using it to convert the err into the string and then formatting the strings with the "*" at the starting and adding a line and a tab space for the next err to be printed.

Changes proposed in this pull request:

- ...

## Testing

<!-- Describe necessary steps to test the changes.
You can refer to the existing documentation if some steps are already described. -->

## Related issue(s)

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
