### PR TITLE
Cancel previous runs, bump CI deps, migrate set-output

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -25,14 +25,14 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: Docker Login
         uses: docker/login-action@v1
         with:
@@ -40,7 +40,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5
         with:
           install-only: true
           version: latest
@@ -70,16 +70,16 @@ jobs:
           - discord
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5
         with:
           install-only: true
           version: latest
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -129,12 +129,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -166,7 +166,7 @@ jobs:
            --set image.tag="${IMAGE_TAG}" \
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5
         with:
           install-only: true
           version: latest

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -7,6 +7,10 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }} #  scope to for the current workflow
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # cancel only PR related jobs
+
 jobs:
   chart-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ env:
   HELM_VERSION: v3.9.0
   GOLANGCI_LINT_VERSION: v1.54.2
   GOLANGCI_LINT_TIMEOUT: 10m
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }} #  scope to for the current workflow
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # cancel only PR related jobs
+
 jobs:
   lint-go:
     if: ${{ !contains(github.event.commits[0].message, '[skip-ci]') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,12 @@ jobs:
     name: Lint Go code
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --timeout=${{ env.GOLANGCI_LINT_TIMEOUT }}
       - name: Verify Go modules
         run: go mod verify
         if: always()
@@ -45,6 +40,32 @@ jobs:
           else
             echo '✔ No issues detected. Have a nice day :-)'
           fi
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          # When the files to be extracted are already present,
+          # tar extraction in Golangci Lint fails with the "File exists"
+          # errors. These files appear to be present because of
+          # cache in setup-go, on disabling the cache we are no more seeing
+          # such error. Cache is to be enabled once the fix is available for
+          # this issue:
+          # https://github.com/golangci/golangci-lint-action/issues/807
+          cache: false
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          args: --timeout=${{ env.GOLANGCI_LINT_TIMEOUT }}
+
 
   test:
     if: ${{ !contains(github.event.commits[0].message, '[skip-ci]') }}
@@ -52,9 +73,9 @@ jobs:
     name: Run tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -70,9 +91,9 @@ jobs:
     name: Build app
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -10,6 +10,10 @@ on:
     # Runs at 09:00 UTC on Wed.
     - cron: '0 9 * * 3'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }} #  scope to for the current workflow
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # cancel only PR related jobs
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/cut-new-release.yml
+++ b/.github/workflows/cut-new-release.yml
@@ -21,7 +21,7 @@ jobs:
       ref: ${{ steps.extract.outputs.ref }}
       base-version: ${{ steps.extract.outputs.base-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0
@@ -43,8 +43,8 @@ jobs:
               echo "release-${BASE_VERSION} is found, now REF=release-${BASE_VERSION}"
               REF=$(echo "release-${BASE_VERSION}") 
             fi 
-            echo ::set-output name=ref::$REF
-            echo ::set-output name=base-version::$BASE_VERSION
+            echo "ref=$REF" >> $GITHUB_OUTPUT
+            echo "base-version=$BASE_VERSION" >> $GITHUB_OUTPUT
           else
             # Fail entire job if it is not a valid format
             echo "${{ inputs.version }} is not a valid version format. Use something like 'v0.14.0'"
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [workflow-metadata]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.workflow-metadata.outputs.ref }}
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -23,7 +23,7 @@ jobs:
         id: extract
         run: |
           BASE_VERSION=$(echo "${{ inputs.version }}" | cut -c2- |  awk 'BEGIN{FS=OFS="."}NF--')
-          echo ::set-output name=base-version::$BASE_VERSION
+          echo "base-version=$BASE_VERSION" >> $GITHUB_OUTPUT
 
   process-chart:
     needs: [extract-metadata]

--- a/.github/workflows/next-rc.yml
+++ b/.github/workflows/next-rc.yml
@@ -22,7 +22,7 @@ jobs:
       branch: ${{ steps.next-rc.outputs.branch }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0
@@ -59,10 +59,10 @@ jobs:
           NEW_RELEASE_VERSION="${BASE_TAG}-rc.${NEW_RELEASE_REVISION}"
           echo "Latest release-candidate tag found: ${BASE_TAG}-rc.${LATEST_RELEASE_TAG}, creating: ${BASE_TAG}-rc.${NEW_RELEASE_REVISION}"
 
-          echo ::set-output name=release-version::$BASE_TAG
-          echo ::set-output name=new-rc-version::$NEW_RELEASE_VERSION
-          echo ::set-output name=commit-msg::$COMMIT_MSG
-          echo ::set-output name=branch::$CURRENT_BRANCH
+          echo "release-version=$BASE_TAG" >> $GITHUB_OUTPUT
+          echo "new-rc-version=$NEW_RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "commit-msg=$COMMIT_MSG" >> $GITHUB_OUTPUT
+          echo "branch=$CURRENT_BRANCH" >> $GITHUB_OUTPUT
 
   process-chart:
     if: ${{ (!contains(github.event.commits[0].message, '[skip-ci]')) && (needs.next-rc.outputs.new-rc-version != '') }}

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -45,19 +45,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5
         with:
           install-only: true
           version: latest
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -198,13 +198,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -236,7 +236,7 @@ jobs:
           --set image.tag="${IMAGE_TAG}" \
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5
         with:
           install-only: true
           version: latest

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -30,6 +30,10 @@ env:
   IMAGE_TAG: ${{ github.event.pull_request.number }}-PR
   IMAGE_SAVE_LOAD_DIR: /tmp/botkube-images
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }} #  scope to for the current workflow
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # cancel only PR related jobs
+
 jobs:
 
   save-image:

--- a/.github/workflows/process-chart.yml
+++ b/.github/workflows/process-chart.yml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       new-version: ${{ inputs.next-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.release-branch }}
           token: ${{ secrets.gh-token }}
@@ -86,7 +86,7 @@ jobs:
           git push --tags
 
       - name: Checkout to gh-pages for Helm
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: chart
           ref: gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0
@@ -22,13 +22,13 @@ jobs:
         run: git fetch --force --tags
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Docker Login
         uses: docker/login-action@v1
@@ -48,10 +48,10 @@ jobs:
           git fetch origin "refs/notes/*:refs/notes/*"
           BASE_VERSION=$(echo "${BASE_TAG}" | cut -c2- |  awk 'BEGIN{FS=OFS="."}NF--')
           PREV_VERSION=$(echo $(git log --pretty=format:"%N" --show-notes="release-${BASE_VERSION}") | awk -F',' '{ print $1 }' | awk NF | awk '{ print $2 }')
-          echo ::set-output name=previous-version::$PREV_VERSION
+          echo "previous-version=$PREV_VERSION" >> $GITHUB_OUTPUT
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v5
         with:
           install-only: true
           version: latest

--- a/.github/workflows/upload-plugins.yaml
+++ b/.github/workflows/upload-plugins.yaml
@@ -12,7 +12,7 @@ jobs:
       GOBIN: /home/runner/work/botkube/bin
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: GCP auth
       uses: 'google-github-actions/auth@v1'
       with:
@@ -20,14 +20,14 @@ jobs:
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
         cache: true
     - name: Install GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+      uses: goreleaser/goreleaser-action@v5
       with:
         install-only: true
         version: latest

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,6 +1,11 @@
 name: Vulnerability Scan
 on:
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }} #  scope to for the current workflow
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # cancel only PR related jobs
+
 jobs:
   scan-repo:
     if: ${{ !contains(github.event.commits[0].message, '[skip-ci]') }}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

## Bumps
- actions/checkout@v3 -> actions/checkout@v4
- goreleaser/goreleaser-action@v3 -> goreleaser/goreleaser-action@v5
- goreleaser/goreleaser-action@v2 -> goreleaser/goreleaser-action@v5
- actions/setup-go@v3 -> actions/setup-go@v4
- docker/setup-qemu-action@v2 -> docker/setup-qemu-action@v3 
- docker/setup-qemu-action@v1 -> docker/setup-qemu-action@v3

## Issues
- https://github.com/kubeshop/botkube/actions/runs/6247237725: 
   ```
   - The following actions uses node12 which is deprecated and will be forced to run on node16: docker/setup-qemu-action@v1, goreleaser/goreleaser-action@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
   ```
   bumping deps should resolve that
- https://github.com/kubeshop/botkube/actions/runs/6247237724
    ```
    Lint Go code
    Cannot open: File exists
    ```
   I disabled the cache and put it a separate job as approached here: https://github.com/golangci/golangci-lint-action/issues/807

- set-output 
   ```
   The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
   ```
   resources:
     - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 
     - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-masking-a-generated-output-within-a-single-job


## Testing

I didn't test the release, instead I just did a change test in isolation: https://github.com/mszostok/gh-action-playground/actions/runs/6248743921/job/16963972158

I used the official migration guide: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 
