### PR TITLE
Fix dispatching events for sink platforms

### DIFF
--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -177,6 +177,13 @@ func (d *Dispatcher) getBotNotifiers(dispatch PluginDispatch) []notifier.Bot {
 	return d.markdownNotifiers
 }
 
+func (d *Dispatcher) getSinkNotifiers(dispatch PluginDispatch) []notifier.Sink {
+	if dispatch.isInteractivitySupported {
+		return nil // we shouldn't forward interactive events
+	}
+	return d.sinkNotifiers
+}
+
 func (d *Dispatcher) dispatchMsg(ctx context.Context, event source.Event, dispatch PluginDispatch) {
 	var (
 		pluginName = dispatch.pluginName
@@ -207,7 +214,7 @@ func (d *Dispatcher) dispatchMsg(ctx context.Context, event source.Event, dispat
 		}(n)
 	}
 
-	for _, n := range d.sinkNotifiers {
+	for _, n := range d.getSinkNotifiers(dispatch) {
 		go func(n notifier.Sink) {
 			defer analytics.ReportPanicIfOccurs(d.log, d.reporter)
 			err := n.SendEvent(ctx, event.RawObject, sources)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

The problem only occurs when you have both things:
- `socketSlack` enabled
- the same binding used both, under `socketSlack` and `elasticsearch`

-- 
Technical explanation:
1. `socketSlack` supports interactivity, such as buttons, dropdowns etc.
1. all other platforms don’t support that yet
1. sinks such as elastic or webhook doesn't support interactivity because they are one directional.

When socketSlack and other non-interactive platform are enabled and uses the same source configuration, we start 2 process:
- with indication that events can include interactive elements
- with indication that it should produce plain events

So a given event e.g. create is produced twice and we route them to a given supported platform. Unfortunately, we had a bug and for sinks we were routing both events, resulting in duplication that you saw.

## Testing

You need to install ES (see this https://dejavu.reactivesearch.io) and install Botkube with such configuration:
```yaml
sources:
  "k8s-all-events":
    botkube/kubernetes:
      enabled: true
      config:
        namespaces: &k8s-events-namespaces
          include:
            - ".*"
        event:
          types:
            - delete
            - error
        resources:
          - type: v1/services
          - type: networking.k8s.io/v1/ingresses
          - type: v1/nodes
          - type: v1/namespaces
          - type: v1/persistentvolumes
          - type: v1/persistentvolumeclaims
          # - type: v1/configmaps
          #   namespaces:
          #     include:
          #       - ".*"
          #     exclude:
          #       - "gitlab-runner"
          - type: rbac.authorization.k8s.io/v1/roles
          - type: rbac.authorization.k8s.io/v1/rolebindings
          - type: rbac.authorization.k8s.io/v1/clusterrolebindings
          - type: rbac.authorization.k8s.io/v1/clusterroles
          - type: apps/v1/daemonsets
          - type: batch/v1/jobs
          - type: apps/v1/deployments
          - type: apps/v1/statefulsets

communications:
  'default-group':
    socketSlack:
      enabled: true
      appToken: "xapp-1-"
      botToken: "xoxb-"
      channels:
        "default":
          name: "random"
          bindings:
            executors: [ ]
            sources:
              - k8s-all-events
    elasticsearch:
      enabled: true
      server: 'http://host.k3d.internal:9200'
      username: admin
      password: admin
      skipTLSVerify: true
      indices:
        'default':
          name: botkube
          type: botkube-event
          shards: 1
          replicas: 0
          bindings:
            sources:
              - k8s-all-events
              - k8s-err-events
              - k8s-err-with-logs-events
              - k8s-create-events

settings:
  kubeconfig: "/Users/mszostok/.kube/config"
  log:
    level: "info"
    formatter: "text"
  clusterName: "labs"
  upgradeNotifier: false

analytics:
  disable: true

configWatcher:
  enabled: false
```

Next, create Namespace and then delete it. Check ES events and Slack events.

## Related issue(s)

Fix https://github.com/kubeshop/botkube/issues/1266