### PR TITLE
Fix help flag error, remove color codes

### DIFF
--- a/internal/executor/flux/commands.go
+++ b/internal/executor/flux/commands.go
@@ -47,9 +47,9 @@ func ExecuteCommand(ctx context.Context, in string, opts ...pluginx.ExecuteComma
 	return out.CombinedOutput(), nil
 }
 
-// isConfirmDelete uses string contains in order to detect if a user was asked to confirm deletion.
+// isDeleteConfirmationErr uses string contains in order to detect if a user was asked to confirm deletion.
 // For now, there is no better way as we use terminal output not Go SDK.
-func isConfirmDelete(err error) bool {
+func isDeleteConfirmationErr(err error) bool {
 	if err == nil {
 		return false
 	}

--- a/internal/executor/flux/commands.go
+++ b/internal/executor/flux/commands.go
@@ -2,14 +2,18 @@ package flux
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/gookit/color"
 
 	"github.com/kubeshop/botkube/pkg/formatx"
 	"github.com/kubeshop/botkube/pkg/pluginx"
 )
+
+// deleteConfirmPhase represent a confirmation phase for deletion. Taken from flux: v2.0.1.
+const deleteConfirmPhase = "Are you sure you want to delete"
+
+var deleteConfirmErr = errors.New("To delete the resource, please explicitly include the -s or --silent flag in your command")
 
 // escapePositionals add '--' after known keyword. Example:
 //
@@ -35,9 +39,19 @@ func normalize(in string) string {
 
 // ExecuteCommand is a syntax sugar for running CLI commands.
 func ExecuteCommand(ctx context.Context, in string, opts ...pluginx.ExecuteCommandMutation) (string, error) {
+	opts = append(opts, pluginx.ExecuteClearColorCodes())
 	out, err := pluginx.ExecuteCommand(ctx, in, opts...)
 	if err != nil {
 		return "", err
 	}
-	return color.ClearCode(out.CombinedOutput()), nil
+	return out.CombinedOutput(), nil
+}
+
+// isConfirmDelete uses string contains in order to detect if a user was asked to confirm deletion.
+// For now, there is no better way as we use terminal output not Go SDK.
+func isConfirmDelete(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), deleteConfirmPhase)
 }

--- a/internal/executor/flux/executor.go
+++ b/internal/executor/flux/executor.go
@@ -141,6 +141,10 @@ func (d *Executor) Execute(ctx context.Context, in executor.ExecuteInput) (execu
 			"KUBECONFIG": kubeConfigPath,
 		}))
 		if err != nil {
+			if isConfirmDelete(err) {
+				return "", deleteConfirmErr
+			}
+
 			log.WithError(err).WithField("command", command.ToExecute).Error("failed to run command")
 			return "", fmt.Errorf("while running command: %v", err)
 		}

--- a/internal/executor/flux/executor.go
+++ b/internal/executor/flux/executor.go
@@ -141,7 +141,7 @@ func (d *Executor) Execute(ctx context.Context, in executor.ExecuteInput) (execu
 			"KUBECONFIG": kubeConfigPath,
 		}))
 		if err != nil {
-			if isConfirmDelete(err) {
+			if isDeleteConfirmationErr(err) {
 				return "", deleteConfirmErr
 			}
 

--- a/internal/executor/flux/forbidden.go
+++ b/internal/executor/flux/forbidden.go
@@ -32,6 +32,8 @@ func detectNotSupportedGlobalFlags(normalizedCmd string) error {
 	issues := multierror.New()
 
 	f := pflag.NewFlagSet("detect-not-supported-flags", pflag.ContinueOnError)
+	f.BoolP("help", "h", false, "to make sure that parsing is ignoring the --help,-h flags")
+
 	f.ParseErrorsWhitelist.UnknownFlags = true
 
 	for key := range notSupportedGlobalFlags {
@@ -50,7 +52,7 @@ func detectNotSupportedGlobalFlags(normalizedCmd string) error {
 
 	// visit ONLY flags which have been defined by f.String and explicitly set in the command:
 	f.Visit(func(f *pflag.Flag) {
-		if f == nil {
+		if f == nil || f.Name == "help" {
 			return
 		}
 		issues = multierror.Append(issues, fmt.Errorf("The %q flag is not supported by the Botkube flux plugin. Please remove it.", f.Name))

--- a/pkg/pluginx/command.go
+++ b/pkg/pluginx/command.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/alexflint/go-arg"
+	"github.com/gookit/color"
 	"github.com/mattn/go-shellwords"
 
 	"github.com/kubeshop/botkube/internal/plugin"
@@ -126,11 +127,16 @@ func ExecuteCommand(ctx context.Context, rawCmd string, mutators ...ExecuteComma
 		Stderr:   stderr.String(),
 		ExitCode: cmd.ProcessState.ExitCode(),
 	}
+	if opts.ClearColorCodes {
+		out.Stdout = color.ClearCode(out.Stdout)
+		out.Stderr = color.ClearCode(out.Stderr)
+	}
+
 	if err != nil {
-		return out, runErr(stdout.String(), stderr.String(), err)
+		return out, runErr(out.Stdout, out.Stderr, err)
 	}
 	if out.ExitCode != 0 {
-		return out, fmt.Errorf("got non-zero exit code, stdout [%q], stderr [%q]", stdout.String(), stderr.String())
+		return out, fmt.Errorf("got non-zero exit code, stdout [%q], stderr [%q]", out.Stdout, out.Stderr)
 	}
 	return out, nil
 }

--- a/pkg/pluginx/command_opts.go
+++ b/pkg/pluginx/command_opts.go
@@ -4,10 +4,11 @@ import "io"
 
 // ExecuteCommandOptions represents the options for executing a command.
 type ExecuteCommandOptions struct {
-	Envs          map[string]string
-	DependencyDir string
-	WorkDir       string
-	Stdin         io.Reader
+	Envs            map[string]string
+	DependencyDir   string
+	WorkDir         string
+	Stdin           io.Reader
+	ClearColorCodes bool
 }
 
 // ExecuteCommandMutation is a function type that can be used to modify ExecuteCommandOptions.
@@ -38,5 +39,12 @@ func ExecuteCommandWorkingDir(dir string) ExecuteCommandMutation {
 func ExecuteCommandStdin(in io.Reader) ExecuteCommandMutation {
 	return func(options *ExecuteCommandOptions) {
 		options.Stdin = in
+	}
+}
+
+// ExecuteClearColorCodes is a function that enables removing color codes.
+func ExecuteClearColorCodes() ExecuteCommandMutation {
+	return func(options *ExecuteCommandOptions) {
+		options.ClearColorCodes = true
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix help flag error, remove color codes

## Testing

1. `env PLUGIN_SERVER_HOST=http://host.k3d.internal go run test/helpers/plugin_server.go`
2. `PLUGIN_TARGETS="flux" make build-plugins-single`
3. Botkube config:
    ```yaml
    communications:
      default-group:
        socketSlack:
          enabled: true
          channels:
            default:
              name: hakuna-matata
              bindings:
                sources: []
                executors:
                  - flux
          appToken: "xapp-1-"
          botToken: "xoxb-"
    
    
    executors:
      flux:
        botkube/flux:
          enabled: true
          config:
            log:
              level: "debug"
    
          context:
            rbac:
              group:
                type: Static
                static:
                  values: [ "system:masters" ]
    
    plugins:
      cacheDir: "/tmp/plugins"
    
      repositories:
        botkube:
          url: http://host.k3d.internal:3010/botkube.yaml
    
    settings:
      log:
        level: "debug"
        formatter: "text"
      clusterName: "labs"
      upgradeNotifier: false
    
    analytics:
      disable: true
    
    configWatcher:
      enabled: false
    ```
4. Commands to run:
    ```
    @Botkube flux delete source git --help
    ```
    ```
    @Botkube flux create source git webapp-latest
       --url=https://github.com/stefanprodan/podinfo 
       --branch=master 
       --interval=3m
    ```
    ```
    @Botkube flux delete source git webapp-latest
    ```
    ```
    @Botkube flux delete source git webapp-latest -s
    ```

![Screenshot 2023-09-07 at 10 13 15](https://github.com/kubeshop/botkube/assets/17568639/24e20649-dd74-4d3b-9bb4-74a888341ef5)


## Related issue(s)

Fix #1229 