### PR TITLE
Interactive Message Response Size Handling

### DIFF
--- a/pkg/bot/slack_cloud.go
+++ b/pkg/bot/slack_cloud.go
@@ -42,7 +42,6 @@ const (
 	maxRetries              = 30
 	successIntervalDuration = 3 * time.Minute
 	quotaExceededMsg        = "Quota exceeded detected. Stopping reconnecting to Botkube Cloud gRPC API..."
-	MaxListingLimit			= 45
 )
 
 var _ Bot = &CloudSlack{}

--- a/pkg/bot/slack_cloud.go
+++ b/pkg/bot/slack_cloud.go
@@ -537,8 +537,6 @@ func (b *CloudSlack) send(ctx context.Context, event slackMessage, resp interact
 
 			result := strings.Join(newBlocks, "\n")
 
-			fmt.Println("result is",result)
-
 			resp = interactive.CoreMessage{
 				Description: resp.Description,
 				Message: api.Message{

--- a/pkg/bot/slack_cloud.go
+++ b/pkg/bot/slack_cloud.go
@@ -520,7 +520,6 @@ func (b *CloudSlack) send(ctx context.Context, event slackMessage, resp interact
 	var err error
 	if len(markdown) >= slackMaxMessageSize {
 		if strings.Contains(resp.Description, "logs") {
-
 			file, err = uploadFileToSlack(ctx, event.Channel, resp, b.client, event.ThreadTimeStamp)
 			if err != nil {
 				return err

--- a/pkg/bot/slack_cloud.go
+++ b/pkg/bot/slack_cloud.go
@@ -519,14 +519,36 @@ func (b *CloudSlack) send(ctx context.Context, event slackMessage, resp interact
 	var file *slack.File
 	var err error
 	if len(markdown) >= slackMaxMessageSize {
-		file, err = uploadFileToSlack(ctx, event.Channel, resp, b.client, event.ThreadTimeStamp)
-		if err != nil {
-			return err
-		}
-		resp = interactive.CoreMessage{
-			Message: api.Message{
-				PlaintextInputs: resp.PlaintextInputs,
-			},
+		if strings.Contains(resp.Description, "logs") {
+
+			file, err = uploadFileToSlack(ctx, event.Channel, resp, b.client, event.ThreadTimeStamp)
+			if err != nil {
+				return err
+			}
+			resp = interactive.CoreMessage{
+				Message: api.Message{
+					PlaintextInputs: resp.PlaintextInputs,
+				},
+			}
+		} else {
+			newBlocks := strings.Split(resp.BaseBody.CodeBlock, "\n")
+
+			newBlocks = newBlocks[:45]
+
+			result := strings.Join(newBlocks, "\n")
+
+			fmt.Println("result is",result)
+
+			resp = interactive.CoreMessage{
+				Description: resp.Description,
+				Message: api.Message{
+					PlaintextInputs: resp.PlaintextInputs,
+
+					BaseBody: api.Body{
+						CodeBlock: result,
+					},
+				},
+			}
 		}
 	}
 

--- a/pkg/bot/slack_cloud.go
+++ b/pkg/bot/slack_cloud.go
@@ -42,6 +42,7 @@ const (
 	maxRetries              = 30
 	successIntervalDuration = 3 * time.Minute
 	quotaExceededMsg        = "Quota exceeded detected. Stopping reconnecting to Botkube Cloud gRPC API..."
+	MaxListingLimit			= 45
 )
 
 var _ Bot = &CloudSlack{}
@@ -533,7 +534,7 @@ func (b *CloudSlack) send(ctx context.Context, event slackMessage, resp interact
 		} else {
 			newBlocks := strings.Split(resp.BaseBody.CodeBlock, "\n")
 
-			newBlocks = newBlocks[:45]
+			newBlocks = newBlocks[:MaxListingLimit]
 
 			result := strings.Join(newBlocks, "\n")
 

--- a/pkg/bot/slack_socket.go
+++ b/pkg/bot/slack_socket.go
@@ -30,6 +30,10 @@ import (
 //    - split to multiple files in a separate package,
 //    - review all the methods and see if they can be simplified.
 
+const (
+	MaxListingLimit = 45
+)
+
 var _ Bot = &SocketSlack{}
 
 // SocketSlack listens for user's message, execute commands and sends back the response.
@@ -421,7 +425,7 @@ func (b *SocketSlack) send(ctx context.Context, event slackMessage, resp interac
 		} else {
 			newBlocks := strings.Split(resp.BaseBody.CodeBlock, "\n")
 
-			newBlocks = newBlocks[:45]
+			newBlocks = newBlocks[:MaxListingLimit]
 
 			result := strings.Join(newBlocks, "\n")
 

--- a/pkg/bot/slack_socket.go
+++ b/pkg/bot/slack_socket.go
@@ -412,7 +412,6 @@ func (b *SocketSlack) send(ctx context.Context, event slackMessage, resp interac
 	var err error
 	if len(markdown) >= slackMaxMessageSize {
 		if strings.Contains(resp.Description, "logs") {
-
 			file, err = uploadFileToSlack(ctx, event.Channel, resp, b.client, event.ThreadTimeStamp)
 			if err != nil {
 				return err

--- a/pkg/bot/slack_socket.go
+++ b/pkg/bot/slack_socket.go
@@ -429,8 +429,6 @@ func (b *SocketSlack) send(ctx context.Context, event slackMessage, resp interac
 
 			result := strings.Join(newBlocks, "\n")
 
-			fmt.Println("result is",result)
-
 			resp = interactive.CoreMessage{
 				Description: resp.Description,
 				Message: api.Message{

--- a/pkg/bot/slack_socket.go
+++ b/pkg/bot/slack_socket.go
@@ -407,14 +407,36 @@ func (b *SocketSlack) send(ctx context.Context, event slackMessage, resp interac
 	var file *slack.File
 	var err error
 	if len(markdown) >= slackMaxMessageSize {
-		file, err = uploadFileToSlack(ctx, event.Channel, resp, b.client, event.ThreadTimeStamp)
-		if err != nil {
-			return err
-		}
-		resp = interactive.CoreMessage{
-			Message: api.Message{
-				PlaintextInputs: resp.PlaintextInputs,
-			},
+		if strings.Contains(resp.Description, "logs") {
+
+			file, err = uploadFileToSlack(ctx, event.Channel, resp, b.client, event.ThreadTimeStamp)
+			if err != nil {
+				return err
+			}
+			resp = interactive.CoreMessage{
+				Message: api.Message{
+					PlaintextInputs: resp.PlaintextInputs,
+				},
+			}
+		} else {
+			newBlocks := strings.Split(resp.BaseBody.CodeBlock, "\n")
+
+			newBlocks = newBlocks[:45]
+
+			result := strings.Join(newBlocks, "\n")
+
+			fmt.Println("result is",result)
+
+			resp = interactive.CoreMessage{
+				Description: resp.Description,
+				Message: api.Message{
+					PlaintextInputs: resp.PlaintextInputs,
+
+					BaseBody: api.Body{
+						CodeBlock: result,
+					},
+				},
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

If resources are request and their size exceeds the max limit of text allowed in slack instead of showing them in a file , we will limit the size to 45 now and only show 45 items maintaining the interactivity for the interactive messages , in the future we will be implementing pagination for this 


## Related issue(s)

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->

Fixes: #1051 
