### PR TITLE
Upload only plugin archives as latest plugins

### DIFF
--- a/.github/workflows/upload-plugins.yaml
+++ b/.github/workflows/upload-plugins.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+    - narrow-down-gcs-upload
 jobs:
   publish_plugins:
     runs-on: ubuntu-latest
@@ -43,6 +44,7 @@ jobs:
       with:
           path: 'plugin-dist'
           destination: 'botkube-plugins-latest/'
+          glob: '*.tar.gz'
           parent: false
     - name: Upload plugin index to GCS
       uses: google-github-actions/upload-cloud-storage@v1

--- a/.github/workflows/upload-plugins.yaml
+++ b/.github/workflows/upload-plugins.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - main
-    - narrow-down-gcs-upload
 jobs:
   publish_plugins:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

For [the latest plugin release](https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml), we use only archive plugins on index.yaml. However, we still push both the binaries and archives making the bucket size to grow.

- Upload only plugin archives as latest plugins

## Testing

Tested on CI branch: https://github.com/kubeshop/botkube/actions/runs/6455472645/job/17523021491?pr=1287


![Screenshot 2023-10-09 at 12 51 39](https://github.com/kubeshop/botkube/assets/17568639/5128ede9-6c06-4317-9ab5-39682c6a7c40)


```
 ▲ gsutil du -s -h gs://botkube-plugins-latest                                                                                                            2s
1.38 GiB     gs://botkube-plugins-latest

 ▲ gsutil du -s -h "gs://botkube-plugins-latest/*.tar.gz"
685.12 MiB   gs://botkube-plugins-latest/*.tar.gz

 ▲ gsutil du -s -h -e "*.tar.gz" gs://botkube-plugins-latest/                                                                                             2s
723.15 MiB   gs://botkube-plugins-latest
```

Before merge I will clean the whole bucket so binaries will be removed and latest main will push only archives.