### PR TITLE
Fix concurrent PR jobs

### DIFF
--- a/.github/workflows/chart-testing.yaml
+++ b/.github/workflows/chart-testing.yaml
@@ -8,8 +8,8 @@ on:
     branches: [ "main" ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }} #  scope to for the current workflow
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # cancel only PR related jobs
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || 'branch' }} # scope to for the current workflow
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }} # cancel only PR related jobs
 
 jobs:
   chart-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ env:
   GOLANGCI_LINT_TIMEOUT: 10m
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }} #  scope to for the current workflow
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # cancel only PR related jobs
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || 'branch' }} # scope to for the current workflow
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }} # cancel only PR related jobs
 
 jobs:
   lint-go:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -11,8 +11,8 @@ on:
     - cron: '0 9 * * 3'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }} #  scope to for the current workflow
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # cancel only PR related jobs
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || 'branch' }} # scope to for the current workflow
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }} # cancel only PR related jobs
 
 jobs:
   analyze:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -31,8 +31,8 @@ env:
   IMAGE_SAVE_LOAD_DIR: /tmp/botkube-images
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }} #  scope to for the current workflow
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # cancel only PR related jobs
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || 'branch' }} # scope to for the current workflow
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }} # cancel only PR related jobs
 
 jobs:
 

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -3,8 +3,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }} #  scope to for the current workflow
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }} # cancel only PR related jobs
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || 'branch' }} # scope to for the current workflow
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }} # cancel only PR related jobs
 
 jobs:
   scan-repo:


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix concurrent PR jobs

For `pull_request_target` event, `github.ref` is always `refs/heads/main`.

## Related issue(s)

#1269 
