### PR TITLE
Restart crashed plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ gen-grpc-resources:
 	@./hack/gen-grpc-resources.sh
 
 # Generate plugins YAML index files for both all plugins and end-user ones.
-gen-plugins-index: #build-plugins
+gen-plugins-index: build-plugins
 	go run ./hack/gen-plugin-index.go -output-path ./plugins-dev-index.yaml
 	go run ./hack/gen-plugin-index.go -output-path ./plugins-index.yaml -plugin-name-filter 'kubectl|helm|kubernetes|prometheus|exec|doctor|keptn|github-events|flux'
 

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ gen-grpc-resources:
 	@./hack/gen-grpc-resources.sh
 
 # Generate plugins YAML index files for both all plugins and end-user ones.
-gen-plugins-index: build-plugins
+gen-plugins-index: #build-plugins
 	go run ./hack/gen-plugin-index.go -output-path ./plugins-dev-index.yaml
 	go run ./hack/gen-plugin-index.go -output-path ./plugins-index.yaml -plugin-name-filter 'kubectl|helm|kubernetes|prometheus|exec|doctor|keptn|github-events|flux'
 

--- a/cmd/botkube-agent/main.go
+++ b/cmd/botkube-agent/main.go
@@ -393,7 +393,7 @@ func run(ctx context.Context) (err error) {
 
 	sourcePluginDispatcher := source.NewDispatcher(logger, conf.Settings.ClusterName, bots, sinkNotifiers, pluginManager, actionProvider, reporter, auditReporter, kubeConfig)
 	scheduler := source.NewScheduler(ctx, logger, conf, sourcePluginDispatcher, schedulerChan)
-	err = scheduler.Start(ctx, "")
+	err = scheduler.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("while starting source plugin event dispatcher: %w", err)
 	}

--- a/cmd/botkube-agent/main.go
+++ b/cmd/botkube-agent/main.go
@@ -392,7 +392,7 @@ func run(ctx context.Context) (err error) {
 	actionProvider := action.NewProvider(logger.WithField(componentLogFieldKey, "Action Provider"), conf.Actions, executorFactory)
 
 	sourcePluginDispatcher := source.NewDispatcher(logger, conf.Settings.ClusterName, bots, sinkNotifiers, pluginManager, actionProvider, reporter, auditReporter, kubeConfig)
-	scheduler := source.NewScheduler(logger, conf, sourcePluginDispatcher, schedulerChan)
+	scheduler := source.NewScheduler(ctx, logger, conf, sourcePluginDispatcher, schedulerChan)
 	err = scheduler.Start(ctx, "")
 	if err != nil {
 		return fmt.Errorf("while starting source plugin event dispatcher: %w", err)

--- a/cmd/botkube-agent/main.go
+++ b/cmd/botkube-agent/main.go
@@ -368,7 +368,7 @@ func run(ctx context.Context) (err error) {
 
 	// Send help message
 	helpDB := storage.NewForHelp(conf.Settings.SystemConfigMap.Namespace, conf.Settings.SystemConfigMap.Name, k8sCli)
-	err = sendHelp(ctx, helpDB, conf.Settings.ClusterName, enabledPluginExecutors, bots)
+	err = sendHelp(ctx, helpDB, conf.Settings.ClusterName, plugin.CollectPluginNames(enabledPluginExecutors), bots)
 	if err != nil {
 		return fmt.Errorf("while sending initial help message: %w", err)
 	}

--- a/cmd/executor/echo/main.go
+++ b/cmd/executor/echo/main.go
@@ -54,6 +54,10 @@ func (*EchoExecutor) Execute(_ context.Context, in executor.ExecuteInput) (execu
 		return executor.ExecuteOutput{}, errors.New("The @fail label was specified. Failing execution.")
 	}
 
+	if strings.Contains(data, "@panic") {
+		panic("The @panic label was specified. Panicking.")
+	}
+
 	if cfg.ChangeResponseToUpperCase != nil && *cfg.ChangeResponseToUpperCase {
 		data = strings.ToUpper(data)
 	}

--- a/cmd/source/cm-watcher/main.go
+++ b/cmd/source/cm-watcher/main.go
@@ -101,6 +101,11 @@ func listenEvents(ctx context.Context, kubeConfig []byte, obj Object, sink chan 
 	infiniteWatch := func(event watch.Event) (bool, error) {
 		if event.Type == obj.Event {
 			cm := event.Object.(*corev1.ConfigMap)
+
+			if cm.Annotations["die"] == "true" {
+				exitOnError(fmt.Errorf("die annotation set to true"))
+			}
+
 			msg := fmt.Sprintf("Plugin %s detected `%s` event on `%s/%s`", pluginName, obj.Event, cm.Namespace, cm.Name)
 			sink <- source.Event{
 				Message: api.NewPlaintextMessage(msg, true),

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -50,9 +50,9 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [executors.k8s-default-tools.botkube/kubectl.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [executors.ai.botkube/doctor.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [executors.bins-management.botkube/exec.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [sources.k8s-err-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [executors.bins-management.botkube/exec.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [executors.k8s-default-tools.botkube/helm.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [executors.flux.botkube/flux.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [sources.k8s-all-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
@@ -62,14 +62,14 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [executors.k8s-default-tools.botkube/helm.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [executors.bins-management.botkube/exec.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [executors.flux.botkube/flux.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [executors.flux.botkube/flux.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [executors.bins-management.botkube/exec.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [executors.ai.botkube/doctor.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.k8s-default-tools.botkube/helm.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.ai.botkube/doctor.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
@@ -78,7 +78,7 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.bins-management.botkube/exec.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
@@ -264,18 +264,17 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [configWatcher.image.repository](./values.yaml#L1108) | string | `"kubeshop/k8s-sidecar"` | Config watcher image repository. |
 | [configWatcher.image.tag](./values.yaml#L1110) | string | `"in-cluster-config"` | Config watcher image tag. |
 | [configWatcher.image.pullPolicy](./values.yaml#L1112) | string | `"IfNotPresent"` | Config watcher image pull policy. |
-| [plugins](./values.yaml#L1115) | object | `{"cacheDir":"/tmp","repositories":{"agentRestartPolicy":{"threshold":5,"type":"deactivatePlugin"},"botkube":{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}}}` | Configuration for Botkube executors and sources plugins. |
+| [plugins](./values.yaml#L1115) | object | `{"cacheDir":"/tmp","healthCheckInterval":"10s","repositories":{"botkube":{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}},"restartPolicy":{"threshold":5,"type":"DeactivatePlugin"}}` | Configuration for Botkube executors and sources plugins. |
 | [plugins.cacheDir](./values.yaml#L1117) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
-| [plugins.repositories](./values.yaml#L1119) | object | `{"agentRestartPolicy":{"threshold":5,"type":"deactivatePlugin"},"botkube":{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}}` | List of plugins repositories. |
+| [plugins.repositories](./values.yaml#L1119) | object | `{"botkube":{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}}` | List of plugins repositories. |
 | [plugins.repositories.botkube](./values.yaml#L1121) | object | `{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
-| [plugins.repositories.agentRestartPolicy](./values.yaml#L1124) | object | `{"threshold":5,"type":"deactivatePlugin"}` | Botkube Restart Policy on plugin failure. |
-| [plugins.repositories.agentRestartPolicy.type](./values.yaml#L1126) | string | `"deactivatePlugin"` | Restart policy type. Allowed values: "restartAgent", "deactivatePlugin". |
-| [plugins.repositories.agentRestartPolicy.threshold](./values.yaml#L1128) | int | `5` | Number of restarts before policy takes into effect. |
-| [config](./values.yaml#L1131) | object | `{"provider":{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}}` | Configuration for synchronizing Botkube configuration. |
-| [config.provider](./values.yaml#L1133) | object | `{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}` | Base provider definition. |
-| [config.provider.identifier](./values.yaml#L1136) | string | `""` | Unique identifier for remote Botkube settings. If set to an empty string, Botkube won't fetch remote configuration. |
-| [config.provider.endpoint](./values.yaml#L1138) | string | `"https://api.botkube.io/graphql"` | Endpoint to fetch Botkube settings from. |
-| [config.provider.apiKey](./values.yaml#L1140) | string | `""` | Key passed as a `X-API-Key` header to the provider's endpoint. |
+| [plugins.restartPolicy.type](./values.yaml#L1126) | string | `"DeactivatePlugin"` | Restart policy type. Allowed values: "RestartAgent", "DeactivatePlugin". |
+| [plugins.restartPolicy.threshold](./values.yaml#L1128) | int | `5` | Number of restarts before policy takes into effect. |
+| [config](./values.yaml#L1132) | object | `{"provider":{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}}` | Configuration for synchronizing Botkube configuration. |
+| [config.provider](./values.yaml#L1134) | object | `{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}` | Base provider definition. |
+| [config.provider.identifier](./values.yaml#L1137) | string | `""` | Unique identifier for remote Botkube settings. If set to an empty string, Botkube won't fetch remote configuration. |
+| [config.provider.endpoint](./values.yaml#L1139) | string | `"https://api.botkube.io/graphql"` | Endpoint to fetch Botkube settings from. |
+| [config.provider.apiKey](./values.yaml#L1141) | string | `""` | Key passed as a `X-API-Key` header to the provider's endpoint. |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -47,50 +47,50 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [actions.show-logs-on-error.bindings.executors](./values.yaml#L109) | list | `["k8s-default-tools"]` | Executors configuration used to execute a configured command. |
 | [sources](./values.yaml#L118) | object | See the `values.yaml` file for full object. | Map of sources. Source contains configuration for Kubernetes events and sending recommendations. The property name under `sources` object is an alias for a given configuration. You can define multiple sources configuration with different names. Key name is used as a binding reference.   |
 | [sources.k8s-recommendation-events.botkube/kubernetes](./values.yaml#L123) | object | See the `values.yaml` file for full object. | Describes Kubernetes source configuration. |
-| [executors.bins-management.botkube/exec.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [executors.flux.botkube/flux.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [executors.k8s-default-tools.botkube/helm.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [executors.k8s-default-tools.botkube/kubectl.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-create-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [executors.ai.botkube/doctor.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [executors.bins-management.botkube/exec.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [sources.k8s-err-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [executors.ai.botkube/doctor.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [executors.flux.botkube/flux.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [executors.bins-management.botkube/exec.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [executors.k8s-default-tools.botkube/helm.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [executors.k8s-default-tools.botkube/helm.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [executors.flux.botkube/flux.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [sources.k8s-create-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac](./values.yaml#L126) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [executors.k8s-default-tools.botkube/helm.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [executors.bins-management.botkube/exec.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [executors.flux.botkube/flux.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [executors.ai.botkube/doctor.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.type](./values.yaml#L129) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [executors.k8s-default-tools.botkube/helm.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.ai.botkube/doctor.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [executors.bins-management.botkube/exec.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.flux.botkube/flux.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [executors.k8s-default-tools.botkube/helm.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [executors.bins-management.botkube/exec.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [executors.k8s-default-tools.botkube/helm.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [executors.flux.botkube/flux.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L131) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [executors.flux.botkube/flux.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [executors.bins-management.botkube/exec.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [executors.ai.botkube/doctor.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [executors.k8s-default-tools.botkube/helm.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L134) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations](./values.yaml#L148) | object | `{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}}` | Describes configuration for various recommendation insights. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations.pod](./values.yaml#L150) | object | `{"labelsSet":true,"noLatestImageTag":true}` | Recommendations for Pod Kubernetes resource. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations.pod.noLatestImageTag](./values.yaml#L152) | bool | `true` | If true, notifies about Pod containers that use `latest` tag for images. |
@@ -103,10 +103,10 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [sources.k8s-all-events.botkube/kubernetes.config.filters.objectAnnotationChecker](./values.yaml#L174) | bool | `true` | If true, enables support for `botkube.io/disable` resource annotation. |
 | [sources.k8s-all-events.botkube/kubernetes.config.filters.nodeEventsChecker](./values.yaml#L176) | bool | `true` | If true, filters out Node-related events that are not important. |
 | [sources.k8s-all-events.botkube/kubernetes.config.namespaces](./values.yaml#L180) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
-| [sources.k8s-err-with-logs-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L184) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-err-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L184) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-all-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L184) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-create-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L184) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [sources.k8s-err-with-logs-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L184) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-err-events-with-ai-support.botkube/kubernetes.config.namespaces.include](./values.yaml#L184) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-all-events.botkube/kubernetes.config.event](./values.yaml#L194) | object | `{"message":{"exclude":[],"include":[]},"reason":{"exclude":[],"include":[]},"types":["create","delete","error"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
 | [sources.k8s-all-events.botkube/kubernetes.config.event.types](./values.yaml#L196) | list | `["create","delete","error"]` | Lists all event types to be watched. |
@@ -264,15 +264,18 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [configWatcher.image.repository](./values.yaml#L1108) | string | `"kubeshop/k8s-sidecar"` | Config watcher image repository. |
 | [configWatcher.image.tag](./values.yaml#L1110) | string | `"in-cluster-config"` | Config watcher image tag. |
 | [configWatcher.image.pullPolicy](./values.yaml#L1112) | string | `"IfNotPresent"` | Config watcher image pull policy. |
-| [plugins](./values.yaml#L1115) | object | `{"cacheDir":"/tmp","repositories":{"botkube":{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}}}` | Configuration for Botkube executors and sources plugins. |
+| [plugins](./values.yaml#L1115) | object | `{"cacheDir":"/tmp","repositories":{"agentRestartPolicy":{"threshold":5,"type":"deactivatePlugin"},"botkube":{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}}}` | Configuration for Botkube executors and sources plugins. |
 | [plugins.cacheDir](./values.yaml#L1117) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
-| [plugins.repositories](./values.yaml#L1119) | object | `{"botkube":{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}}` | List of plugins repositories. |
+| [plugins.repositories](./values.yaml#L1119) | object | `{"agentRestartPolicy":{"threshold":5,"type":"deactivatePlugin"},"botkube":{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}}` | List of plugins repositories. |
 | [plugins.repositories.botkube](./values.yaml#L1121) | object | `{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
-| [config](./values.yaml#L1125) | object | `{"provider":{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}}` | Configuration for synchronizing Botkube configuration. |
-| [config.provider](./values.yaml#L1127) | object | `{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}` | Base provider definition. |
-| [config.provider.identifier](./values.yaml#L1130) | string | `""` | Unique identifier for remote Botkube settings. If set to an empty string, Botkube won't fetch remote configuration. |
-| [config.provider.endpoint](./values.yaml#L1132) | string | `"https://api.botkube.io/graphql"` | Endpoint to fetch Botkube settings from. |
-| [config.provider.apiKey](./values.yaml#L1134) | string | `""` | Key passed as a `X-API-Key` header to the provider's endpoint. |
+| [plugins.repositories.agentRestartPolicy](./values.yaml#L1124) | object | `{"threshold":5,"type":"deactivatePlugin"}` | Botkube Restart Policy on plugin failure. |
+| [plugins.repositories.agentRestartPolicy.type](./values.yaml#L1126) | string | `"deactivatePlugin"` | Restart policy type. Allowed values: "restartAgent", "deactivatePlugin". |
+| [plugins.repositories.agentRestartPolicy.threshold](./values.yaml#L1128) | int | `5` | Number of restarts before policy takes into effect. |
+| [config](./values.yaml#L1131) | object | `{"provider":{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}}` | Configuration for synchronizing Botkube configuration. |
+| [config.provider](./values.yaml#L1133) | object | `{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}` | Base provider definition. |
+| [config.provider.identifier](./values.yaml#L1136) | string | `""` | Unique identifier for remote Botkube settings. If set to an empty string, Botkube won't fetch remote configuration. |
+| [config.provider.endpoint](./values.yaml#L1138) | string | `"https://api.botkube.io/graphql"` | Endpoint to fetch Botkube settings from. |
+| [config.provider.apiKey](./values.yaml#L1140) | string | `""` | Key passed as a `X-API-Key` header to the provider's endpoint. |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/e2e-test-values.yaml
+++ b/helm/botkube/e2e-test-values.yaml
@@ -322,6 +322,10 @@ plugins:
   repositories:
     botkube:
       url: http://host.k3d.internal:3000/botkube.yaml
+  restartPolicy:
+    type: "DeactivatePlugin"
+    threshold: 5
+  healthCheckInterval: 10s
 
 actions:
   'get-created-resource':

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -1120,9 +1120,12 @@ plugins:
     # -- This repository serves officially supported Botkube plugins.
     botkube:
       url: https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml
+    # -- Botkube Restart Policy on plugin failure.
     agentRestartPolicy:
-        type: "deactivatePlugin"
-        threshold: 5
+      # -- Restart policy type. Allowed values: "restartAgent", "deactivatePlugin".
+      type: "deactivatePlugin"
+      # -- Number of restarts before policy takes into effect.
+      threshold: 5
 
 # -- Configuration for synchronizing Botkube configuration.
 config:

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -1121,11 +1121,12 @@ plugins:
     botkube:
       url: https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml
     # -- Botkube Restart Policy on plugin failure.
-    agentRestartPolicy:
-      # -- Restart policy type. Allowed values: "restartAgent", "deactivatePlugin".
-      type: "deactivatePlugin"
-      # -- Number of restarts before policy takes into effect.
-      threshold: 5
+  restartPolicy:
+    # -- Restart policy type. Allowed values: "RestartAgent", "DeactivatePlugin".
+    type: "DeactivatePlugin"
+    # -- Number of restarts before policy takes into effect.
+    threshold: 5
+  healthCheckInterval: 10s
 
 # -- Configuration for synchronizing Botkube configuration.
 config:

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -1120,6 +1120,9 @@ plugins:
     # -- This repository serves officially supported Botkube plugins.
     botkube:
       url: https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml
+    agentRestartPolicy:
+        type: "deactivatePlugin"
+        threshold: 5
 
 # -- Configuration for synchronizing Botkube configuration.
 config:

--- a/internal/plugin/health_monitor.go
+++ b/internal/plugin/health_monitor.go
@@ -74,7 +74,7 @@ func (m *HealthMonitor) monitorSourcePluginHealth(ctx context.Context) {
 			}
 
 			m.sourcesStore.EnabledPlugins.Insert(repoPluginPair, p)
-			m.schedulerChan <- fmt.Sprintf("%s/%s/%s", plugin.group, plugin.repo, plugin.name)
+			m.schedulerChan <- repoPluginPair
 		}
 	}
 }

--- a/internal/plugin/health_monitor.go
+++ b/internal/plugin/health_monitor.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/kubeshop/botkube/pkg/api/executor"
 	"github.com/kubeshop/botkube/pkg/api/source"
 	"github.com/kubeshop/botkube/pkg/config"
-	"github.com/sirupsen/logrus"
 )
 
 type HealthMonitor struct {

--- a/internal/plugin/health_monitor.go
+++ b/internal/plugin/health_monitor.go
@@ -1,0 +1,96 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubeshop/botkube/pkg/api/executor"
+	"github.com/kubeshop/botkube/pkg/api/source"
+	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+type HealthMonitor struct {
+	log                    logrus.FieldLogger
+	logConfig              config.Logger
+	sourceSupervisorChan   chan pluginMetadata
+	executorSupervisorChan chan pluginMetadata
+	schedulerChan          chan string
+	executorsStore         *store[executor.Executor]
+	sourcesStore           *store[source.Source]
+}
+
+func NewHealthMonitor(logger logrus.FieldLogger, logCfg config.Logger, schedulerChan chan string, sourceSupervisorChan, executorSupervisorChan chan pluginMetadata, executorsStore *store[executor.Executor], sourcesStore *store[source.Source]) *HealthMonitor {
+	return &HealthMonitor{
+		log:                    logger,
+		logConfig:              logCfg,
+		schedulerChan:          schedulerChan,
+		sourceSupervisorChan:   sourceSupervisorChan,
+		executorSupervisorChan: executorSupervisorChan,
+		executorsStore:         executorsStore,
+		sourcesStore:           sourcesStore,
+	}
+}
+
+func (m *HealthMonitor) Start(ctx context.Context) {
+	go m.monitorSourcePluginHealth(ctx)
+	go m.monitorExecutorPluginHealth(ctx)
+}
+
+func (m *HealthMonitor) monitorSourcePluginHealth(ctx context.Context) {
+	m.log.Info("Starting source plugin supervisor...")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case plugin := <-m.sourceSupervisorChan:
+			m.log.Infof("Restarting source plugin %q...", plugin.name)
+			if source, ok := m.sourcesStore.EnabledPlugins.Get(plugin.name); ok && source.Cleanup != nil {
+				m.log.Infof("Releasing resources of source plugin %q...", plugin.name)
+				source.Cleanup()
+			}
+
+			// botkube/kubernetes
+			repoPluginPair := fmt.Sprintf("%s/%s", plugin.repo, plugin.name)
+			m.sourcesStore.EnabledPlugins.Delete(repoPluginPair)
+
+			p, err := createGRPCClient[source.Source](ctx, m.log, m.logConfig, plugin, TypeSource, m.sourceSupervisorChan)
+			if err != nil {
+				m.log.WithError(err).Errorf("Failed to restart plugin %q.", plugin.name)
+				continue
+			}
+
+			m.sourcesStore.EnabledPlugins.Insert(repoPluginPair, p)
+			m.schedulerChan <- repoPluginPair
+		}
+	}
+}
+
+func (m *HealthMonitor) monitorExecutorPluginHealth(ctx context.Context) {
+	m.log.Info("Starting executor plugin supervisor...")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case plugin := <-m.executorSupervisorChan:
+			m.log.Infof("Restarting executor plugin %q...", plugin.name)
+			if executor, ok := m.executorsStore.EnabledPlugins.Get(plugin.name); ok && executor.Cleanup != nil {
+				m.log.Infof("Releasing executors of executor plugin %q...", plugin.name)
+				executor.Cleanup()
+			}
+
+			// botkube/kubectl
+			// TODO: if other naming scheme is used, it might be safer to try guess the name from channel bindings
+			repoPluginPair := fmt.Sprintf("%s/%s", plugin.repo, plugin.name)
+			m.executorsStore.EnabledPlugins.Delete(repoPluginPair)
+
+			p, err := createGRPCClient[executor.Executor](ctx, m.log, m.logConfig, plugin, TypeExecutor, m.executorSupervisorChan)
+			if err != nil {
+				m.log.WithError(err).Errorf("Failed to restart plugin %q.", plugin.name)
+				continue
+			}
+
+			m.executorsStore.EnabledPlugins.Insert(repoPluginPair, p)
+		}
+	}
+}

--- a/internal/plugin/index_builder.go
+++ b/internal/plugin/index_builder.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-getter"
 	"github.com/sirupsen/logrus"
@@ -178,7 +179,7 @@ func (i *IndexBuilder) getPluginMetadata(dir string, index []pluginBinariesIndex
 				binPath: filepath.Join(dir, item.BinaryPath),
 			},
 		}
-		clients, err := createGRPCClients[metadataGetter](context.Background(), i.log, config.Logger{}, bins, item.Type, make(chan pluginMetadata))
+		clients, err := createGRPCClients[metadataGetter](context.Background(), i.log, config.Logger{}, bins, item.Type, make(chan pluginMetadata), 10*time.Second)
 		if err != nil {
 			return nil, fmt.Errorf("while creating gRPC client: %w", err)
 		}

--- a/internal/plugin/index_builder.go
+++ b/internal/plugin/index_builder.go
@@ -178,14 +178,12 @@ func (i *IndexBuilder) getPluginMetadata(dir string, index []pluginBinariesIndex
 				binPath: filepath.Join(dir, item.BinaryPath),
 			},
 		}
-		emptyChan := make(chan pluginMetadata)
-		// close(emptyChan)
-		clients, err := createGRPCClients[metadataGetter](context.Background(), i.log, config.Logger{}, bins, item.Type, emptyChan)
+		clients, err := createGRPCClients[metadataGetter](context.Background(), i.log, config.Logger{}, bins, item.Type, make(chan pluginMetadata))
 		if err != nil {
 			return nil, fmt.Errorf("while creating gRPC client: %w", err)
 		}
 
-		cli := clients[item.Type.String()]
+		cli := clients.data[item.Type.String()]
 		meta, err := cli.Client.Metadata(context.Background())
 		if err != nil {
 			return nil, fmt.Errorf("while calling metadata RPC: %w", err)

--- a/internal/plugin/index_builder.go
+++ b/internal/plugin/index_builder.go
@@ -176,7 +176,7 @@ func (i *IndexBuilder) getPluginMetadata(dir string, bins []pluginBinariesIndex)
 		bins := map[string]string{
 			item.Type.String(): filepath.Join(dir, item.BinaryPath),
 		}
-		clients, err := createGRPCClients[metadataGetter](i.log, config.Logger{}, bins, item.Type)
+		clients, err := createGRPCClients[metadataGetter](context.Background(), i.log, config.Logger{}, bins, item.Type)
 		if err != nil {
 			return nil, fmt.Errorf("while creating gRPC client: %w", err)
 		}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -162,8 +162,8 @@ func (m *Manager) monitorHealth(ctx context.Context) {
 			}
 			m.sourcesStore.EnabledPlugins[plugin.name] = p
 
-			// botkube/kubernetes@1.0.0
-			sourceName := fmt.Sprintf("%s/%s@%s", plugin.repo, plugin.name, plugin.version)
+			// botkube/kubernetes
+			sourceName := fmt.Sprintf("%s/%s", plugin.repo, plugin.name)
 			m.schedulerChan <- sourceName
 		}
 	}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -90,8 +90,10 @@ func NewManager(logger logrus.FieldLogger, logCfg config.Logger, cfg config.Plug
 		sourcesStore:           &sourcesStore,
 		log:                    logger.WithField("component", "Plugin Manager"),
 		logConfig:              logCfg, // used when we create on-demand loggers for plugins
-		monitor: NewHealthMonitor(logger.WithField("component", "Plugin Health Monitor"),
+		monitor: NewHealthMonitor(
+			logger.WithField("component", "Plugin Health Monitor"),
 			logCfg,
+			cfg.RestartPolicy,
 			schedulerChan,
 			sourceSupervisorChan,
 			executorSupervisorChan,

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -33,6 +33,8 @@ const (
 
 	// DependencyDirEnvName define environment variable where plugin dependency binaries are stored.
 	DependencyDirEnvName = "PLUGIN_DEPENDENCY_DIR"
+
+	defaultHealthCheckInterval = 10 * time.Second
 )
 
 // pluginMap is the map of plugins we can dispense.
@@ -425,7 +427,11 @@ func createGRPCClient[C any](ctx context.Context, logger logrus.FieldLogger, log
 
 func startPluginHealthWatcher(ctx context.Context, logger logrus.FieldLogger, rpcClient plugin.ClientProtocol, pm pluginMetadata, supervisorChan chan pluginMetadata, healthCheckInterval time.Duration) {
 	logger.Infof("Starting plugin %q health watcher...", pm.name)
-	ticker := time.NewTicker(healthCheckInterval)
+	interval := healthCheckInterval
+	if interval.Seconds() < 1 {
+		interval = defaultHealthCheckInterval
+	}
+	ticker := time.NewTicker(interval)
 	go func() {
 		for {
 			select {

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -384,7 +384,7 @@ func createGRPCClients[C any](ctx context.Context, logger logrus.FieldLogger, lo
 }
 
 func createGRPCClient[C any](ctx context.Context, logger logrus.FieldLogger, logConfig config.Logger, pm pluginMetadata, pluginType Type, supervisorChan chan pluginMetadata, healthCheckInterval time.Duration) (enabledPlugins[C], error) {
-	pluginLogger, stdoutLogger, stderrLogger := NewPluginLoggers(logger, logConfig, pm.name, pluginType)
+	pluginLogger, stdoutLogger, stderrLogger := NewPluginLoggers(logger, logConfig, fmt.Sprintf("%s/%s", pm.repo, pm.name), pluginType)
 
 	cli := plugin.NewClient(&plugin.ClientConfig{
 		Plugins: pluginMap,

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -16,17 +16,17 @@ func TestCollectEnabledRepositories(t *testing.T) {
 	tests := []struct {
 		name string
 
-		enabledExecutors    []string
-		enabledSources      []string
+		enabledExecutors    []Plugin
+		enabledSources      []Plugin
 		definedRepositories map[string]config.PluginsRepositories
 
 		expErrMsg string
 	}{
 		{
 			name: "report not defined repositories for source plugins",
-			enabledSources: []string{
-				"botkube/cm-watcher",
-				"mszostok/hakuna-matata",
+			enabledSources: []Plugin{
+				{Name: "botkube/cm-watcher"},
+				{Name: "mszostok/hakuna-matata"},
 			},
 			expErrMsg: heredoc.Doc(`
 				2 errors occurred:
@@ -35,10 +35,10 @@ func TestCollectEnabledRepositories(t *testing.T) {
 		},
 		{
 			name: "report not defined repositories for executor plugins",
-			enabledExecutors: []string{
-				"botkube/helm",
-				"botkube/kubectl",
-				"mszostok/hakuna-matata",
+			enabledExecutors: []Plugin{
+				{Name: "botkube/helm"},
+				{Name: "botkube/kubectl"},
+				{Name: "mszostok/hakuna-matata"},
 			},
 			expErrMsg: heredoc.Doc(`
 				3 errors occurred:
@@ -48,14 +48,14 @@ func TestCollectEnabledRepositories(t *testing.T) {
 		},
 		{
 			name: "report not defined repositories for source and executor plugins",
-			enabledSources: []string{
-				"botkube/cm-watcher",
-				"mszostok/hakuna-matata",
+			enabledSources: []Plugin{
+				{Name: "botkube/cm-watcher"},
+				{Name: "mszostok/hakuna-matata"},
 			},
-			enabledExecutors: []string{
-				"botkube/helm",
-				"botkube/kubectl",
-				"mszostok/hakuna-matata",
+			enabledExecutors: []Plugin{
+				{Name: "botkube/helm"},
+				{Name: "botkube/kubectl"},
+				{Name: "mszostok/hakuna-matata"},
 			},
 			expErrMsg: heredoc.Doc(`
 				5 errors occurred:

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -71,7 +71,7 @@ func TestCollectEnabledRepositories(t *testing.T) {
 			// given
 			manager := NewManager(loggerx.NewNoop(), config.Logger{}, config.PluginManagement{
 				Repositories: tc.definedRepositories,
-			}, tc.enabledExecutors, tc.enabledSources)
+			}, tc.enabledExecutors, tc.enabledSources, make(chan string))
 
 			// when
 			out, err := manager.collectEnabledRepositories()

--- a/internal/plugin/store.go
+++ b/internal/plugin/store.go
@@ -33,7 +33,7 @@ type (
 	}
 
 	// storePlugins holds enabled plugins indexed by {repo}/{plugin_name} key.
-	storePlugins[T any] map[string]enabledPlugins[T]
+	storePlugins[T any] map[string]enabledPlugins[T] // TODO: sync.Map/sync.RWMutex
 
 	enabledPlugins[T any] struct {
 		Client  T

--- a/internal/plugin/store.go
+++ b/internal/plugin/store.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"fmt"
 	"sort"
+	"sync"
 
 	semver "github.com/hashicorp/go-version"
 	"gopkg.in/yaml.v3"
@@ -12,7 +13,7 @@ type (
 	// store holds information about processed and started plugins.
 	store[T any] struct {
 		Repository     storeRepository
-		EnabledPlugins storePlugins[T]
+		EnabledPlugins *storePlugins[T]
 	}
 
 	// storeRepository holds known plugins metadata indexed by {repo}/{plugin_name} key.
@@ -33,7 +34,10 @@ type (
 	}
 
 	// storePlugins holds enabled plugins indexed by {repo}/{plugin_name} key.
-	storePlugins[T any] map[string]enabledPlugins[T] // TODO: sync.Map/sync.RWMutex
+	storePlugins[T any] struct {
+		sync.RWMutex
+		data map[string]enabledPlugins[T]
+	}
 
 	enabledPlugins[T any] struct {
 		Client  T
@@ -43,9 +47,30 @@ type (
 
 func newStore[T any]() store[T] {
 	return store[T]{
-		Repository:     storeRepository{},
-		EnabledPlugins: map[string]enabledPlugins[T]{},
+		Repository: storeRepository{},
+		EnabledPlugins: &storePlugins[T]{
+			data: map[string]enabledPlugins[T]{},
+		},
 	}
+}
+
+func (p *storePlugins[T]) Insert(key string, plugin enabledPlugins[T]) {
+	p.Lock()
+	defer p.Unlock()
+	p.data[key] = plugin
+}
+
+func (p *storePlugins[T]) Get(key string) (enabledPlugins[T], bool) {
+	p.RLock()
+	defer p.RUnlock()
+	plugin, found := p.data[key]
+	return plugin, found
+}
+
+func (p *storePlugins[T]) Delete(key string) {
+	p.Lock()
+	defer p.Unlock()
+	delete(p.data, key)
 }
 
 func newStoreRepositories(indexes map[string][]byte) (storeRepository, storeRepository, error) {

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -102,8 +102,6 @@ func (d *Dispatcher) Dispatch(dispatch PluginDispatch) error {
 		return fmt.Errorf("while getting source client for %s: %w", dispatch.pluginName, err)
 	}
 
-	log.Infof("Source client address %p", &sourceClient)
-
 	kubeconfig, err := plugin.GenerateKubeConfig(d.restCfg, d.clusterName, dispatch.pluginContext, plugin.KubeConfigInput{})
 	if err != nil {
 		return fmt.Errorf("while generating kube config for %s: %w", dispatch.pluginName, err)

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -97,7 +97,6 @@ func (d *Dispatcher) Dispatch(dispatch PluginDispatch) error {
 	log.Info("Start source streaming...")
 
 	sourceClient, err := d.manager.GetSource(dispatch.pluginName)
-	// is permanently failed?
 	if err != nil {
 		return fmt.Errorf("while getting source client for %s: %w", dispatch.pluginName, err)
 	}

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -125,7 +125,7 @@ func (d *Dispatcher) Dispatch(dispatch PluginDispatch) error {
 			select {
 			case msg, ok := <-out.Event:
 				if !ok {
-					// d.manager.GetSource(dispatch.pluginName)
+					log.WithError(fmt.Errorf("stream for %s.%s source was closed", dispatch.sourceName, dispatch.pluginName)).Error("Stream closed")
 					return
 				}
 				log.WithField("message", msg).Debug("Dispatching received message...")

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -97,6 +97,7 @@ func (d *Dispatcher) Dispatch(dispatch PluginDispatch) error {
 	log.Info("Start source streaming...")
 
 	sourceClient, err := d.manager.GetSource(dispatch.pluginName)
+	// is permanently failed?
 	if err != nil {
 		return fmt.Errorf("while getting source client for %s: %w", dispatch.pluginName, err)
 	}
@@ -124,6 +125,7 @@ func (d *Dispatcher) Dispatch(dispatch PluginDispatch) error {
 			select {
 			case msg, ok := <-out.Event:
 				if !ok {
+					// d.manager.GetSource(dispatch.pluginName)
 					return
 				}
 				log.WithField("message", msg).Debug("Dispatching received message...")

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -102,6 +102,8 @@ func (d *Dispatcher) Dispatch(dispatch PluginDispatch) error {
 		return fmt.Errorf("while getting source client for %s: %w", dispatch.pluginName, err)
 	}
 
+	log.Infof("Source client address %p", &sourceClient)
+
 	kubeconfig, err := plugin.GenerateKubeConfig(d.restCfg, d.clusterName, dispatch.pluginContext, plugin.KubeConfigInput{})
 	if err != nil {
 		return fmt.Errorf("while generating kube config for %s: %w", dispatch.pluginName, err)

--- a/internal/source/scheduler.go
+++ b/internal/source/scheduler.go
@@ -115,10 +115,10 @@ func (d *Scheduler) Start(ctx context.Context) error {
 func (d *Scheduler) schedule(pluginFilter string) error {
 	for _, sourceConfig := range d.dispatchConfig {
 		for pluginName, config := range sourceConfig {
-			if ok := d.runningProcesses.exists(pluginName); ok {
-				d.log.Infof("Not starting %q as it was already started.", pluginName)
-				continue
-			}
+			// if ok := d.runningProcesses.exists(pluginName); ok {
+			// 	d.log.Infof("Not starting %q as it was already started.", pluginName)
+			// 	continue
+			// }
 			if pluginFilter != "" && pluginFilter != pluginName {
 				d.log.Debugf("Not starting %q as it doesn't pass plugin filter.", pluginName)
 				continue

--- a/internal/source/scheduler.go
+++ b/internal/source/scheduler.go
@@ -12,6 +12,10 @@ import (
 	"github.com/kubeshop/botkube/pkg/config"
 )
 
+const (
+	emptyPluginFilter = ""
+)
+
 type pluginDispatcher interface {
 	Dispatch(dispatch PluginDispatch) error
 }
@@ -88,7 +92,7 @@ func (d *Scheduler) monitorHealth(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case pluginName := <-d.schedulerChan:
-			d.log.Infof("Scheduling restarted plugin %q", pluginName)
+			d.log.Debugf("Scheduling restarted plugin %q", pluginName)
 			d.runningProcesses.delete(pluginName)
 			if err := d.schedule(pluginName); err != nil {
 				d.log.Errorf("while scheduling %q: %s", pluginName, err)
@@ -102,7 +106,7 @@ func (d *Scheduler) Start(ctx context.Context) error {
 	if err := d.generateConfigs(ctx); err != nil {
 		return err
 	}
-	if err := d.schedule(""); err != nil {
+	if err := d.schedule(emptyPluginFilter); err != nil {
 		return err
 	}
 	return nil
@@ -116,7 +120,7 @@ func (d *Scheduler) schedule(pluginFilter string) error {
 				continue
 			}
 			if pluginFilter != "" && pluginFilter != pluginName {
-				d.log.Infof("Not starting %q as it doesn't pass plugin filter.", pluginName)
+				d.log.Debugf("Not starting %q as it doesn't pass plugin filter.", pluginName)
 				continue
 			}
 

--- a/internal/source/scheduler.go
+++ b/internal/source/scheduler.go
@@ -115,20 +115,21 @@ func (d *Scheduler) Start(ctx context.Context) error {
 func (d *Scheduler) schedule(pluginFilter string) error {
 	for _, sourceConfig := range d.dispatchConfig {
 		for pluginName, config := range sourceConfig {
-			// if ok := d.runningProcesses.exists(pluginName); ok {
-			// 	d.log.Infof("Not starting %q as it was already started.", pluginName)
-			// 	continue
-			// }
-			if pluginFilter != "" && pluginFilter != pluginName {
-				d.log.Debugf("Not starting %q as it doesn't pass plugin filter.", pluginName)
+			key := fmt.Sprintf("%s/%s", config.sourceName, pluginName)
+			if ok := d.runningProcesses.exists(key); ok {
+				d.log.Infof("Not starting %q as it was already started.", key)
+				continue
+			}
+			if pluginFilter != "" && pluginFilter != key {
+				d.log.Debugf("Not starting %q as it doesn't pass plugin filter.", key)
 				continue
 			}
 
-			d.log.Infof("Starting a new stream for plugin %q", pluginName)
+			d.log.Infof("Starting a new stream for plugin %q", key)
 			if err := d.dispatcher.Dispatch(config); err != nil {
-				return fmt.Errorf("while starting plugin source %s: %w", pluginName, err)
+				return fmt.Errorf("while starting plugin source %s: %w", key, err)
 			}
-			d.runningProcesses.add(pluginName)
+			d.runningProcesses.add(key)
 		}
 	}
 	return nil

--- a/internal/source/scheduler_test.go
+++ b/internal/source/scheduler_test.go
@@ -54,7 +54,7 @@ func TestStartingUniqueProcesses(t *testing.T) {
 	}
 
 	// when
-	scheduler := NewScheduler(loggerx.NewNoop(), givenCfg, fakeDispatcherFunc(assertStarter))
+	scheduler := NewScheduler(context.Background(), loggerx.NewNoop(), givenCfg, fakeDispatcherFunc(assertStarter), make(chan string))
 
 	err = scheduler.Start(context.Background())
 	require.NoError(t, err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,9 +133,22 @@ type Config struct {
 
 // PluginManagement holds Botkube plugin management related configuration.
 type PluginManagement struct {
-	CacheDir     string                         `yaml:"cacheDir"`
-	Repositories map[string]PluginsRepositories `yaml:"repositories"`
+	CacheDir      string                         `yaml:"cacheDir"`
+	Repositories  map[string]PluginsRepositories `yaml:"repositories"`
+	RestartPolicy PluginRestartPolicy            `yaml:"agentRestartPolicy"`
 }
+
+type PluginRestartPolicy struct {
+	Type      PluginRestartPolicyType `yaml:"type"`
+	Threshold int                     `yaml:"threshold"`
+}
+
+type PluginRestartPolicyType string
+
+const (
+	KeepAgentRunningWhenThresholdReached PluginRestartPolicyType = "deactivatePlugin"
+	RestartAgentWhenThresholdReached     PluginRestartPolicyType = "restartAgent"
+)
 
 // PluginsRepositories holds the Plugin repository information.
 type PluginsRepositories struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,9 +133,10 @@ type Config struct {
 
 // PluginManagement holds Botkube plugin management related configuration.
 type PluginManagement struct {
-	CacheDir      string                         `yaml:"cacheDir"`
-	Repositories  map[string]PluginsRepositories `yaml:"repositories"`
-	RestartPolicy PluginRestartPolicy            `yaml:"agentRestartPolicy"`
+	CacheDir            string                         `yaml:"cacheDir"`
+	Repositories        map[string]PluginsRepositories `yaml:"repositories"`
+	RestartPolicy       PluginRestartPolicy            `yaml:"restartPolicy"`
+	HealthCheckInterval time.Duration                  `yaml:"healthCheckInterval"`
 }
 
 type PluginRestartPolicy struct {
@@ -146,8 +147,8 @@ type PluginRestartPolicy struct {
 type PluginRestartPolicyType string
 
 const (
-	KeepAgentRunningWhenThresholdReached PluginRestartPolicyType = "deactivatePlugin"
-	RestartAgentWhenThresholdReached     PluginRestartPolicyType = "restartAgent"
+	KeepAgentRunningWhenThresholdReached PluginRestartPolicyType = "DeactivatePlugin"
+	RestartAgentWhenThresholdReached     PluginRestartPolicyType = "RestartAgent"
 )
 
 // PluginsRepositories holds the Plugin repository information.

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -172,3 +172,6 @@ plugins:
     repositories:
         botkube:
             url: http://localhost:3000/botkube.yaml
+    agentRestartPolicy:
+        type: ""
+        threshold: 0

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -172,6 +172,7 @@ plugins:
     repositories:
         botkube:
             url: http://localhost:3000/botkube.yaml
-    agentRestartPolicy:
+    restartPolicy:
         type: ""
         threshold: 0
+    healthCheckInterval: 0s

--- a/pkg/execute/config_test.go
+++ b/pkg/execute/config_test.go
@@ -78,6 +78,9 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 						plugins:
 						    cacheDir: ""
 						    repositories: {}
+						    agentRestartPolicy:
+						        type: ""
+						        threshold: 0
 						`),
 		},
 	}

--- a/pkg/execute/config_test.go
+++ b/pkg/execute/config_test.go
@@ -78,9 +78,10 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 						plugins:
 						    cacheDir: ""
 						    repositories: {}
-						    agentRestartPolicy:
+						    restartPolicy:
 						        type: ""
 						        threshold: 0
+						    healthCheckInterval: 0s
 						`),
 		},
 	}

--- a/pkg/execute/help.go
+++ b/pkg/execute/help.go
@@ -28,7 +28,7 @@ func NewHelpExecutor(log logrus.FieldLogger, cfg config.Config) *HelpExecutor {
 
 	return &HelpExecutor{
 		log:                    log,
-		enabledPluginExecutors: enabledPluginExecutors,
+		enabledPluginExecutors: plugin.CollectPluginNames(enabledPluginExecutors),
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Use built-in hashicorp `Ping()` API call to monitor health of source plugins
- Release resources of crashed plugins
- Restart crashed plugins
- Define configurable strategies to approach restart policies 

## Testing

Add source cm-watcher and executor echo to your comm platform.

Add to your config:
```
plugins:
    agentRestartPolicy:
      # -- Restart policy type. Allowed values: "restartAgent", "deactivatePlugin".
      type: "deactivatePlugin"
      # -- Number of restarts before policy takes into effect.
      threshold: 5
```

Recompile plugins and start botkube locally

```
make build-plugins-single gen-plugins-index
go run cmd/botkube-agent/main.go
```

Watch botkube pod logs.

### Executor testing

`@Botkube echo @panic` will cause the echo plugin to panic and exit. Wait a few seconds and it will be restarted.
Check again with `@Botkube echo hello`.

### Source testing

Create cm with annotation `die: "true"`.

```
kubectl apply -f - <<EOF
apiVersion: v1
kind: ConfigMap
metadata:
  annotations:
    die: "true"
  name: watcher
  namespace: botkube
EOF
```

When this cm exists, cm-watcher plugin will continue to crash. Remove the cm. The plugin should restart.
Create the cm without the annotation - plugin should send message to specified channel.

<!-- Describe necessary steps to test the changes.
You can refer to the existing documentation if some steps are already described. -->

## Related issue(s)

https://github.com/kubeshop/botkube/issues/878
