### PR TITLE
Upload only plugin archives as latest plugins

### DIFF
--- a/.github/workflows/upload-plugins.yaml
+++ b/.github/workflows/upload-plugins.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+    - narrow-down-gcs-upload
 jobs:
   publish_plugins:
     runs-on: ubuntu-latest
@@ -43,6 +44,7 @@ jobs:
       with:
           path: 'plugin-dist'
           destination: 'botkube-plugins-latest/'
+          glob: '*.tar.gz'
           parent: false
     - name: Upload plugin index to GCS
       uses: google-github-actions/upload-cloud-storage@v1


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

For [the latest plugin release](https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml), we use only archive plugins on index.yaml. However, we still push both the binaries and archives making the bucket size to grow.

- Upload only plugin archives as latest plugins

## Testing

Tested on CI branch
