### PR TITLE
Add GitHub action to enforce labels

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,17 @@
+name: Enforce PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+
+# Disable permissions for all the available scopes
+permissions: {}
+
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: yogevbd/enforce-label-action@2.1.0
+        with:
+          REQUIRED_LABELS_ANY: "bug,enhancement,breaking,documentation,other"
+          BANNED_LABELS: "hold,'do not merge'"


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

We generate changelog automatically by using pull-reqest's labels, without them everything goes into "others" section making this changelog harder to read.

Introduced actions should forbid merging PRs without labels in case if someone forgot to add some.

## Testing

Previous run when labels were removed: https://github.com/kubeshop/botkube/actions/runs/6023709284/job/16340963084?pr=1219


After merging I will add enforce label job as required.