### PR TITLE
Fix downloader for non archived plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ build-plugins: pre-build gen-plugins-goreleaser
 # Build Botkube official plugins only for current GOOS and GOARCH.
 build-plugins-single: pre-build gen-plugins-goreleaser
 	@echo "Building single target plugins binaries"
-	go run ./hack/target/build-plugins/main.go --single-platform
+	go run ./hack/target/build-plugins/main.go --single-platform --output-mode binary
 	@echo "Build completed successfully"
 
 # Build the image

--- a/hack/target/build-plugins/main.go
+++ b/hack/target/build-plugins/main.go
@@ -50,7 +50,7 @@ func buildPlugins(pluginTargets string, single bool) {
 	}
 
 	if single {
-		command += "--single-target"
+		command += " --single-target"
 	}
 
 	runCommand(command)

--- a/internal/plugin/downloader.go
+++ b/internal/plugin/downloader.go
@@ -54,7 +54,7 @@ func downloadBinary(ctx context.Context, destPath string, url URL, autoDetectFil
 	}
 
 	if stat, err := os.Stat(tmpDestPath); err == nil && stat.IsDir() {
-		if autoDetectFilename {
+		if autoDetectFilename && hasArchiveExtension(url.URL) {
 			filename, err = getFirstFileInDirectory(tmpDestPath)
 			if err != nil {
 				return fmt.Errorf("while getting binary name")

--- a/test/fake/plugin_server.go
+++ b/test/fake/plugin_server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -37,7 +38,8 @@ func NewPluginServer(cfg PluginConfig) (string, func() error) {
 	builder := plugin.NewIndexBuilder(loggerx.NewNoop())
 
 	http.HandleFunc(indexFileEndpoint, func(w http.ResponseWriter, _ *http.Request) {
-		idx, err := builder.Build(cfg.BinariesDirectory, basePath+"/static", ".*", true, true)
+		isArchive := os.Getenv("OUTPUT_MODE") == "archive"
+		idx, err := builder.Build(cfg.BinariesDirectory, basePath+"/static", ".*", true, isArchive)
 		if err != nil {
 			log.Printf("Cannot build index file: %s", err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix downloader for non archived plugins

## Testing


1. Build plugins: `PLUGIN_TARGETS="cm-watcher,echo" make build-plugins-single`
2. Run server: `env PLUGIN_SERVER_HOST=http://host.k3d.internal go run test/helpers/plugin_server.go`
3. Run Botkube with config similar to:
```yaml
communications:
  default-group:
    socketSlack:
      enabled: true
      channels:
        default:
          name: random
          bindings:
            sources:
              - cm-watcher
            executors:
              - echo
      appToken: "xapp-1-"
      botToken: "xoxb-"
sources:
  'cm-watcher':
    botkube/cm-watcher:
      enabled: true
      config:
        configMap:
          name: cm-watcher-trigger
          namespace: botkube
          event: ADDED

executors:
  echo:
    botkube/echo:
      enabled: true
      config:
        changeResponseToUpperCase: true

plugins:
  repositories:
    botkube:
      url: http://host.k3d.internal:3010/botkube.yaml

settings:
  log:
    level: "debug"
    formatter: text
  clusterName: "labs"
  upgradeNotifier: false

analytics:
  disable: true

```