### PR TITLE
Fix merging Kubernetes configuration

### DIFF
--- a/internal/source/kubernetes/router.go
+++ b/internal/source/kubernetes/router.go
@@ -20,21 +20,21 @@ type registrationHandler func(resource string) (cache.SharedIndexInformer, error
 type eventHandler func(ctx context.Context, source Source, event event.Event, updateDiffs []string)
 
 type route struct {
-	resourceName  config.RegexConstraints
-	labels        *map[string]string
-	annotations   *map[string]string
-	namespaces    *config.RegexConstraints
-	updateSetting *config.UpdateSetting
-	event         *config.KubernetesEvent
+	ResourceName  config.RegexConstraints
+	Labels        *map[string]string
+	Annotations   *map[string]string
+	Namespaces    *config.RegexConstraints
+	UpdateSetting *config.UpdateSetting
+	Event         *config.KubernetesEvent
 }
 
 func (r route) hasActionableUpdateSetting() bool {
-	return r.updateSetting != nil && len(r.updateSetting.Fields) > 0
+	return r.UpdateSetting != nil && len(r.UpdateSetting.Fields) > 0
 }
 
 type entry struct {
-	event  config.EventType
-	routes []route
+	Event  config.EventType
+	Routes []route
 }
 
 // Router maintains handled event types from registered
@@ -66,7 +66,7 @@ func (r *Router) BuildTable(cfg *config.Config) *Router {
 	for resource, resourceEvents := range mergedEvents {
 		eventRoutes := r.mergeEventRoutes(resource, cfg)
 		for evt := range resourceEvents {
-			r.table[resource] = append(r.table[resource], entry{event: evt, routes: eventRoutes[evt]})
+			r.table[resource] = append(r.table[resource], entry{Event: evt, Routes: eventRoutes[evt]})
 		}
 	}
 	r.log.Debugf("routing table: %+v", r.table)
@@ -169,25 +169,26 @@ func mergeResourceEvents(cfg *config.Config) mergedEvents {
 
 func (r *Router) mergeEventRoutes(resource string, cfg *config.Config) map[config.EventType][]route {
 	out := make(map[config.EventType][]route)
-	for _, r := range cfg.Resources {
+	for idx := range cfg.Resources {
+		r := cfg.Resources[idx] // make sure that we work on a copy
 		for _, e := range flattenEventTypes(cfg.Event.Types, r.Event.Types) {
 			if resource != r.Type {
 				continue
 			}
-
 			route := route{
-				namespaces:   resourceNamespaces(cfg.Namespaces, &r.Namespaces),
-				annotations:  resourceStringMap(cfg.Annotations, r.Annotations),
-				labels:       resourceStringMap(cfg.Labels, r.Labels),
-				resourceName: r.Name,
-				event:        resourceEvent(*cfg.Event, r.Event),
+				Namespaces:   resourceNamespaces(cfg.Namespaces, &r.Namespaces),
+				Annotations:  resourceStringMap(cfg.Annotations, r.Annotations),
+				Labels:       resourceStringMap(cfg.Labels, r.Labels),
+				ResourceName: r.Name,
+				Event:        resourceEvent(*cfg.Event, r.Event),
 			}
 			if e == config.UpdateEvent {
-				route.updateSetting = &config.UpdateSetting{
+				route.UpdateSetting = &config.UpdateSetting{
 					Fields:      r.UpdateSetting.Fields,
 					IncludeDiff: r.UpdateSetting.IncludeDiff,
 				}
 			}
+
 			out[e] = append(out[e], route)
 		}
 	}
@@ -211,8 +212,8 @@ func (r *Router) setEventRouteForRecommendationsIfShould(routeMap *map[config.Ev
 	}
 
 	recommRoute := route{
-		namespaces: cfg.Namespaces,
-		event: &config.KubernetesEvent{
+		Namespaces: cfg.Namespaces,
+		Event: &config.KubernetesEvent{
 			Reason:  config.RegexConstraints{},
 			Message: config.RegexConstraints{},
 			Types:   nil,
@@ -222,7 +223,7 @@ func (r *Router) setEventRouteForRecommendationsIfShould(routeMap *map[config.Ev
 	// Override route and get all these events for all namespaces.
 	// The events without recommendations will be filtered out when sending the event.
 	for i, r := range (*routeMap)[eventType] {
-		recommRoute.namespaces = resourceNamespaces(cfg.Namespaces, r.namespaces)
+		recommRoute.Namespaces = resourceNamespaces(cfg.Namespaces, r.Namespaces)
 		(*routeMap)[eventType][i] = recommRoute
 		return
 	}
@@ -234,8 +235,8 @@ func (r *Router) setEventRouteForRecommendationsIfShould(routeMap *map[config.Ev
 func eventRoutes(routeTable map[string][]entry, targetResource string, targetEvent config.EventType) []route {
 	var out []route
 	for _, routedEvent := range routeTable[targetResource] {
-		if routedEvent.event == targetEvent {
-			out = append(out, routedEvent.routes...)
+		if routedEvent.Event == targetEvent {
+			out = append(out, routedEvent.Routes...)
 		}
 	}
 	return out
@@ -244,7 +245,7 @@ func eventRoutes(routeTable map[string][]entry, targetResource string, targetEve
 func (r *Router) resourceEvents(resource string) []config.EventType {
 	var out []config.EventType
 	for _, routedEvent := range r.table[resource] {
-		out = append(out, routedEvent.event)
+		out = append(out, routedEvent.Event)
 	}
 	return out
 }
@@ -254,7 +255,7 @@ func (r *Router) resourcesForEvents(targets []config.EventType) []string {
 	for _, target := range targets {
 		for resource, routedEvents := range r.table {
 			for _, routedEvent := range routedEvents {
-				if routedEvent.event == target {
+				if routedEvent.Event == target {
 					out = append(out, resource)
 					break
 				}

--- a/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/override-fields-config.yaml
+++ b/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/override-fields-config.yaml
@@ -1,0 +1,44 @@
+event:
+  types:
+    - delete
+  reason:
+    include: ["reason-include-1-level"]
+    exclude: ["reason-exclude-1-level"]
+  message:
+    include: ["message-include-1-level"]
+    exclude: ["message-exclude-1-level"]
+
+annotations:
+  test: "annotation-1-level"
+
+labels:
+  test: "label-1-level"
+
+namespaces:
+  include: ["namespace-include-1-level"]
+  exclude: ["namespace-exclude-1-level"]
+
+resources:
+  - type: v1/configmaps # change all nested properties
+    namespaces:
+      include: ["namespace-include-2-level"]
+      exclude: ["namespace-exclude-2-level"]
+    event:
+      types:
+        - create
+      reason:
+        include: ["reason-include-2-level"]
+        exclude: ["reason-exclude-2-level"]
+      message:
+        include: ["message-include-2-level"]
+        exclude: ["message-exclude-2-level"]
+    annotations:
+      test: "annotation-2-level"
+    labels:
+      test: "label-2-level"
+
+  - type: apps/v1/deployments # change only ns
+    namespaces:
+      exclude:
+        - "other"
+  - type: v1/pod # use top level properties

--- a/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-apps.v1.deployments.golden.yaml
+++ b/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-apps.v1.deployments.golden.yaml
@@ -1,0 +1,26 @@
+- event: delete
+  routes:
+    - resourcename:
+        include: []
+      labels:
+        test: label-1-level
+      annotations:
+        test: annotation-1-level
+      namespaces:
+        include: []
+        exclude:
+            - other
+      updatesetting: null
+      event:
+        reason:
+            include:
+                - reason-include-1-level
+            exclude:
+                - reason-exclude-1-level
+        message:
+            include:
+                - message-include-1-level
+            exclude:
+                - message-exclude-1-level
+        types:
+            - delete

--- a/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-v1.configmaps.golden.yaml
+++ b/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-v1.configmaps.golden.yaml
@@ -1,0 +1,27 @@
+- event: create
+  routes:
+    - resourcename:
+        include: []
+      labels:
+        test: label-2-level
+      annotations:
+        test: annotation-2-level
+      namespaces:
+        include:
+            - namespace-include-2-level
+        exclude:
+            - namespace-exclude-2-level
+      updatesetting: null
+      event:
+        reason:
+            include:
+                - reason-include-2-level
+            exclude:
+                - reason-exclude-2-level
+        message:
+            include:
+                - message-include-2-level
+            exclude:
+                - message-exclude-2-level
+        types:
+            - create

--- a/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-v1.pod.golden.yaml
+++ b/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-v1.pod.golden.yaml
@@ -1,0 +1,27 @@
+- event: delete
+  routes:
+    - resourcename:
+        include: []
+      labels:
+        test: label-1-level
+      annotations:
+        test: annotation-1-level
+      namespaces:
+        include:
+            - namespace-include-1-level
+        exclude:
+            - namespace-exclude-1-level
+      updatesetting: null
+      event:
+        reason:
+            include:
+                - reason-include-1-level
+            exclude:
+                - reason-exclude-1-level
+        message:
+            include:
+                - message-include-1-level
+            exclude:
+                - message-exclude-1-level
+        types:
+            - delete


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- I tried to add some linter to warns when assigning the address of the variable from `range`, but unfortunately, none were able to catch this because we are passing that pointer to a function. Even [`revive`](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-address).


It's a valid candidate for cherry-picking into v1.4.1 release.

## Testing
### Unit tests
Writing manual compare was too slow, so first I used 
```go
dump = litter.Options{
	StripPackageNames:         true,
	HidePrivateFields:         false,
	HideZeroValues:            true,
	DisablePointerReplacement: true,
	Separator:                 " ",
}
dump.Sdump(router.table)
```

but this was not producing readable enough assets, so I decided to go with YAML, but for that I had to export fields. Because the struct is still private, it doesn't change anything.

### Manual
1. Create cluster: `k3d cluster create`
2. Build k8s plugin: `PLUGIN_TARGETS="kubernetes" make build-plugins-single`
3. Start server: `env PLUGIN_SERVER_HOST=http://host.k3d.internal go run test/helpers/plugin_server.go`
4. Create Botkube config:
    ```yaml
    communications:
      default-group:
        socketSlack:
          enabled: true
          channels:
            default:
              name: hakuna-matata
              bindings:
                sources:
                  - "k8s-all-events"
                executors: [ ]
          appToken: "xapp-"
          botToken: "xoxb-"
    
    sources:
      "k8s-all-events":
        botkube/kubernetes:
          enabled: true
          config:
            namespaces:
              include:
                - ".*"
            event:
              types:
                - delete
                - error
            resources:
              - type: v1/services
              - type: networking.k8s.io/v1/ingresses
              - type: v1/nodes
              - type: v1/namespaces
              - type: v1/persistentvolumes
              - type: v1/persistentvolumeclaims
              - type: v1/configmaps
                namespaces:
                  include:
                    - ".*"
                  exclude:
                    - "gitlab-runner"
              - type: rbac.authorization.k8s.io/v1/roles
              - type: rbac.authorization.k8s.io/v1/rolebindings
              - type: rbac.authorization.k8s.io/v1/clusterrolebindings
              - type: rbac.authorization.k8s.io/v1/clusterroles
              - type: apps/v1/daemonsets
              - type: batch/v1/jobs
              - type: apps/v1/deployments
              - type: apps/v1/statefulsets
    
    plugins:
      cacheDir: "/tmp/plugins"
    
      repositories:
        botkube:
          url: http://host.k3d.internal:3010/botkube.yaml
    
    
    settings:
      log:
        level: "debug"
        formatter: "text"
      clusterName: "labs"
      upgradeNotifier: false
    
    analytics:
      disable: true
    
    configWatcher:
      enabled: false
    
    ```
5. Start Botkube: `env BOTKUBE_CONFIG_PATHS="./helm/botkube/values.yaml,/tmp/debug-events.yaml" go run ./cmd/botkube-agent/main.go`
5. Create configmap in `gitlab-runner` ns and delete it, create configmap in `default` ns and try to delete it.
    ```bash
    kc create ns gitlab-runner
    
    kubectl create configmap my-config --from-literal=key1=config1 -n gitlab-runner                                                                                                                       
    kubectl create configmap my-config --from-literal=key1=config1 -n default
    
    kubectl delete cm my-config -n gitlab-runner
    kubectl delete cm my-config -n default
    ```
## Related issue(s)

#1251 