### PR TITLE
Restart crashed plugins

### DIFF
--- a/cmd/botkube-agent/main.go
+++ b/cmd/botkube-agent/main.go
@@ -151,9 +151,10 @@ func run(ctx context.Context) (err error) {
 		err = reportFatalError("while waiting for goroutines to finish gracefully", multiErr.ErrorOrNil())
 	}()
 
+	schedulerChan := make(chan string)
 	collector := plugin.NewCollector(logger)
 	enabledPluginExecutors, enabledPluginSources := collector.GetAllEnabledAndUsedPlugins(conf)
-	pluginManager := plugin.NewManager(logger, conf.Settings.Log, conf.Plugins, enabledPluginExecutors, enabledPluginSources)
+	pluginManager := plugin.NewManager(logger, conf.Settings.Log, conf.Plugins, enabledPluginExecutors, enabledPluginSources, schedulerChan)
 
 	err = pluginManager.Start(ctx)
 	if err != nil {
@@ -391,7 +392,7 @@ func run(ctx context.Context) (err error) {
 	actionProvider := action.NewProvider(logger.WithField(componentLogFieldKey, "Action Provider"), conf.Actions, executorFactory)
 
 	sourcePluginDispatcher := source.NewDispatcher(logger, conf.Settings.ClusterName, bots, sinkNotifiers, pluginManager, actionProvider, reporter, auditReporter, kubeConfig)
-	scheduler := source.NewScheduler(logger, conf, sourcePluginDispatcher)
+	scheduler := source.NewScheduler(ctx, logger, conf, sourcePluginDispatcher, schedulerChan)
 	err = scheduler.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("while starting source plugin event dispatcher: %w", err)

--- a/cmd/executor/echo/main.go
+++ b/cmd/executor/echo/main.go
@@ -54,6 +54,10 @@ func (*EchoExecutor) Execute(_ context.Context, in executor.ExecuteInput) (execu
 		return executor.ExecuteOutput{}, errors.New("The @fail label was specified. Failing execution.")
 	}
 
+	if strings.Contains(data, "@panic") {
+		panic("The @panic label was specified. Panicking.")
+	}
+
 	if cfg.ChangeResponseToUpperCase != nil && *cfg.ChangeResponseToUpperCase {
 		data = strings.ToUpper(data)
 	}

--- a/cmd/source/cm-watcher/main.go
+++ b/cmd/source/cm-watcher/main.go
@@ -131,6 +131,11 @@ func listenEvents(ctx context.Context, kubeConfig []byte, obj Object, sink chan 
 	infiniteWatch := func(event watch.Event) (bool, error) {
 		if event.Type == obj.Event {
 			cm := event.Object.(*corev1.ConfigMap)
+
+			if cm.Annotations["die"] == "true" {
+				exitOnError(fmt.Errorf("die annotation set to true"))
+			}
+
 			msg := fmt.Sprintf("Plugin %s detected `%s` event on `%s/%s`", pluginName, obj.Event, cm.Namespace, cm.Name)
 			sink <- source.Event{
 				Message: api.NewPlaintextMessage(msg, true),

--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -52,50 +52,50 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [actions.show-logs-on-error.bindings.executors](./values.yaml#L128) | list | `["k8s-default-tools"]` | Executors configuration used to execute a configured command. |
 | [sources](./values.yaml#L137) | object | See the `values.yaml` file for full object. | Map of sources. Source contains configuration for Kubernetes events and sending recommendations. The property name under `sources` object is an alias for a given configuration. You can define multiple sources configuration with different names. Key name is used as a binding reference.   |
 | [sources.k8s-recommendation-events.botkube/kubernetes](./values.yaml#L142) | object | See the `values.yaml` file for full object. | Describes Kubernetes source configuration. |
-| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-create-events.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [executors.ai.botkube/doctor.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [executors.k8s-default-tools.botkube/kubectl.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [sources.k8s-create-events.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [executors.bins-management.botkube/exec.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [executors.ai.botkube/doctor.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [executors.k8s-default-tools.botkube/helm.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [executors.flux.botkube/flux.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
-| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac](./values.yaml#L145) | object | `{"group":{"prefix":"","static":{"values":["botkube-plugins-default"]},"type":"Static"}}` | RBAC configuration for this plugin. |
 | [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [executors.bins-management.botkube/exec.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [executors.ai.botkube/doctor.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [executors.flux.botkube/flux.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [executors.bins-management.botkube/exec.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [executors.ai.botkube/doctor.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
 | [executors.k8s-default-tools.botkube/helm.context.rbac.group.type](./values.yaml#L148) | string | `"Static"` | Static impersonation for a given username and groups. |
-| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [executors.k8s-default-tools.botkube/helm.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [executors.ai.botkube/doctor.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [executors.flux.botkube/flux.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [executors.k8s-default-tools.botkube/helm.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.bins-management.botkube/exec.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
-| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [executors.k8s-default-tools.botkube/helm.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [executors.flux.botkube/flux.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
+| [executors.ai.botkube/doctor.context.rbac.group.prefix](./values.yaml#L150) | string | `""` | Prefix that will be applied to .static.value[*]. |
 | [executors.ai.botkube/doctor.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [executors.bins-management.botkube/exec.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
-| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-all-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-err-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [executors.flux.botkube/flux.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [executors.k8s-default-tools.botkube/kubectl.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-recommendation-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-create-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [executors.k8s-default-tools.botkube/helm.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
+| [sources.k8s-err-with-logs-events.botkube/kubernetes.context.rbac.group.static.values](./values.yaml#L153) | list | `["botkube-plugins-default"]` | Name of group.rbac.authorization.k8s.io the plugin will be bound to. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations](./values.yaml#L167) | object | `{"ingress":{"backendServiceValid":true,"tlsSecretValid":true},"pod":{"labelsSet":true,"noLatestImageTag":true}}` | Describes configuration for various recommendation insights. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations.pod](./values.yaml#L169) | object | `{"labelsSet":true,"noLatestImageTag":true}` | Recommendations for Pod Kubernetes resource. |
 | [sources.k8s-recommendation-events.botkube/kubernetes.config.recommendations.pod.noLatestImageTag](./values.yaml#L171) | bool | `true` | If true, notifies about Pod containers that use `latest` tag for images. |
@@ -108,11 +108,11 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [sources.k8s-all-events.botkube/kubernetes.config.filters.objectAnnotationChecker](./values.yaml#L193) | bool | `true` | If true, enables support for `botkube.io/disable` resource annotation. |
 | [sources.k8s-all-events.botkube/kubernetes.config.filters.nodeEventsChecker](./values.yaml#L195) | bool | `true` | If true, filters out Node-related events that are not important. |
 | [sources.k8s-all-events.botkube/kubernetes.config.namespaces](./values.yaml#L199) | object | `{"include":[".*"]}` | Describes namespaces for every Kubernetes resources you want to watch or exclude. These namespaces are applied to every resource specified in the resources list. However, every specified resource can override this by using its own namespaces object. |
-| [sources.k8s-all-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L203) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-err-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L203) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-err-with-logs-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L203) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
-| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.config.namespaces.include](./values.yaml#L203) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-create-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L203) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [sources.k8s-all-events.botkube/kubernetes.config.namespaces.include](./values.yaml#L203) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
+| [sources.k8s-err-events-with-ai-support.botkube/kubernetes.config.namespaces.include](./values.yaml#L203) | list | `[".*"]` | Include contains a list of allowed Namespaces. It can also contain regex expressions:  `- ".*"` - to specify all Namespaces. |
 | [sources.k8s-all-events.botkube/kubernetes.config.event](./values.yaml#L213) | object | `{"message":{"exclude":[],"include":[]},"reason":{"exclude":[],"include":[]},"types":["create","delete","error"]}` | Describes event constraints for Kubernetes resources. These constraints are applied for every resource specified in the `resources` list, unless they are overridden by the resource's own `events` object. |
 | [sources.k8s-all-events.botkube/kubernetes.config.event.types](./values.yaml#L215) | list | `["create","delete","error"]` | Lists all event types to be watched. |
 | [sources.k8s-all-events.botkube/kubernetes.config.event.reason](./values.yaml#L221) | object | `{"exclude":[],"include":[]}` | Optional list of exact values or regex patterns to filter events by event reason. Skipped, if both include/exclude lists are empty. |
@@ -273,16 +273,18 @@ Controller for the Botkube Slack app which helps you monitor your Kubernetes clu
 | [configWatcher.image.repository](./values.yaml#L1170) | string | `"kubeshop/k8s-sidecar"` | Config watcher image repository. |
 | [configWatcher.image.tag](./values.yaml#L1172) | string | `"in-cluster-config"` | Config watcher image tag. |
 | [configWatcher.image.pullPolicy](./values.yaml#L1174) | string | `"IfNotPresent"` | Config watcher image pull policy. |
-| [plugins](./values.yaml#L1177) | object | `{"cacheDir":"/tmp","incomingWebhook":{"enabled":true,"port":2115,"targetPort":2115},"repositories":{"botkube":{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}}}` | Configuration for Botkube executors and sources plugins. |
+| [plugins](./values.yaml#L1177) | object | `{"cacheDir":"/tmp","healthCheckInterval":"10s","incomingWebhook":{"enabled":true,"port":2115,"targetPort":2115},"repositories":{"botkube":{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}},"restartPolicy":{"threshold":10,"type":"DeactivatePlugin"}}` | Configuration for Botkube executors and sources plugins. |
 | [plugins.cacheDir](./values.yaml#L1179) | string | `"/tmp"` | Directory, where downloaded plugins are cached. |
 | [plugins.repositories](./values.yaml#L1181) | object | `{"botkube":{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}}` | List of plugins repositories. |
 | [plugins.repositories.botkube](./values.yaml#L1183) | object | `{"url":"https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml"}` | This repository serves officially supported Botkube plugins. |
 | [plugins.incomingWebhook](./values.yaml#L1186) | object | `{"enabled":true,"port":2115,"targetPort":2115}` | Configure Incoming webhook for source plugins. |
-| [config](./values.yaml#L1192) | object | `{"provider":{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}}` | Configuration for synchronizing Botkube configuration. |
-| [config.provider](./values.yaml#L1194) | object | `{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}` | Base provider definition. |
-| [config.provider.identifier](./values.yaml#L1197) | string | `""` | Unique identifier for remote Botkube settings. If set to an empty string, Botkube won't fetch remote configuration. |
-| [config.provider.endpoint](./values.yaml#L1199) | string | `"https://api.botkube.io/graphql"` | Endpoint to fetch Botkube settings from. |
-| [config.provider.apiKey](./values.yaml#L1201) | string | `""` | Key passed as a `X-API-Key` header to the provider's endpoint. |
+| [plugins.restartPolicy.type](./values.yaml#L1193) | string | `"DeactivatePlugin"` | Restart policy type. Allowed values: "RestartAgent", "DeactivatePlugin". |
+| [plugins.restartPolicy.threshold](./values.yaml#L1195) | int | `10` | Number of restarts before policy takes into effect. |
+| [config](./values.yaml#L1199) | object | `{"provider":{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}}` | Configuration for synchronizing Botkube configuration. |
+| [config.provider](./values.yaml#L1201) | object | `{"apiKey":"","endpoint":"https://api.botkube.io/graphql","identifier":""}` | Base provider definition. |
+| [config.provider.identifier](./values.yaml#L1204) | string | `""` | Unique identifier for remote Botkube settings. If set to an empty string, Botkube won't fetch remote configuration. |
+| [config.provider.endpoint](./values.yaml#L1206) | string | `"https://api.botkube.io/graphql"` | Endpoint to fetch Botkube settings from. |
+| [config.provider.apiKey](./values.yaml#L1208) | string | `""` | Key passed as a `X-API-Key` header to the provider's endpoint. |
 
 ### AWS IRSA on EKS support
 

--- a/helm/botkube/e2e-test-values.yaml
+++ b/helm/botkube/e2e-test-values.yaml
@@ -322,6 +322,10 @@ plugins:
   repositories:
     botkube:
       url: http://host.k3d.internal:3000/botkube.yaml
+  restartPolicy:
+    type: "DeactivatePlugin"
+    threshold: 5
+  healthCheckInterval: 10s
 
 actions:
   'get-created-resource':

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -1187,6 +1187,13 @@ plugins:
     enabled: true
     port: 2115
     targetPort: 2115
+    # -- Botkube Restart Policy on plugin failure.
+  restartPolicy:
+    # -- Restart policy type. Allowed values: "RestartAgent", "DeactivatePlugin".
+    type: "DeactivatePlugin"
+    # -- Number of restarts before policy takes into effect.
+    threshold: 10
+  healthCheckInterval: 10s
 
 # -- Configuration for synchronizing Botkube configuration.
 config:

--- a/internal/plugin/health_monitor.go
+++ b/internal/plugin/health_monitor.go
@@ -1,0 +1,129 @@
+package plugin
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/kubeshop/botkube/pkg/api/executor"
+	"github.com/kubeshop/botkube/pkg/api/source"
+	"github.com/kubeshop/botkube/pkg/config"
+)
+
+// HealthMonitor restarts a failed plugin process and inform scheduler to start dispatching loop again with a new client that was generated.
+type HealthMonitor struct {
+	log                    logrus.FieldLogger
+	logConfig              config.Logger
+	sourceSupervisorChan   chan pluginMetadata
+	executorSupervisorChan chan pluginMetadata
+	schedulerChan          chan string
+	executorsStore         *store[executor.Executor]
+	sourcesStore           *store[source.Source]
+	policy                 config.PluginRestartPolicy
+	pluginRestartStats     map[string]int
+	healthCheckInterval    time.Duration
+}
+
+// NewHealthMonitor returns a new HealthMonitor instance.
+func NewHealthMonitor(logger logrus.FieldLogger, logCfg config.Logger, policy config.PluginRestartPolicy, schedulerChan chan string, sourceSupervisorChan, executorSupervisorChan chan pluginMetadata, executorsStore *store[executor.Executor], sourcesStore *store[source.Source], healthCheckInterval time.Duration) *HealthMonitor {
+	return &HealthMonitor{
+		log:                    logger,
+		logConfig:              logCfg,
+		policy:                 policy,
+		schedulerChan:          schedulerChan,
+		sourceSupervisorChan:   sourceSupervisorChan,
+		executorSupervisorChan: executorSupervisorChan,
+		executorsStore:         executorsStore,
+		sourcesStore:           sourcesStore,
+		pluginRestartStats:     make(map[string]int),
+		healthCheckInterval:    healthCheckInterval,
+	}
+}
+
+// Start starts monitor processes for sources and executors.
+func (m *HealthMonitor) Start(ctx context.Context) {
+	go m.monitorSourcePluginHealth(ctx)
+	go m.monitorExecutorPluginHealth(ctx)
+}
+
+func (m *HealthMonitor) monitorSourcePluginHealth(ctx context.Context) {
+	m.log.Info("Starting source plugin supervisor...")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case plugin := <-m.sourceSupervisorChan:
+			m.log.Infof("Restarting source plugin %q, attempt %d/%d...", plugin.pluginKey, m.pluginRestartStats[plugin.pluginKey]+1, m.policy.Threshold)
+			if source, ok := m.sourcesStore.EnabledPlugins.Get(plugin.pluginKey); ok && source.Cleanup != nil {
+				m.log.Debugf("Releasing resources of source plugin %q...", plugin.pluginKey)
+				source.Cleanup()
+			}
+
+			m.sourcesStore.EnabledPlugins.Delete(plugin.pluginKey)
+
+			if ok := m.shouldRestartPlugin(plugin.pluginKey); !ok {
+				m.log.Warnf("Plugin %q has been restarted too many times. Deactivating...", plugin.pluginKey)
+				continue
+			}
+
+			p, err := createGRPCClient[source.Source](ctx, m.log, m.logConfig, plugin, TypeSource, m.sourceSupervisorChan, m.healthCheckInterval)
+			if err != nil {
+				m.log.WithError(err).Errorf("Failed to restart plugin %q.", plugin.pluginKey)
+				continue
+			}
+
+			m.sourcesStore.EnabledPlugins.Insert(plugin.pluginKey, p)
+			m.schedulerChan <- plugin.pluginKey
+		}
+	}
+}
+
+func (m *HealthMonitor) monitorExecutorPluginHealth(ctx context.Context) {
+	m.log.Info("Starting executor plugin supervisor...")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case plugin := <-m.executorSupervisorChan:
+			m.log.Infof("Restarting executor plugin %q, attempt %d/%d...", plugin.pluginKey, m.pluginRestartStats[plugin.pluginKey]+1, m.policy.Threshold)
+
+			if executor, ok := m.executorsStore.EnabledPlugins.Get(plugin.pluginKey); ok && executor.Cleanup != nil {
+				m.log.Infof("Releasing executors of executor plugin %q...", plugin.pluginKey)
+				executor.Cleanup()
+			}
+
+			m.executorsStore.EnabledPlugins.Delete(plugin.pluginKey)
+			if ok := m.shouldRestartPlugin(plugin.pluginKey); !ok {
+				m.log.Warnf("Plugin %q has been restarted too many times. Deactivating...", plugin.pluginKey)
+				continue
+			}
+
+			p, err := createGRPCClient[executor.Executor](ctx, m.log, m.logConfig, plugin, TypeExecutor, m.executorSupervisorChan, m.healthCheckInterval)
+			if err != nil {
+				m.log.WithError(err).Errorf("Failed to restart plugin %q.", plugin.pluginKey)
+				continue
+			}
+
+			m.executorsStore.EnabledPlugins.Insert(plugin.pluginKey, p)
+		}
+	}
+}
+
+func (m *HealthMonitor) shouldRestartPlugin(plugin string) bool {
+	restarts := m.pluginRestartStats[plugin]
+	m.pluginRestartStats[plugin]++
+
+	switch m.policy.Type.ToLower() {
+	case config.KeepAgentRunningWhenThresholdReached.ToLower():
+		return restarts < m.policy.Threshold
+	case config.RestartAgentWhenThresholdReached.ToLower():
+		if restarts >= m.policy.Threshold {
+			m.log.Fatalf("Plugin %q has been restarted %d times and selected restartPolicy is %q. Exiting...", plugin, restarts, m.policy.Type)
+		}
+		return true
+	default:
+		m.log.Errorf("Unknown restart policy %q.", m.policy.Type)
+		return false
+	}
+}

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -71,7 +71,7 @@ func TestCollectEnabledRepositories(t *testing.T) {
 			// given
 			manager := NewManager(loggerx.NewNoop(), config.Logger{}, config.PluginManagement{
 				Repositories: tc.definedRepositories,
-			}, tc.enabledExecutors, tc.enabledSources)
+			}, tc.enabledExecutors, tc.enabledSources, make(chan string))
 
 			// when
 			out, err := manager.collectEnabledRepositories()

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -130,6 +130,7 @@ func (d *Dispatcher) Dispatch(dispatch PluginDispatch) error {
 			select {
 			case msg, ok := <-out.Event:
 				if !ok {
+					log.WithError(fmt.Errorf("stream for %s.%s source was closed", dispatch.sourceName, dispatch.pluginName)).Error("Stream closed")
 					return
 				}
 				log.WithField("message", msg).Debug("Dispatching received message...")

--- a/internal/source/testdata/TestStartingUniqueProcesses/config.yaml
+++ b/internal/source/testdata/TestStartingUniqueProcesses/config.yaml
@@ -12,6 +12,39 @@ sources:
 
 communications:
   default-group:
+    discord:
+      enabled: true
+      channels:
+        all: # proces1 - should use the same process as #random channel as sources order is the same
+          id: all
+          bindings:
+            sources:
+              - 'keptn-us-east-2'
+              - 'keptn-eu-central-1'
+        random: # proces1 -should use the same process as #all channel as sources order is the same
+          id: random
+          bindings:
+            sources: # get events from 2 regions
+              - 'keptn-us-east-2'
+              - 'keptn-eu-central-1'
+        general: # proces2 - should use different process than #all and #random channels as sources order is different
+          id: general
+          bindings:
+            sources: # get events from 2 regions
+              - 'keptn-eu-central-1'
+              - 'keptn-us-east-2'
+
+        eu: # proces3 - should use different process as it has only once source
+          id: eu
+          bindings:
+            sources: # get even only from eu
+              - 'keptn-eu-central-1'
+        us: # proces4 - should use different process as it has only once source
+          id: us
+          bindings:
+            sources: # get even only from us
+              - 'keptn-us-east-2'
+
     socketSlack:
       enabled: true
       appToken: "xapp-testing"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,9 +133,27 @@ type Config struct {
 
 // PluginManagement holds Botkube plugin management related configuration.
 type PluginManagement struct {
-	CacheDir        string                         `yaml:"cacheDir"`
-	Repositories    map[string]PluginsRepositories `yaml:"repositories"`
-	IncomingWebhook IncomingWebhook                `yaml:"incomingWebhook"`
+	CacheDir            string                         `yaml:"cacheDir"`
+	Repositories        map[string]PluginsRepositories `yaml:"repositories"`
+	IncomingWebhook     IncomingWebhook                `yaml:"incomingWebhook"`
+	RestartPolicy       PluginRestartPolicy            `yaml:"restartPolicy"`
+	HealthCheckInterval time.Duration                  `yaml:"healthCheckInterval"`
+}
+
+type PluginRestartPolicy struct {
+	Type      PluginRestartPolicyType `yaml:"type"`
+	Threshold int                     `yaml:"threshold"`
+}
+
+type PluginRestartPolicyType string
+
+const (
+	KeepAgentRunningWhenThresholdReached PluginRestartPolicyType = "DeactivatePlugin"
+	RestartAgentWhenThresholdReached     PluginRestartPolicyType = "RestartAgent"
+)
+
+func (p PluginRestartPolicyType) ToLower() string {
+	return strings.ToLower(string(p))
 }
 
 // PluginsRepositories holds the Plugin repository information.

--- a/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
+++ b/pkg/config/testdata/TestLoadConfigSuccess/config.golden.yaml
@@ -176,3 +176,7 @@ plugins:
         enabled: false
         port: 0
         inClusterBaseURL: ""
+    restartPolicy:
+        type: ""
+        threshold: 0
+    healthCheckInterval: 0s

--- a/pkg/execute/config_test.go
+++ b/pkg/execute/config_test.go
@@ -82,6 +82,10 @@ func TestConfigExecutorShowConfig(t *testing.T) {
 						        enabled: false
 						        port: 0
 						        inClusterBaseURL: ""
+						    restartPolicy:
+						        type: ""
+						        threshold: 0
+						    healthCheckInterval: 0s
 						`),
 		},
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Restart crashed plugins based on  https://github.com/kubeshop/botkube/pull/1204
  - [x] change the `runningProcesses` to support plugin name in the context of a given configuration
  - [x] fix logging statements to make them more readable
  - [x] apply suggestions from https://github.com/kubeshop/botkube/pull/1204
  - [ ] add e2e tests
  - [x] IMPORTANT: fixed key names used for string enabled plugins in map.
  - [x] `INFO[2023-09-07T17:05:44+02:00] Starting server on %q...:2115                 component="Incoming Webhook Server`

- still todo:
  - add option to print plugin status or add it to list executors/sources as a new column
  - add e2e tests cases
  - update documentation


## Testing

- [ ] add e2e tests


Co-authored-by: Josef Karasek <josef@kubeshop.io>