### PR TITLE
Fix ArgoCD template name normalization

### DIFF
--- a/internal/source/argocd/argocd.go
+++ b/internal/source/argocd/argocd.go
@@ -99,12 +99,12 @@ func (s *Source) Stream(ctx context.Context, input source.StreamInput) (source.S
 		return source.StreamOutput{}, fmt.Errorf("while configuring Argo notifications: %w", err)
 	}
 
-	s.log.Info("Set up successful for source configuration %q", input.Context.SourceName)
+	s.log.Infof("Setup successful for source configuration %q", input.Context.SourceName)
 	return source.StreamOutput{}, nil
 }
 
 // HandleExternalRequest handles external requests from ArgoCD.
-func (s *Source) HandleExternalRequest(ctx context.Context, input source.ExternalRequestInput) (source.ExternalRequestOutput, error) {
+func (s *Source) HandleExternalRequest(_ context.Context, input source.ExternalRequestInput) (source.ExternalRequestOutput, error) {
 	payload := formatx.StructDumper().Sdump(string(input.Payload))
 	s.log.WithField("payload", payload).Debug("Handling external request...")
 	fallbackTimestamp := time.Now()

--- a/internal/source/argocd/default-config.yaml
+++ b/internal/source/argocd/default-config.yaml
@@ -10,6 +10,15 @@ interactivity:
     - "get"
     - "describe"
 
+# -- ArgoCD-related configuration.
+argoCD:
+  # -- ArgoCD UI base URL. It is used for generating links in the incoming events.
+  uiBaseUrl: http://localhost:8080
+  # -- ArgoCD Notifications ConfigMap reference.
+  notificationsConfigMap:
+    name: argocd-notifications-cm
+    namespace: argocd
+
 # -- Webhook configuration.
 webhook:
   # -- If true, it registers Botkube webhook in ArgoCD notification config.

--- a/internal/source/argocd/render.go
+++ b/internal/source/argocd/render.go
@@ -2,9 +2,13 @@ package argocd
 
 import (
 	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	gotemplate "text/template"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/kubeshop/botkube/pkg/api/source"
 )
@@ -12,6 +16,36 @@ import (
 const (
 	goTplOpeningTag = "{{"
 )
+
+// renderTemplateName renders template name.
+// In fact, ConfigMap keys can contain slashes, so we don't need to do it for templates
+// but hey, let's keep the same normalization rules across the plugin codebase.
+func (s *Source) renderTemplateName(tpl string, srcCtx source.CommonSourceContext) (string, error) {
+	s.log.Debugf("Rendering template name %q...", tpl)
+	templateName, err := renderStringIfTemplate(tpl, srcCtx)
+	if err != nil {
+		return "", fmt.Errorf("while rendering template name: %w", err)
+	}
+	return normalize(s.log, templateName, maxTemplateNameLength), nil
+}
+
+func (s *Source) renderTriggerName(tpl string, srcCtx source.CommonSourceContext) (string, error) {
+	s.log.Debugf("Rendering trigger name %q...", tpl)
+	triggerName, err := renderStringIfTemplate(tpl, srcCtx)
+	if err != nil {
+		return "", fmt.Errorf("while rendering trigger name: %w", err)
+	}
+	return normalize(s.log, triggerName, maxTriggerNameLength), nil
+}
+
+func (s *Source) renderWebhookName(tpl string, srcCtx source.CommonSourceContext) (string, error) {
+	s.log.Debugf("Rendering webhook name %q...", tpl)
+	webhookName, err := renderStringIfTemplate(tpl, srcCtx)
+	if err != nil {
+		return "", fmt.Errorf("while rendering webhook name: %w", err)
+	}
+	return normalize(s.log, webhookName, maxWebhookNameLength), nil
+}
 
 func renderStringIfTemplate(tpl string, srcCtx source.CommonSourceContext) (string, error) {
 	if !strings.Contains(tpl, goTplOpeningTag) {
@@ -30,4 +64,32 @@ func renderStringIfTemplate(tpl string, srcCtx source.CommonSourceContext) (stri
 	}
 
 	return result.String(), nil
+}
+
+func normalize(log logrus.FieldLogger, in string, maxSize int) string {
+	out := in
+	defer log.Debugf("Normalized %q to %q", in, out)
+
+	// replace all special characters with `-`
+	out = allowedCharsRegex.ReplaceAllString(out, "-")
+
+	// make it lowercase
+	out = strings.ToLower(out)
+
+	if len(out) <= maxSize {
+		return out
+	}
+
+	// nolint:gosec // false positive
+	h := sha1.New()
+	h.Write([]byte(in))
+	hash := hex.EncodeToString(h.Sum(nil))
+
+	hashMaxSize := maxSize - 2 // 2 chars for the `b-` prefix
+	// if the hash is too long, truncate it
+	if len(hash) > hashMaxSize {
+		hash = hash[:hashMaxSize]
+	}
+
+	return fmt.Sprintf("%s-%s", namePrefix, hash)
 }

--- a/internal/source/argocd/render_test.go
+++ b/internal/source/argocd/render_test.go
@@ -43,8 +43,7 @@ func TestNormalize(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			s := &Source{log: loggerx.NewNoop()}
-			out := s.normalize(tc.Input, tc.MaxSize)
+			out := normalize(loggerx.NewNoop(), tc.Input, tc.MaxSize)
 			assert.Equal(t, tc.ExpectedOutput, out)
 		})
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix ArgoCD template name normalization
- Fix incoming webhook for handling `/` characters in the source name

## Testing

Use instruction from https://github.com/kubeshop/botkube/pull/1220, but instead of argocd source config name, try to use something like, e.g. `argocd/BK`. Use the name both in Helm chart and the values.yaml for overrides.

## Related issue(s)

#1175 