### PR TITLE
Fix configuration merging when using `existingCommunicationsSecretName`

### DIFF
--- a/helm/botkube/templates/communicationsecret.yaml
+++ b/helm/botkube/templates/communicationsecret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.existingCommunicationsSecretName -}}
+{{- if and (not .Values.existingCommunicationsSecretName) (not (include "botkube.remoteConfigEnabled" $)) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -101,8 +101,10 @@ spec:
             - name: cache
               mountPath: "/.kube/cache"
           env:
+            {{- if not (include "botkube.remoteConfigEnabled" $) }}
             - name: BOTKUBE_CONFIG_PATHS
               value: "/config/global_config.yaml,/config/comm_config.yaml,/config/{{ .Values.settings.persistentConfig.runtime.fileName}},/startup-config/{{ .Values.settings.persistentConfig.startup.fileName}}"
+            {{- end }}
             - name: BOTKUBE_SETTINGS_METRICS__PORT
               value: {{ .Values.service.targetPort | quote }}
             {{- if .Values.kubeconfig.enabled }}
@@ -207,7 +209,7 @@ spec:
         - name: startup-config
           configMap:
             name: {{ .Values.settings.persistentConfig.startup.configMap.name }}
-        {{ end}}
+        {{ end }}
       {{- with .Values.extraVolumes }}
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/botkube/templates/global-config.yaml
+++ b/helm/botkube/templates/global-config.yaml
@@ -1,3 +1,4 @@
+{{- if not (include "botkube.remoteConfigEnabled" $) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -42,3 +43,4 @@ data:
 
     analytics:
       disable: {{ .Values.analytics.disable }}
+{{- end }}

--- a/helm/botkube/templates/persistent-config.yaml
+++ b/helm/botkube/templates/persistent-config.yaml
@@ -1,3 +1,4 @@
+{{- if not (include "botkube.remoteConfigEnabled" $) }}
 {{- $runtimeStateCfgMap := .Values.settings.persistentConfig.runtime.configMap.name -}}
 {{- $communications := .Values.communications }}
 {{- if .Values.existingCommunicationsSecretName }}
@@ -104,4 +105,4 @@ data:
         {{/* MS Teams doesn't support notification configuration via Botkube commands. */}}
       {{- end }}
     {{- end }}
-
+{{- end }}

--- a/helm/botkube/templates/persistent-config.yaml
+++ b/helm/botkube/templates/persistent-config.yaml
@@ -1,4 +1,11 @@
 {{- $runtimeStateCfgMap := .Values.settings.persistentConfig.runtime.configMap.name -}}
+{{- $communications := .Values.communications }}
+{{- if .Values.existingCommunicationsSecretName }}
+  {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.existingCommunicationsSecretName | default dict  }}
+  {{- $data := b64dec (index $secret.data "comm_config.yaml") -}}
+  {{- $dataYaml := $data | fromYaml -}}
+  {{- $communications =  $dataYaml.communications }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,7 +23,7 @@ metadata:
 data:
   {{- $prevRuntimeCfgMap := lookup "v1" "ConfigMap" .Release.Namespace $runtimeStateCfgMap | default dict }}
   {{- $prevRuntimeFile := index ( $prevRuntimeCfgMap.data | default dict ) .Values.settings.persistentConfig.runtime.fileName | default "" | fromYaml -}}
-  {{- $mergedRuntimeCommunications := mustMergeOverwrite (mustDeepCopy (default (dict) $prevRuntimeFile.communications )) (mustDeepCopy .Values.communications) }}
+  {{- $mergedRuntimeCommunications := mustMergeOverwrite (mustDeepCopy (default (dict) $prevRuntimeFile.communications )) (mustDeepCopy $communications) }}
   {{- $mergedRuntimeAction := mustMergeOverwrite (mustDeepCopy (default (dict) $prevRuntimeFile.actions )) (mustDeepCopy .Values.actions) }}
   # This file has a special prefix to load it as the last config file during Botkube startup.
   {{ .Values.settings.persistentConfig.runtime.fileName }}: |


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix configuration merging when using `existingCommunicationsSecretName`
- Do not create unused ConfigMaps when using remote config

## Testing

See the instruction in #1273 and test the values:
```yaml
existingCommunicationsSecretName: "comm-config.yaml"
settings:
  clusterName: "devops.azure.akelius.com"
sources:
  k8s-custom:
    botkube/kubernetes:
      config:
        event:
          types:
            - error
        namespaces:
          include:
            - kube-infrastructure
        resources:
          - type: v1/pods
      context:
        rbac:
          group:
            prefix: ""
            static:
              values:
                - botkube-plugins-default
            type: Static
      enabled: true
    displayName: Kubernetes Errors Kube Infra

resources:
  limits:
    cpu: 100m
    memory: 512Mi
  requests:
    cpu: 10m
    memory: 136Mi
```

Also, test the following scenarios:
- Remote config

- Using default Communications secret - you can simply use
```yaml
communications:
  'default-group':
    socketSlack:
      enabled: true
      channels:
        'default':
          name: 'k8s_devops_azure'
          bindings:
            sources:
              - k8s-custom
      botToken: 'xoxb-'
      appToken: 'xapp-'
settings:
  clusterName: "devops.azure.akelius.com"
sources:
  k8s-custom:
    botkube/kubernetes:
      config:
        event:
          types:
            - error
        namespaces:
          include:
            - kube-infrastructure
        resources:
          - type: v1/pods
      context:
        rbac:
          group:
            prefix: ""
            static:
              values:
                - botkube-plugins-default
            type: Static
      enabled: true
    displayName: Kubernetes Errors Kube Infra

resources:
  limits:
    cpu: 100m
    memory: 512Mi
  requests:
    cpu: 10m
    memory: 136Mi
```


## Related issue(s)
 
Resolves #1273 
