### PR TITLE
Include full plugin name in reported command

### DIFF
--- a/cmd/botkube-agent/main.go
+++ b/cmd/botkube-agent/main.go
@@ -239,8 +239,10 @@ func run(ctx context.Context) (err error) {
 	//    For example, if in both communication groups there's a Slack configuration pointing to the same workspace,
 	//	  when user executes `kubectl` command, one Bot instance will execute the command and return response,
 	//	  and the second "Sorry, this channel is not authorized to execute kubectl command" error.
+	commGroupIdx := 1
 	for commGroupName, commGroupCfg := range conf.Communications {
 		commGroupLogger := logger.WithField(commGroupFieldKey, commGroupName)
+		commGroupMeta := bot.CommGroupMetadata{Name: commGroupName, Index: commGroupIdx}
 
 		scheduleBotNotifier := func(in bot.Bot) {
 			bots[fmt.Sprintf("%s-%s", commGroupName, in.IntegrationName())] = in
@@ -252,7 +254,7 @@ func run(ctx context.Context) (err error) {
 
 		// Run bots
 		if commGroupCfg.Slack.Enabled {
-			sb, err := bot.NewSlack(commGroupLogger.WithField(botLogFieldKey, "Slack"), commGroupName, commGroupCfg.Slack, executorFactory, reporter)
+			sb, err := bot.NewSlack(commGroupLogger.WithField(botLogFieldKey, "Slack"), commGroupMeta, commGroupCfg.Slack, executorFactory, reporter)
 			if err != nil {
 				return reportFatalError("while creating Slack bot", err)
 			}
@@ -260,7 +262,7 @@ func run(ctx context.Context) (err error) {
 		}
 
 		if commGroupCfg.SocketSlack.Enabled {
-			sb, err := bot.NewSocketSlack(commGroupLogger.WithField(botLogFieldKey, "SocketSlack"), commGroupName, commGroupCfg.SocketSlack, executorFactory, reporter)
+			sb, err := bot.NewSocketSlack(commGroupLogger.WithField(botLogFieldKey, "SocketSlack"), commGroupMeta, commGroupCfg.SocketSlack, executorFactory, reporter)
 			if err != nil {
 				return reportFatalError("while creating SocketSlack bot", err)
 			}
@@ -268,7 +270,7 @@ func run(ctx context.Context) (err error) {
 		}
 
 		if commGroupCfg.CloudSlack.Enabled {
-			sb, err := bot.NewCloudSlack(commGroupLogger.WithField(botLogFieldKey, "CloudSlack"), commGroupName, commGroupCfg.CloudSlack, conf.Settings.ClusterName, executorFactory, reporter)
+			sb, err := bot.NewCloudSlack(commGroupLogger.WithField(botLogFieldKey, "CloudSlack"), commGroupMeta, commGroupCfg.CloudSlack, conf.Settings.ClusterName, executorFactory, reporter)
 			if err != nil {
 				return reportFatalError("while creating CloudSlack bot", err)
 			}
@@ -276,7 +278,7 @@ func run(ctx context.Context) (err error) {
 		}
 
 		if commGroupCfg.Mattermost.Enabled {
-			mb, err := bot.NewMattermost(ctx, commGroupLogger.WithField(botLogFieldKey, "Mattermost"), commGroupName, commGroupCfg.Mattermost, executorFactory, reporter)
+			mb, err := bot.NewMattermost(ctx, commGroupLogger.WithField(botLogFieldKey, "Mattermost"), commGroupMeta, commGroupCfg.Mattermost, executorFactory, reporter)
 			if err != nil {
 				return reportFatalError("while creating Mattermost bot", err)
 			}
@@ -284,7 +286,7 @@ func run(ctx context.Context) (err error) {
 		}
 
 		if commGroupCfg.Teams.Enabled {
-			tb, err := bot.NewTeams(commGroupLogger.WithField(botLogFieldKey, "MS Teams"), commGroupName, commGroupCfg.Teams, conf.Settings.ClusterName, executorFactory, reporter)
+			tb, err := bot.NewTeams(commGroupLogger.WithField(botLogFieldKey, "MS Teams"), commGroupMeta, commGroupCfg.Teams, conf.Settings.ClusterName, executorFactory, reporter)
 			if err != nil {
 				return reportFatalError("while creating Teams bot", err)
 			}
@@ -292,7 +294,7 @@ func run(ctx context.Context) (err error) {
 		}
 
 		if commGroupCfg.Discord.Enabled {
-			db, err := bot.NewDiscord(commGroupLogger.WithField(botLogFieldKey, "Discord"), commGroupName, commGroupCfg.Discord, executorFactory, reporter)
+			db, err := bot.NewDiscord(commGroupLogger.WithField(botLogFieldKey, "Discord"), commGroupMeta, commGroupCfg.Discord, executorFactory, reporter)
 			if err != nil {
 				return reportFatalError("while creating Discord bot", err)
 			}
@@ -301,7 +303,7 @@ func run(ctx context.Context) (err error) {
 
 		// Run sinks
 		if commGroupCfg.Elasticsearch.Enabled {
-			es, err := sink.NewElasticsearch(commGroupLogger.WithField(sinkLogFieldKey, "Elasticsearch"), commGroupCfg.Elasticsearch, reporter)
+			es, err := sink.NewElasticsearch(commGroupLogger.WithField(sinkLogFieldKey, "Elasticsearch"), commGroupMeta.Index, commGroupCfg.Elasticsearch, reporter)
 			if err != nil {
 				return reportFatalError("while creating Elasticsearch sink", err)
 			}
@@ -309,13 +311,15 @@ func run(ctx context.Context) (err error) {
 		}
 
 		if commGroupCfg.Webhook.Enabled {
-			wh, err := sink.NewWebhook(commGroupLogger.WithField(sinkLogFieldKey, "Webhook"), commGroupCfg.Webhook, reporter)
+			wh, err := sink.NewWebhook(commGroupLogger.WithField(sinkLogFieldKey, "Webhook"), commGroupMeta.Index, commGroupCfg.Webhook, reporter)
 			if err != nil {
 				return reportFatalError("while creating Webhook sink", err)
 			}
 
 			sinkNotifiers = append(sinkNotifiers, wh)
 		}
+
+		commGroupIdx++
 	}
 	healthChecker.SetNotifiers(getHealthNotifiers(bots, sinkNotifiers))
 

--- a/internal/analytics/noop_reporter.go
+++ b/internal/analytics/noop_reporter.go
@@ -23,7 +23,7 @@ func (n NoopReporter) RegisterCurrentIdentity(_ context.Context, _ kubernetes.In
 	return nil
 }
 
-// ReportCommandInput reports a new executed command. The command should be anonymized before using this method.
+// ReportCommand reports a new executed command. The command should be anonymized before using this method.
 func (n NoopReporter) ReportCommand(_ ReportCommandInput) error {
 	return nil
 }

--- a/internal/analytics/noop_reporter.go
+++ b/internal/analytics/noop_reporter.go
@@ -25,7 +25,7 @@ func (n NoopReporter) RegisterCurrentIdentity(_ context.Context, _ kubernetes.In
 }
 
 // ReportCommand reports a new executed command. The command should be anonymized before using this method.
-func (n NoopReporter) ReportCommand(_ config.CommPlatformIntegration, _ string, _ command.Origin, _ bool) error {
+func (n NoopReporter) ReportCommand(_ config.CommPlatformIntegration, _, _ string, _ command.Origin, _ bool) error {
 	return nil
 }
 

--- a/internal/analytics/noop_reporter.go
+++ b/internal/analytics/noop_reporter.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubeshop/botkube/pkg/config"
-	"github.com/kubeshop/botkube/pkg/execute/command"
 )
 
 var _ Reporter = &NoopReporter{}
@@ -25,17 +24,17 @@ func (n NoopReporter) RegisterCurrentIdentity(_ context.Context, _ kubernetes.In
 }
 
 // ReportCommand reports a new executed command. The command should be anonymized before using this method.
-func (n NoopReporter) ReportCommand(_ config.CommPlatformIntegration, _, _ string, _ command.Origin, _ bool) error {
+func (n NoopReporter) ReportCommand(_ ReportCommand) error {
 	return nil
 }
 
 // ReportBotEnabled reports an enabled bot.
-func (n NoopReporter) ReportBotEnabled(_ config.CommPlatformIntegration) error {
+func (n NoopReporter) ReportBotEnabled(_ config.CommPlatformIntegration, _ int) error {
 	return nil
 }
 
 // ReportSinkEnabled reports an enabled sink.
-func (n NoopReporter) ReportSinkEnabled(_ config.CommPlatformIntegration) error {
+func (n NoopReporter) ReportSinkEnabled(_ config.CommPlatformIntegration, _ int) error {
 	return nil
 }
 

--- a/internal/analytics/noop_reporter.go
+++ b/internal/analytics/noop_reporter.go
@@ -23,8 +23,8 @@ func (n NoopReporter) RegisterCurrentIdentity(_ context.Context, _ kubernetes.In
 	return nil
 }
 
-// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-func (n NoopReporter) ReportCommand(_ ReportCommand) error {
+// ReportCommandInput reports a new executed command. The command should be anonymized before using this method.
+func (n NoopReporter) ReportCommand(_ ReportCommandInput) error {
 	return nil
 }
 
@@ -39,12 +39,12 @@ func (n NoopReporter) ReportSinkEnabled(_ config.CommPlatformIntegration, _ int)
 }
 
 // ReportHandledEventSuccess reports a successfully handled event using a given communication platform.
-func (n NoopReporter) ReportHandledEventSuccess(_ ReportEvent) error {
+func (n NoopReporter) ReportHandledEventSuccess(_ ReportEventInput) error {
 	return nil
 }
 
 // ReportHandledEventError reports a failure while handling event using a given communication platform.
-func (n NoopReporter) ReportHandledEventError(_ ReportEvent, _ error) error {
+func (n NoopReporter) ReportHandledEventError(_ ReportEventInput, _ error) error {
 	return nil
 }
 

--- a/internal/analytics/reporter.go
+++ b/internal/analytics/reporter.go
@@ -15,13 +15,13 @@ type Reporter interface {
 	RegisterCurrentIdentity(ctx context.Context, k8sCli kubernetes.Interface, deployID string) error
 
 	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(platform config.CommPlatformIntegration, pluginName, command string, origin command.Origin, withFilter bool) error
+	ReportCommand(in ReportCommand) error
 
 	// ReportBotEnabled reports an enabled bot.
-	ReportBotEnabled(platform config.CommPlatformIntegration) error
+	ReportBotEnabled(platform config.CommPlatformIntegration, commGroupIdx int) error
 
 	// ReportSinkEnabled reports an enabled sink.
-	ReportSinkEnabled(platform config.CommPlatformIntegration) error
+	ReportSinkEnabled(platform config.CommPlatformIntegration, commGroupIdx int) error
 
 	// ReportHandledEventSuccess reports a successfully handled event using a given integration type, communication platform, and plugin.
 	ReportHandledEventSuccess(event ReportEvent) error
@@ -41,4 +41,12 @@ type ReportEvent struct {
 	Platform              config.CommPlatformIntegration
 	PluginName            string
 	AnonymizedEventFields map[string]any
+}
+
+type ReportCommand struct {
+	Platform   config.CommPlatformIntegration
+	PluginName string
+	Command    string
+	Origin     command.Origin
+	WithFilter bool
 }

--- a/internal/analytics/reporter.go
+++ b/internal/analytics/reporter.go
@@ -15,7 +15,7 @@ type Reporter interface {
 	RegisterCurrentIdentity(ctx context.Context, k8sCli kubernetes.Interface, deployID string) error
 
 	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(platform config.CommPlatformIntegration, command string, origin command.Origin, withFilter bool) error
+	ReportCommand(platform config.CommPlatformIntegration, pluginName, command string, origin command.Origin, withFilter bool) error
 
 	// ReportBotEnabled reports an enabled bot.
 	ReportBotEnabled(platform config.CommPlatformIntegration) error

--- a/internal/analytics/reporter.go
+++ b/internal/analytics/reporter.go
@@ -14,7 +14,7 @@ type Reporter interface {
 	// RegisterCurrentIdentity loads the current anonymous identity and registers it.
 	RegisterCurrentIdentity(ctx context.Context, k8sCli kubernetes.Interface, deployID string) error
 
-	// ReportCommandInput reports a new executed command. The command should be anonymized before using this method.
+	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
 	ReportCommand(in ReportCommandInput) error
 
 	// ReportBotEnabled reports an enabled bot.

--- a/internal/analytics/reporter.go
+++ b/internal/analytics/reporter.go
@@ -14,8 +14,8 @@ type Reporter interface {
 	// RegisterCurrentIdentity loads the current anonymous identity and registers it.
 	RegisterCurrentIdentity(ctx context.Context, k8sCli kubernetes.Interface, deployID string) error
 
-	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(in ReportCommand) error
+	// ReportCommandInput reports a new executed command. The command should be anonymized before using this method.
+	ReportCommand(in ReportCommandInput) error
 
 	// ReportBotEnabled reports an enabled bot.
 	ReportBotEnabled(platform config.CommPlatformIntegration, commGroupIdx int) error
@@ -24,10 +24,10 @@ type Reporter interface {
 	ReportSinkEnabled(platform config.CommPlatformIntegration, commGroupIdx int) error
 
 	// ReportHandledEventSuccess reports a successfully handled event using a given integration type, communication platform, and plugin.
-	ReportHandledEventSuccess(event ReportEvent) error
+	ReportHandledEventSuccess(event ReportEventInput) error
 
 	// ReportHandledEventError reports a failure while handling event using a given integration type, communication platform, and plugin.
-	ReportHandledEventError(event ReportEvent, err error) error
+	ReportHandledEventError(event ReportEventInput, err error) error
 
 	// ReportFatalError reports a fatal app error.
 	ReportFatalError(err error) error
@@ -36,14 +36,14 @@ type Reporter interface {
 	Close() error
 }
 
-type ReportEvent struct {
+type ReportEventInput struct {
 	IntegrationType       config.IntegrationType
 	Platform              config.CommPlatformIntegration
 	PluginName            string
 	AnonymizedEventFields map[string]any
 }
 
-type ReportCommand struct {
+type ReportCommandInput struct {
 	Platform   config.CommPlatformIntegration
 	PluginName string
 	Command    string

--- a/internal/analytics/segment_reporter.go
+++ b/internal/analytics/segment_reporter.go
@@ -66,7 +66,7 @@ func (r *SegmentReporter) RegisterCurrentIdentity(ctx context.Context, k8sCli ku
 	return nil
 }
 
-// ReportCommandInput reports a new executed command. The command should be anonymized before using this method.
+// ReportCommand reports a new executed command. The command should be anonymized before using this method.
 // The RegisterCurrentIdentity needs to be called first.
 func (r *SegmentReporter) ReportCommand(in ReportCommandInput) error {
 	return r.reportEvent("Command executed", map[string]interface{}{

--- a/internal/analytics/segment_reporter.go
+++ b/internal/analytics/segment_reporter.go
@@ -66,9 +66,9 @@ func (r *SegmentReporter) RegisterCurrentIdentity(ctx context.Context, k8sCli ku
 	return nil
 }
 
-// ReportCommand reports a new executed command. The command should be anonymized before using this method.
+// ReportCommandInput reports a new executed command. The command should be anonymized before using this method.
 // The RegisterCurrentIdentity needs to be called first.
-func (r *SegmentReporter) ReportCommand(in ReportCommand) error {
+func (r *SegmentReporter) ReportCommand(in ReportCommandInput) error {
 	return r.reportEvent("Command executed", map[string]interface{}{
 		"platform": in.Platform,
 		"command":  in.Command,
@@ -82,9 +82,9 @@ func (r *SegmentReporter) ReportCommand(in ReportCommand) error {
 // The RegisterCurrentIdentity needs to be called first.
 func (r *SegmentReporter) ReportBotEnabled(platform config.CommPlatformIntegration, commGroupIdx int) error {
 	return r.reportEvent("Integration enabled", map[string]interface{}{
-		"platform": platform,
-		"type":     config.BotIntegrationType,
-		"index":    commGroupIdx,
+		"platform":             platform,
+		"type":                 config.BotIntegrationType,
+		"communicationGroupID": commGroupIdx,
 	})
 }
 
@@ -92,15 +92,15 @@ func (r *SegmentReporter) ReportBotEnabled(platform config.CommPlatformIntegrati
 // The RegisterCurrentIdentity needs to be called first.
 func (r *SegmentReporter) ReportSinkEnabled(platform config.CommPlatformIntegration, commGroupIdx int) error {
 	return r.reportEvent("Integration enabled", map[string]interface{}{
-		"platform": platform,
-		"type":     config.SinkIntegrationType,
-		"index":    commGroupIdx,
+		"platform":             platform,
+		"type":                 config.SinkIntegrationType,
+		"communicationGroupID": commGroupIdx,
 	})
 }
 
 // ReportHandledEventSuccess reports a successfully handled event using a given communication platform.
 // The RegisterCurrentIdentity needs to be called first.
-func (r *SegmentReporter) ReportHandledEventSuccess(event ReportEvent) error {
+func (r *SegmentReporter) ReportHandledEventSuccess(event ReportEventInput) error {
 	return r.reportEvent("Event handled", map[string]interface{}{
 		"platform": event.Platform,
 		"type":     event.IntegrationType,
@@ -112,7 +112,7 @@ func (r *SegmentReporter) ReportHandledEventSuccess(event ReportEvent) error {
 
 // ReportHandledEventError reports a failure while handling event using a given communication platform.
 // The RegisterCurrentIdentity needs to be called first.
-func (r *SegmentReporter) ReportHandledEventError(event ReportEvent, err error) error {
+func (r *SegmentReporter) ReportHandledEventError(event ReportEventInput, err error) error {
 	if err == nil {
 		return nil
 	}

--- a/internal/analytics/segment_reporter.go
+++ b/internal/analytics/segment_reporter.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubeshop/botkube/pkg/config"
-	"github.com/kubeshop/botkube/pkg/execute/command"
 	"github.com/kubeshop/botkube/pkg/version"
 )
 
@@ -69,31 +68,33 @@ func (r *SegmentReporter) RegisterCurrentIdentity(ctx context.Context, k8sCli ku
 
 // ReportCommand reports a new executed command. The command should be anonymized before using this method.
 // The RegisterCurrentIdentity needs to be called first.
-func (r *SegmentReporter) ReportCommand(platform config.CommPlatformIntegration, pluginName, command string, origin command.Origin, withFilter bool) error {
+func (r *SegmentReporter) ReportCommand(in ReportCommand) error {
 	return r.reportEvent("Command executed", map[string]interface{}{
-		"platform": platform,
-		"command":  command,
-		"plugin":   pluginName,
-		"origin":   origin,
-		"filtered": withFilter,
+		"platform": in.Platform,
+		"command":  in.Command,
+		"plugin":   in.PluginName,
+		"origin":   in.Origin,
+		"filtered": in.WithFilter,
 	})
 }
 
 // ReportBotEnabled reports an enabled bot.
 // The RegisterCurrentIdentity needs to be called first.
-func (r *SegmentReporter) ReportBotEnabled(platform config.CommPlatformIntegration) error {
+func (r *SegmentReporter) ReportBotEnabled(platform config.CommPlatformIntegration, commGroupIdx int) error {
 	return r.reportEvent("Integration enabled", map[string]interface{}{
 		"platform": platform,
 		"type":     config.BotIntegrationType,
+		"index":    commGroupIdx,
 	})
 }
 
 // ReportSinkEnabled reports an enabled sink.
 // The RegisterCurrentIdentity needs to be called first.
-func (r *SegmentReporter) ReportSinkEnabled(platform config.CommPlatformIntegration) error {
+func (r *SegmentReporter) ReportSinkEnabled(platform config.CommPlatformIntegration, commGroupIdx int) error {
 	return r.reportEvent("Integration enabled", map[string]interface{}{
 		"platform": platform,
 		"type":     config.SinkIntegrationType,
+		"index":    commGroupIdx,
 	})
 }
 

--- a/internal/analytics/segment_reporter.go
+++ b/internal/analytics/segment_reporter.go
@@ -69,10 +69,11 @@ func (r *SegmentReporter) RegisterCurrentIdentity(ctx context.Context, k8sCli ku
 
 // ReportCommand reports a new executed command. The command should be anonymized before using this method.
 // The RegisterCurrentIdentity needs to be called first.
-func (r *SegmentReporter) ReportCommand(platform config.CommPlatformIntegration, command string, origin command.Origin, withFilter bool) error {
+func (r *SegmentReporter) ReportCommand(platform config.CommPlatformIntegration, pluginName, command string, origin command.Origin, withFilter bool) error {
 	return r.reportEvent("Command executed", map[string]interface{}{
 		"platform": platform,
 		"command":  command,
+		"plugin":   pluginName,
 		"origin":   origin,
 		"filtered": withFilter,
 	})

--- a/internal/analytics/segment_reporter_test.go
+++ b/internal/analytics/segment_reporter_test.go
@@ -101,14 +101,14 @@ func TestSegmentReporter_ReportCommand(t *testing.T) {
 	segmentReporter, segmentCli := fakeSegmentReporterWithIdentity(identity)
 
 	// when
-	err := segmentReporter.ReportCommand(analytics.ReportCommand{
+	err := segmentReporter.ReportCommand(analytics.ReportCommandInput{
 		Platform: config.DiscordCommPlatformIntegration,
 		Command:  "enable notifications",
 		Origin:   command.TypedOrigin,
 	})
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportCommand(analytics.ReportCommand{
+	err = segmentReporter.ReportCommand(analytics.ReportCommandInput{
 		Platform:   config.SlackCommPlatformIntegration,
 		PluginName: "botkube/kubectl",
 		Command:    "get",
@@ -117,7 +117,7 @@ func TestSegmentReporter_ReportCommand(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportCommand(analytics.ReportCommand{
+	err = segmentReporter.ReportCommand(analytics.ReportCommandInput{
 		Platform: config.TeamsCommPlatformIntegration,
 		Command:  "disable notifications",
 		Origin:   command.SelectValueChangeOrigin,
@@ -177,7 +177,7 @@ func TestSegmentReporter_ReportHandledEventSuccess(t *testing.T) {
 	}
 
 	// when
-	err := segmentReporter.ReportHandledEventSuccess(analytics.ReportEvent{
+	err := segmentReporter.ReportHandledEventSuccess(analytics.ReportEventInput{
 		IntegrationType:       config.BotIntegrationType,
 		Platform:              config.SlackCommPlatformIntegration,
 		PluginName:            "botkube/kubernetes",
@@ -185,7 +185,7 @@ func TestSegmentReporter_ReportHandledEventSuccess(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportHandledEventSuccess(analytics.ReportEvent{
+	err = segmentReporter.ReportHandledEventSuccess(analytics.ReportEventInput{
 		IntegrationType:       config.SinkIntegrationType,
 		Platform:              config.ElasticsearchCommPlatformIntegration,
 		PluginName:            "botkube/kubernetes",
@@ -209,7 +209,7 @@ func TestSegmentReporter_ReportHandledEventError(t *testing.T) {
 	sampleErr := errors.New("sample error")
 
 	// when
-	err := segmentReporter.ReportHandledEventError(analytics.ReportEvent{
+	err := segmentReporter.ReportHandledEventError(analytics.ReportEventInput{
 		IntegrationType:       config.BotIntegrationType,
 		Platform:              config.SlackCommPlatformIntegration,
 		PluginName:            "botkube/kubernetes",
@@ -217,7 +217,7 @@ func TestSegmentReporter_ReportHandledEventError(t *testing.T) {
 	}, sampleErr)
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportHandledEventError(analytics.ReportEvent{
+	err = segmentReporter.ReportHandledEventError(analytics.ReportEventInput{
 		IntegrationType:       config.SinkIntegrationType,
 		Platform:              config.ElasticsearchCommPlatformIntegration,
 		PluginName:            "botkube/kubernetes",

--- a/internal/analytics/segment_reporter_test.go
+++ b/internal/analytics/segment_reporter_test.go
@@ -101,13 +101,27 @@ func TestSegmentReporter_ReportCommand(t *testing.T) {
 	segmentReporter, segmentCli := fakeSegmentReporterWithIdentity(identity)
 
 	// when
-	err := segmentReporter.ReportCommand(config.DiscordCommPlatformIntegration, "", "enable notifications", command.TypedOrigin, false)
+	err := segmentReporter.ReportCommand(analytics.ReportCommand{
+		Platform: config.DiscordCommPlatformIntegration,
+		Command:  "enable notifications",
+		Origin:   command.TypedOrigin,
+	})
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportCommand(config.SlackCommPlatformIntegration, "botkube/kubectl", "get", command.ButtonClickOrigin, false)
+	err = segmentReporter.ReportCommand(analytics.ReportCommand{
+		Platform:   config.SlackCommPlatformIntegration,
+		PluginName: "botkube/kubectl",
+		Command:    "get",
+		Origin:     command.ButtonClickOrigin,
+		WithFilter: true,
+	})
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportCommand(config.TeamsCommPlatformIntegration, "", "disable notifications", command.SelectValueChangeOrigin, false)
+	err = segmentReporter.ReportCommand(analytics.ReportCommand{
+		Platform: config.TeamsCommPlatformIntegration,
+		Command:  "disable notifications",
+		Origin:   command.SelectValueChangeOrigin,
+	})
 	require.NoError(t, err)
 
 	// then
@@ -120,15 +134,15 @@ func TestSegmentReporter_ReportBotEnabled(t *testing.T) {
 	segmentReporter, segmentCli := fakeSegmentReporterWithIdentity(identity)
 
 	// when
-	err := segmentReporter.ReportBotEnabled(config.SlackCommPlatformIntegration)
+	err := segmentReporter.ReportBotEnabled(config.SlackCommPlatformIntegration, 1)
 	require.NoError(t, err)
 
 	// when
-	err = segmentReporter.ReportBotEnabled(config.DiscordCommPlatformIntegration)
+	err = segmentReporter.ReportBotEnabled(config.DiscordCommPlatformIntegration, 2)
 	require.NoError(t, err)
 
 	// when
-	err = segmentReporter.ReportBotEnabled(config.TeamsCommPlatformIntegration)
+	err = segmentReporter.ReportBotEnabled(config.TeamsCommPlatformIntegration, 1)
 	require.NoError(t, err)
 
 	// then
@@ -141,11 +155,11 @@ func TestSegmentReporter_ReportSinkEnabled(t *testing.T) {
 	segmentReporter, segmentCli := fakeSegmentReporterWithIdentity(identity)
 
 	// when
-	err := segmentReporter.ReportSinkEnabled(config.WebhookCommPlatformIntegration)
+	err := segmentReporter.ReportSinkEnabled(config.WebhookCommPlatformIntegration, 1)
 	require.NoError(t, err)
 
 	// when
-	err = segmentReporter.ReportSinkEnabled(config.ElasticsearchCommPlatformIntegration)
+	err = segmentReporter.ReportSinkEnabled(config.ElasticsearchCommPlatformIntegration, 2)
 	require.NoError(t, err)
 
 	// then

--- a/internal/analytics/segment_reporter_test.go
+++ b/internal/analytics/segment_reporter_test.go
@@ -101,13 +101,13 @@ func TestSegmentReporter_ReportCommand(t *testing.T) {
 	segmentReporter, segmentCli := fakeSegmentReporterWithIdentity(identity)
 
 	// when
-	err := segmentReporter.ReportCommand(config.DiscordCommPlatformIntegration, "enable notifications", command.TypedOrigin, false)
+	err := segmentReporter.ReportCommand(config.DiscordCommPlatformIntegration, "", "enable notifications", command.TypedOrigin, false)
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportCommand(config.SlackCommPlatformIntegration, "get", command.ButtonClickOrigin, false)
+	err = segmentReporter.ReportCommand(config.SlackCommPlatformIntegration, "botkube/kubectl", "get", command.ButtonClickOrigin, false)
 	require.NoError(t, err)
 
-	err = segmentReporter.ReportCommand(config.TeamsCommPlatformIntegration, "disable notifications", command.SelectValueChangeOrigin, false)
+	err = segmentReporter.ReportCommand(config.TeamsCommPlatformIntegration, "", "disable notifications", command.SelectValueChangeOrigin, false)
 	require.NoError(t, err)
 
 	// then

--- a/internal/analytics/testdata/TestSegmentReporter_ReportBotEnabled.json
+++ b/internal/analytics/testdata/TestSegmentReporter_ReportBotEnabled.json
@@ -6,6 +6,7 @@
 		"event": "Integration enabled",
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
+			"index": 1,
 			"platform": "slack",
 			"type": "bot"
 		}
@@ -17,6 +18,7 @@
 		"event": "Integration enabled",
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
+			"index": 2,
 			"platform": "discord",
 			"type": "bot"
 		}
@@ -28,6 +30,7 @@
 		"event": "Integration enabled",
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
+			"index": 1,
 			"platform": "teams",
 			"type": "bot"
 		}

--- a/internal/analytics/testdata/TestSegmentReporter_ReportBotEnabled.json
+++ b/internal/analytics/testdata/TestSegmentReporter_ReportBotEnabled.json
@@ -6,7 +6,7 @@
 		"event": "Integration enabled",
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
-			"index": 1,
+			"communicationGroupID": 1,
 			"platform": "slack",
 			"type": "bot"
 		}
@@ -18,7 +18,7 @@
 		"event": "Integration enabled",
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
-			"index": 2,
+			"communicationGroupID": 2,
 			"platform": "discord",
 			"type": "bot"
 		}
@@ -30,7 +30,7 @@
 		"event": "Integration enabled",
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
-			"index": 1,
+			"communicationGroupID": 1,
 			"platform": "teams",
 			"type": "bot"
 		}

--- a/internal/analytics/testdata/TestSegmentReporter_ReportCommand.json
+++ b/internal/analytics/testdata/TestSegmentReporter_ReportCommand.json
@@ -21,7 +21,7 @@
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
 			"command": "get",
-			"filtered": false,
+			"filtered": true,
 			"origin": "buttonClick",
 			"platform": "slack",
 			"plugin": "botkube/kubectl"

--- a/internal/analytics/testdata/TestSegmentReporter_ReportCommand.json
+++ b/internal/analytics/testdata/TestSegmentReporter_ReportCommand.json
@@ -9,7 +9,8 @@
 			"command": "enable notifications",
 			"filtered": false,
 			"origin": "typed",
-			"platform": "discord"
+			"platform": "discord",
+			"plugin": ""
 		}
 	},
 	{
@@ -22,7 +23,8 @@
 			"command": "get",
 			"filtered": false,
 			"origin": "buttonClick",
-			"platform": "slack"
+			"platform": "slack",
+			"plugin": "botkube/kubectl"
 		}
 	},
 	{
@@ -35,7 +37,8 @@
 			"command": "disable notifications",
 			"filtered": false,
 			"origin": "selectValueChange",
-			"platform": "teams"
+			"platform": "teams",
+			"plugin": ""
 		}
 	}
 ]

--- a/internal/analytics/testdata/TestSegmentReporter_ReportSinkEnabled.json
+++ b/internal/analytics/testdata/TestSegmentReporter_ReportSinkEnabled.json
@@ -6,6 +6,7 @@
 		"event": "Integration enabled",
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
+			"index": 1,
 			"platform": "webhook",
 			"type": "sink"
 		}
@@ -17,6 +18,7 @@
 		"event": "Integration enabled",
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
+			"index": 2,
 			"platform": "elasticsearch",
 			"type": "sink"
 		}

--- a/internal/analytics/testdata/TestSegmentReporter_ReportSinkEnabled.json
+++ b/internal/analytics/testdata/TestSegmentReporter_ReportSinkEnabled.json
@@ -6,7 +6,7 @@
 		"event": "Integration enabled",
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
-			"index": 1,
+			"communicationGroupID": 1,
 			"platform": "webhook",
 			"type": "sink"
 		}
@@ -18,7 +18,7 @@
 		"event": "Integration enabled",
 		"timestamp": "2009-11-17T20:34:58.651387237Z",
 		"properties": {
-			"index": 2,
+			"communicationGroupID": 2,
 			"platform": "elasticsearch",
 			"type": "sink"
 		}

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -46,10 +46,10 @@ type ActionProvider interface {
 // AnalyticsReporter defines a reporter that collects analytics data.
 type AnalyticsReporter interface {
 	// ReportHandledEventSuccess reports a successfully handled event using a given integration type, communication platform, and plugin.
-	ReportHandledEventSuccess(event analytics.ReportEvent) error
+	ReportHandledEventSuccess(event analytics.ReportEventInput) error
 
 	// ReportHandledEventError reports a failure while handling event using a given integration type, communication platform, and plugin.
-	ReportHandledEventError(event analytics.ReportEvent, err error) error
+	ReportHandledEventError(event analytics.ReportEventInput, err error) error
 
 	// ReportFatalError reports a fatal app error.
 	ReportFatalError(err error) error
@@ -291,7 +291,7 @@ type genericNotifier interface {
 
 func (d *Dispatcher) reportSuccess(n genericNotifier, pluginName string, event source.Event) error {
 	errs := multierror.New()
-	reportErr := d.reporter.ReportHandledEventSuccess(analytics.ReportEvent{
+	reportErr := d.reporter.ReportHandledEventSuccess(analytics.ReportEventInput{
 		IntegrationType:       n.Type(),
 		Platform:              n.IntegrationName(),
 		PluginName:            pluginName,
@@ -305,7 +305,7 @@ func (d *Dispatcher) reportSuccess(n genericNotifier, pluginName string, event s
 
 func (d *Dispatcher) reportError(err error, n genericNotifier, pluginName string, event source.Event) error {
 	errs := multierror.New()
-	reportErr := d.reporter.ReportHandledEventError(analytics.ReportEvent{
+	reportErr := d.reporter.ReportHandledEventError(analytics.ReportEventInput{
 		IntegrationType:       n.Type(),
 		Platform:              n.IntegrationName(),
 		PluginName:            pluginName,

--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -35,7 +35,7 @@ type ExecutorFactory interface {
 // AnalyticsReporter defines a reporter that collects analytics data.
 type AnalyticsReporter interface {
 	// ReportBotEnabled reports an enabled bot.
-	ReportBotEnabled(platform config.CommPlatformIntegration) error
+	ReportBotEnabled(platform config.CommPlatformIntegration, commGroupIdx int) error
 }
 
 // FatalErrorAnalyticsReporter reports a fatal errors.
@@ -62,6 +62,11 @@ type channelConfigByName struct {
 
 	alias  string
 	notify bool
+}
+
+type CommGroupMetadata struct {
+	Name  string
+	Index int
 }
 
 func AsNotifiers(bots map[string]Bot) []notifier.Bot {

--- a/pkg/bot/discord.go
+++ b/pkg/bot/discord.go
@@ -130,8 +130,7 @@ func (b *Discord) Start(ctx context.Context) error {
 
 	err = b.reporter.ReportBotEnabled(b.IntegrationName(), b.commGroupMetadata.Index)
 	if err != nil {
-		b.setFailureReason(health.FailureReasonConnectionError)
-		return fmt.Errorf("while reporting analytics: %w", err)
+		b.log.Errorf("report analytics error: %s", err.Error())
 	}
 
 	b.log.Info("Botkube connected to Discord!")

--- a/pkg/bot/discord.go
+++ b/pkg/bot/discord.go
@@ -50,7 +50,7 @@ type Discord struct {
 	channels              map[string]channelConfigByID
 	notifyMutex           sync.Mutex
 	botMentionRegex       *regexp.Regexp
-	commGroupName         string
+	commGroupMetadata     CommGroupMetadata
 	renderer              *DiscordRenderer
 	messages              chan discordMessage
 	discordMessageWorkers *pool.Pool
@@ -65,7 +65,7 @@ type discordMessage struct {
 }
 
 // NewDiscord creates a new Discord instance.
-func NewDiscord(log logrus.FieldLogger, commGroupName string, cfg config.Discord, executorFactory ExecutorFactory, reporter AnalyticsReporter) (*Discord, error) {
+func NewDiscord(log logrus.FieldLogger, commGroupMetadata CommGroupMetadata, cfg config.Discord, executorFactory ExecutorFactory, reporter AnalyticsReporter) (*Discord, error) {
 	botMentionRegex, err := discordBotMentionRegex(cfg.BotID)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func NewDiscord(log logrus.FieldLogger, commGroupName string, cfg config.Discord
 		executorFactory:       executorFactory,
 		api:                   api,
 		botID:                 cfg.BotID,
-		commGroupName:         commGroupName,
+		commGroupMetadata:     commGroupMetadata,
 		channels:              channelsCfg,
 		botMentionRegex:       botMentionRegex,
 		renderer:              NewDiscordRenderer(),
@@ -128,7 +128,7 @@ func (b *Discord) Start(ctx context.Context) error {
 		return fmt.Errorf("while opening connection: %w", err)
 	}
 
-	err = b.reporter.ReportBotEnabled(b.IntegrationName())
+	err = b.reporter.ReportBotEnabled(b.IntegrationName(), b.commGroupMetadata.Index)
 	if err != nil {
 		b.setFailureReason(health.FailureReasonConnectionError)
 		return fmt.Errorf("while reporting analytics: %w", err)
@@ -251,7 +251,7 @@ func (b *Discord) handleMessage(ctx context.Context, dm discordMessage) error {
 	}
 
 	e := b.executorFactory.NewDefault(execute.NewDefaultInput{
-		CommGroupName:   b.commGroupName,
+		CommGroupName:   b.commGroupMetadata.Name,
 		Platform:        b.IntegrationName(),
 		NotifierHandler: b,
 		Conversation: execute.Conversation{

--- a/pkg/bot/mattermost.go
+++ b/pkg/bot/mattermost.go
@@ -171,8 +171,7 @@ func (b *Mattermost) Start(ctx context.Context) error {
 
 	err = b.reporter.ReportBotEnabled(b.IntegrationName(), b.commGroupMetadata.Index)
 	if err != nil {
-		b.setStatusReason(health.FailureReasonConnectionError)
-		return fmt.Errorf("while reporting analytics: %w", err)
+		b.log.Errorf("report analytics error: %s", err.Error())
 	}
 
 	// It is observed that Mattermost server closes connections unexpectedly after some time.

--- a/pkg/bot/mattermost.go
+++ b/pkg/bot/mattermost.go
@@ -51,28 +51,28 @@ const (
 
 // Mattermost listens for user's message, execute commands and sends back the response.
 type Mattermost struct {
-	log             logrus.FieldLogger
-	executorFactory ExecutorFactory
-	reporter        AnalyticsReporter
-	serverURL       string
-	botName         string
-	botUserID       string
-	teamName        string
-	webSocketURL    string
-	wsClient        *model.WebSocketClient
-	apiClient       *model.Client4
-	channelsMutex   sync.RWMutex
-	commGroupName   string
-	channels        map[string]channelConfigByID
-	notifyMutex     sync.Mutex
-	botMentionRegex *regexp.Regexp
-	renderer        *MattermostRenderer
-	userNamesForID  map[string]string
-	messages        chan mattermostMessage
-	messageWorkers  *pool.Pool
-	shutdownOnce    sync.Once
-	status          health.PlatformStatusMsg
-	failureReason   health.FailureReasonMsg
+	log               logrus.FieldLogger
+	executorFactory   ExecutorFactory
+	reporter          AnalyticsReporter
+	serverURL         string
+	botName           string
+	botUserID         string
+	teamName          string
+	webSocketURL      string
+	wsClient          *model.WebSocketClient
+	apiClient         *model.Client4
+	channelsMutex     sync.RWMutex
+	commGroupMetadata CommGroupMetadata
+	channels          map[string]channelConfigByID
+	notifyMutex       sync.Mutex
+	botMentionRegex   *regexp.Regexp
+	renderer          *MattermostRenderer
+	userNamesForID    map[string]string
+	messages          chan mattermostMessage
+	messageWorkers    *pool.Pool
+	shutdownOnce      sync.Once
+	status            health.PlatformStatusMsg
+	failureReason     health.FailureReasonMsg
 }
 
 // mattermostMessage contains message details to execute command and send back the result
@@ -81,7 +81,7 @@ type mattermostMessage struct {
 }
 
 // NewMattermost creates a new Mattermost instance.
-func NewMattermost(ctx context.Context, log logrus.FieldLogger, commGroupName string, cfg config.Mattermost, executorFactory ExecutorFactory, reporter AnalyticsReporter) (*Mattermost, error) {
+func NewMattermost(ctx context.Context, log logrus.FieldLogger, commGroupMetadata CommGroupMetadata, cfg config.Mattermost, executorFactory ExecutorFactory, reporter AnalyticsReporter) (*Mattermost, error) {
 	botMentionRegex, err := mattermostBotMentionRegex(cfg.BotName)
 	if err != nil {
 		return nil, err
@@ -125,24 +125,24 @@ func NewMattermost(ctx context.Context, log logrus.FieldLogger, commGroupName st
 	}
 
 	return &Mattermost{
-		log:             log,
-		executorFactory: executorFactory,
-		reporter:        reporter,
-		serverURL:       cfg.URL,
-		botName:         cfg.BotName,
-		botUserID:       botUserID,
-		teamName:        team.Name,
-		apiClient:       client,
-		webSocketURL:    webSocketURL,
-		commGroupName:   commGroupName,
-		channels:        channelsByIDCfg,
-		botMentionRegex: botMentionRegex,
-		renderer:        NewMattermostRenderer(),
-		userNamesForID:  map[string]string{},
-		messages:        make(chan mattermostMessage, platformMessageChannelSize),
-		messageWorkers:  pool.New().WithMaxGoroutines(platformMessageWorkersCount),
-		status:          health.StatusUnknown,
-		failureReason:   "",
+		log:               log,
+		executorFactory:   executorFactory,
+		reporter:          reporter,
+		serverURL:         cfg.URL,
+		botName:           cfg.BotName,
+		botUserID:         botUserID,
+		teamName:          team.Name,
+		apiClient:         client,
+		webSocketURL:      webSocketURL,
+		commGroupMetadata: commGroupMetadata,
+		channels:          channelsByIDCfg,
+		botMentionRegex:   botMentionRegex,
+		renderer:          NewMattermostRenderer(),
+		userNamesForID:    map[string]string{},
+		messages:          make(chan mattermostMessage, platformMessageChannelSize),
+		messageWorkers:    pool.New().WithMaxGoroutines(platformMessageWorkersCount),
+		status:            health.StatusUnknown,
+		failureReason:     "",
 	}, nil
 }
 
@@ -169,7 +169,7 @@ func (b *Mattermost) Start(ctx context.Context) error {
 		return fmt.Errorf("while pinging Mattermost server %q: %w", b.serverURL, err)
 	}
 
-	err = b.reporter.ReportBotEnabled(b.IntegrationName())
+	err = b.reporter.ReportBotEnabled(b.IntegrationName(), b.commGroupMetadata.Index)
 	if err != nil {
 		b.setStatusReason(health.FailureReasonConnectionError)
 		return fmt.Errorf("while reporting analytics: %w", err)
@@ -279,7 +279,7 @@ func (b *Mattermost) handleMessage(ctx context.Context, mm mattermostMessage) er
 	}
 
 	e := b.executorFactory.NewDefault(execute.NewDefaultInput{
-		CommGroupName:   b.commGroupName,
+		CommGroupName:   b.commGroupMetadata.Name,
 		Platform:        b.IntegrationName(),
 		NotifierHandler: b,
 		Conversation: execute.Conversation{

--- a/pkg/bot/slack_cloud.go
+++ b/pkg/bot/slack_cloud.go
@@ -73,7 +73,7 @@ type CloudSlack struct {
 // cloudSlackAnalyticsReporter defines a reporter that collects analytics data.
 type cloudSlackAnalyticsReporter interface {
 	FatalErrorAnalyticsReporter
-	ReportCommand(in analytics.ReportCommand) error
+	ReportCommand(in analytics.ReportCommandInput) error
 }
 
 func NewCloudSlack(log logrus.FieldLogger,
@@ -320,7 +320,7 @@ func (b *CloudSlack) handleStreamMessage(ctx context.Context, data *pb.ConnectRe
 			act := callback.ActionCallback.BlockActions[0]
 			if act == nil || strings.HasPrefix(act.ActionID, urlButtonActionIDPrefix) {
 				reportErr := b.reporter.ReportCommand(
-					analytics.ReportCommand{
+					analytics.ReportCommandInput{
 						Platform: b.IntegrationName(),
 						Command:  act.ActionID,
 						Origin:   command.ButtonClickOrigin,

--- a/pkg/bot/slack_cloud.go
+++ b/pkg/bot/slack_cloud.go
@@ -72,7 +72,7 @@ type CloudSlack struct {
 // cloudSlackAnalyticsReporter defines a reporter that collects analytics data.
 type cloudSlackAnalyticsReporter interface {
 	FatalErrorAnalyticsReporter
-	ReportCommand(platform config.CommPlatformIntegration, command string, origin command.Origin, withFilter bool) error
+	ReportCommand(platform config.CommPlatformIntegration, pluginName, command string, origin command.Origin, withFilter bool) error
 }
 
 func NewCloudSlack(log logrus.FieldLogger,
@@ -318,7 +318,7 @@ func (b *CloudSlack) handleStreamMessage(ctx context.Context, data *pb.ConnectRe
 
 			act := callback.ActionCallback.BlockActions[0]
 			if act == nil || strings.HasPrefix(act.ActionID, urlButtonActionIDPrefix) {
-				reportErr := b.reporter.ReportCommand(b.IntegrationName(), act.ActionID, command.ButtonClickOrigin, false)
+				reportErr := b.reporter.ReportCommand(b.IntegrationName(), "", act.ActionID, command.ButtonClickOrigin, false)
 				if reportErr != nil {
 					b.log.Errorf("while reporting URL command, error: %s", reportErr.Error())
 				}

--- a/pkg/bot/slack_cloud.go
+++ b/pkg/bot/slack_cloud.go
@@ -212,6 +212,12 @@ func (b *CloudSlack) start(ctx context.Context) error {
 	b.setFailureReason("")
 	go b.startMessageProcessor(ctx, messageWorkers, messages)
 
+	if err := b.reporter.ReportBotEnabled(b.IntegrationName(), b.commGroupMetadata.Index); err != nil {
+		b.setFailureReason(health.FailureReasonConnectionError)
+		return fmt.Errorf("report analytics error: %w", err)
+	}
+	b.log.Info("Botkube connected to Slack!")
+
 	for {
 		data, err := c.Recv()
 		if err != nil {

--- a/pkg/bot/slack_cloud.go
+++ b/pkg/bot/slack_cloud.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/kubeshop/botkube/internal/analytics"
 	"github.com/kubeshop/botkube/internal/config/remote"
 	"github.com/kubeshop/botkube/internal/health"
 	"github.com/kubeshop/botkube/pkg/api"
@@ -49,34 +50,34 @@ var _ Bot = &CloudSlack{}
 
 // CloudSlack listens for user's message, execute commands and sends back the response.
 type CloudSlack struct {
-	log              logrus.FieldLogger
-	cfg              config.CloudSlack
-	client           *slack.Client
-	executorFactory  ExecutorFactory
-	reporter         cloudSlackAnalyticsReporter
-	commGroupName    string
-	realNamesForID   map[string]string
-	botMentionRegex  *regexp.Regexp
-	botID            string
-	channelsMutex    sync.RWMutex
-	renderer         *SlackRenderer
-	channels         map[string]channelConfigByName
-	notifyMutex      sync.Mutex
-	clusterName      string
-	msgStatusTracker *SlackMessageStatusTracker
-	status           health.PlatformStatusMsg
-	failuresNo       int
-	failureReason    health.FailureReasonMsg
+	log               logrus.FieldLogger
+	cfg               config.CloudSlack
+	client            *slack.Client
+	executorFactory   ExecutorFactory
+	reporter          cloudSlackAnalyticsReporter
+	commGroupMetadata CommGroupMetadata
+	realNamesForID    map[string]string
+	botMentionRegex   *regexp.Regexp
+	botID             string
+	channelsMutex     sync.RWMutex
+	renderer          *SlackRenderer
+	channels          map[string]channelConfigByName
+	notifyMutex       sync.Mutex
+	clusterName       string
+	msgStatusTracker  *SlackMessageStatusTracker
+	status            health.PlatformStatusMsg
+	failuresNo        int
+	failureReason     health.FailureReasonMsg
 }
 
 // cloudSlackAnalyticsReporter defines a reporter that collects analytics data.
 type cloudSlackAnalyticsReporter interface {
 	FatalErrorAnalyticsReporter
-	ReportCommand(platform config.CommPlatformIntegration, pluginName, command string, origin command.Origin, withFilter bool) error
+	ReportCommand(in analytics.ReportCommand) error
 }
 
 func NewCloudSlack(log logrus.FieldLogger,
-	commGroupName string,
+	commGroupMetadata CommGroupMetadata,
 	cfg config.CloudSlack,
 	clusterName string,
 	executorFactory ExecutorFactory,
@@ -99,22 +100,22 @@ func NewCloudSlack(log logrus.FieldLogger,
 	}
 
 	return &CloudSlack{
-		log:              log,
-		cfg:              cfg,
-		executorFactory:  executorFactory,
-		reporter:         reporter,
-		commGroupName:    commGroupName,
-		botMentionRegex:  botMentionRegex,
-		renderer:         NewSlackRenderer(),
-		channels:         channels,
-		client:           client,
-		botID:            cfg.BotID,
-		clusterName:      clusterName,
-		realNamesForID:   map[string]string{},
-		msgStatusTracker: NewSlackMessageStatusTracker(log, client),
-		status:           health.StatusUnknown,
-		failuresNo:       0,
-		failureReason:    "",
+		log:               log,
+		cfg:               cfg,
+		executorFactory:   executorFactory,
+		reporter:          reporter,
+		commGroupMetadata: commGroupMetadata,
+		botMentionRegex:   botMentionRegex,
+		renderer:          NewSlackRenderer(),
+		channels:          channels,
+		client:            client,
+		botID:             cfg.BotID,
+		clusterName:       clusterName,
+		realNamesForID:    map[string]string{},
+		msgStatusTracker:  NewSlackMessageStatusTracker(log, client),
+		status:            health.StatusUnknown,
+		failuresNo:        0,
+		failureReason:     "",
 	}, nil
 }
 
@@ -318,7 +319,12 @@ func (b *CloudSlack) handleStreamMessage(ctx context.Context, data *pb.ConnectRe
 
 			act := callback.ActionCallback.BlockActions[0]
 			if act == nil || strings.HasPrefix(act.ActionID, urlButtonActionIDPrefix) {
-				reportErr := b.reporter.ReportCommand(b.IntegrationName(), "", act.ActionID, command.ButtonClickOrigin, false)
+				reportErr := b.reporter.ReportCommand(
+					analytics.ReportCommand{
+						Platform: b.IntegrationName(),
+						Command:  act.ActionID,
+						Origin:   command.ButtonClickOrigin,
+					})
 				if reportErr != nil {
 					b.log.Errorf("while reporting URL command, error: %s", reportErr.Error())
 				}
@@ -481,7 +487,7 @@ func (b *CloudSlack) handleMessage(ctx context.Context, event slackMessage) erro
 	channel, exists := b.getChannels()[info.Name]
 
 	e := b.executorFactory.NewDefault(execute.NewDefaultInput{
-		CommGroupName:   b.commGroupName,
+		CommGroupName:   b.commGroupMetadata.Name,
 		Platform:        b.IntegrationName(),
 		NotifierHandler: b,
 		Conversation: execute.Conversation{

--- a/pkg/bot/slack_legacy.go
+++ b/pkg/bot/slack_legacy.go
@@ -147,8 +147,7 @@ func (b *Slack) Start(ctx context.Context) error {
 			case *slack.ConnectedEvent:
 				err := b.reporter.ReportBotEnabled(b.IntegrationName(), b.commGroupMetadata.Index)
 				if err != nil {
-					b.setFailureReason(health.FailureReasonConnectionError)
-					return fmt.Errorf("while reporting analytics: %w", err)
+					b.log.Errorf("report analytics error: %s", err.Error())
 				}
 
 				b.log.Info("Botkube connected to Slack!")

--- a/pkg/bot/slack_socket.go
+++ b/pkg/bot/slack_socket.go
@@ -58,7 +58,7 @@ type SocketSlack struct {
 // socketSlackAnalyticsReporter defines a reporter that collects analytics data.
 type socketSlackAnalyticsReporter interface {
 	FatalErrorAnalyticsReporter
-	ReportCommand(in analytics.ReportCommand) error
+	ReportCommand(in analytics.ReportCommandInput) error
 }
 
 // NewSocketSlack creates a new SocketSlack instance.
@@ -183,7 +183,7 @@ func (b *SocketSlack) Start(ctx context.Context) error {
 
 					act := callback.ActionCallback.BlockActions[0]
 					if act == nil || strings.HasPrefix(act.ActionID, urlButtonActionIDPrefix) {
-						reportErr := b.reporter.ReportCommand(analytics.ReportCommand{Platform: b.IntegrationName(), Command: act.ActionID, Origin: command.ButtonClickOrigin})
+						reportErr := b.reporter.ReportCommand(analytics.ReportCommandInput{Platform: b.IntegrationName(), Command: act.ActionID, Origin: command.ButtonClickOrigin})
 						if reportErr != nil {
 							b.log.Errorf("while reporting URL command, error: %s", reportErr.Error())
 						}

--- a/pkg/bot/slack_socket.go
+++ b/pkg/bot/slack_socket.go
@@ -132,8 +132,7 @@ func (b *SocketSlack) Start(ctx context.Context) error {
 				b.log.Info("Botkube is connecting to Slack...")
 			case socketmode.EventTypeConnected:
 				if err := b.reporter.ReportBotEnabled(b.IntegrationName(), b.commGroupMetadata.Index); err != nil {
-					b.setFailureReason(health.FailureReasonConnectionError)
-					return fmt.Errorf("report analytics error: %w", err)
+					b.log.Errorf("report analytics error: %s", err.Error())
 				}
 				b.log.Info("Botkube connected to Slack!")
 			case socketmode.EventTypeEventsAPI:

--- a/pkg/bot/slack_socket.go
+++ b/pkg/bot/slack_socket.go
@@ -58,7 +58,7 @@ type SocketSlack struct {
 // socketSlackAnalyticsReporter defines a reporter that collects analytics data.
 type socketSlackAnalyticsReporter interface {
 	FatalErrorAnalyticsReporter
-	ReportCommand(platform config.CommPlatformIntegration, command string, origin command.Origin, withFilter bool) error
+	ReportCommand(platform config.CommPlatformIntegration, pluginName, command string, origin command.Origin, withFilter bool) error
 }
 
 // NewSocketSlack creates a new SocketSlack instance.
@@ -183,7 +183,7 @@ func (b *SocketSlack) Start(ctx context.Context) error {
 
 					act := callback.ActionCallback.BlockActions[0]
 					if act == nil || strings.HasPrefix(act.ActionID, urlButtonActionIDPrefix) {
-						reportErr := b.reporter.ReportCommand(b.IntegrationName(), act.ActionID, command.ButtonClickOrigin, false)
+						reportErr := b.reporter.ReportCommand(b.IntegrationName(), "", act.ActionID, command.ButtonClickOrigin, false)
 						if reportErr != nil {
 							b.log.Errorf("while reporting URL command, error: %s", reportErr.Error())
 						}

--- a/pkg/bot/slack_socket.go
+++ b/pkg/bot/slack_socket.go
@@ -35,34 +35,34 @@ var _ Bot = &SocketSlack{}
 
 // SocketSlack listens for user's message, execute commands and sends back the response.
 type SocketSlack struct {
-	log              logrus.FieldLogger
-	executorFactory  ExecutorFactory
-	reporter         socketSlackAnalyticsReporter
-	botID            string
-	client           *slack.Client
-	channelsMutex    sync.RWMutex
-	channels         map[string]channelConfigByName
-	notifyMutex      sync.Mutex
-	botMentionRegex  *regexp.Regexp
-	commGroupName    string
-	renderer         *SlackRenderer
-	realNamesForID   map[string]string
-	msgStatusTracker *SlackMessageStatusTracker
-	messages         chan slackMessage
-	messageWorkers   *pool.Pool
-	shutdownOnce     sync.Once
-	status           health.PlatformStatusMsg
-	failureReason    health.FailureReasonMsg
+	log               logrus.FieldLogger
+	executorFactory   ExecutorFactory
+	reporter          socketSlackAnalyticsReporter
+	botID             string
+	client            *slack.Client
+	channelsMutex     sync.RWMutex
+	channels          map[string]channelConfigByName
+	notifyMutex       sync.Mutex
+	botMentionRegex   *regexp.Regexp
+	commGroupMetadata CommGroupMetadata
+	renderer          *SlackRenderer
+	realNamesForID    map[string]string
+	msgStatusTracker  *SlackMessageStatusTracker
+	messages          chan slackMessage
+	messageWorkers    *pool.Pool
+	shutdownOnce      sync.Once
+	status            health.PlatformStatusMsg
+	failureReason     health.FailureReasonMsg
 }
 
 // socketSlackAnalyticsReporter defines a reporter that collects analytics data.
 type socketSlackAnalyticsReporter interface {
 	FatalErrorAnalyticsReporter
-	ReportCommand(platform config.CommPlatformIntegration, pluginName, command string, origin command.Origin, withFilter bool) error
+	ReportCommand(in analytics.ReportCommand) error
 }
 
 // NewSocketSlack creates a new SocketSlack instance.
-func NewSocketSlack(log logrus.FieldLogger, commGroupName string, cfg config.SocketSlack, executorFactory ExecutorFactory, reporter socketSlackAnalyticsReporter) (*SocketSlack, error) {
+func NewSocketSlack(log logrus.FieldLogger, commGroupMetadata CommGroupMetadata, cfg config.SocketSlack, executorFactory ExecutorFactory, reporter socketSlackAnalyticsReporter) (*SocketSlack, error) {
 	client := slack.New(cfg.BotToken, slack.OptionAppLevelToken(cfg.AppToken))
 
 	authResp, err := client.AuthTest()
@@ -82,21 +82,21 @@ func NewSocketSlack(log logrus.FieldLogger, commGroupName string, cfg config.Soc
 	}
 
 	return &SocketSlack{
-		log:              log,
-		executorFactory:  executorFactory,
-		reporter:         reporter,
-		botID:            botID,
-		client:           client,
-		channels:         channels,
-		commGroupName:    commGroupName,
-		renderer:         NewSlackRenderer(),
-		botMentionRegex:  botMentionRegex,
-		realNamesForID:   map[string]string{},
-		msgStatusTracker: NewSlackMessageStatusTracker(log, client),
-		messages:         make(chan slackMessage, platformMessageChannelSize),
-		messageWorkers:   pool.New().WithMaxGoroutines(platformMessageWorkersCount),
-		status:           health.StatusUnknown,
-		failureReason:    "",
+		log:               log,
+		executorFactory:   executorFactory,
+		reporter:          reporter,
+		botID:             botID,
+		client:            client,
+		channels:          channels,
+		commGroupMetadata: commGroupMetadata,
+		renderer:          NewSlackRenderer(),
+		botMentionRegex:   botMentionRegex,
+		realNamesForID:    map[string]string{},
+		msgStatusTracker:  NewSlackMessageStatusTracker(log, client),
+		messages:          make(chan slackMessage, platformMessageChannelSize),
+		messageWorkers:    pool.New().WithMaxGoroutines(platformMessageWorkersCount),
+		status:            health.StatusUnknown,
+		failureReason:     "",
 	}, nil
 }
 
@@ -131,7 +131,7 @@ func (b *SocketSlack) Start(ctx context.Context) error {
 			case socketmode.EventTypeConnecting:
 				b.log.Info("Botkube is connecting to Slack...")
 			case socketmode.EventTypeConnected:
-				if err := b.reporter.ReportBotEnabled(b.IntegrationName()); err != nil {
+				if err := b.reporter.ReportBotEnabled(b.IntegrationName(), b.commGroupMetadata.Index); err != nil {
 					b.setFailureReason(health.FailureReasonConnectionError)
 					return fmt.Errorf("report analytics error: %w", err)
 				}
@@ -183,7 +183,7 @@ func (b *SocketSlack) Start(ctx context.Context) error {
 
 					act := callback.ActionCallback.BlockActions[0]
 					if act == nil || strings.HasPrefix(act.ActionID, urlButtonActionIDPrefix) {
-						reportErr := b.reporter.ReportCommand(b.IntegrationName(), "", act.ActionID, command.ButtonClickOrigin, false)
+						reportErr := b.reporter.ReportCommand(analytics.ReportCommand{Platform: b.IntegrationName(), Command: act.ActionID, Origin: command.ButtonClickOrigin})
 						if reportErr != nil {
 							b.log.Errorf("while reporting URL command, error: %s", reportErr.Error())
 						}
@@ -366,7 +366,7 @@ func (b *SocketSlack) handleMessage(ctx context.Context, event slackMessage) err
 	channel, exists := b.getChannels()[info.Name]
 
 	e := b.executorFactory.NewDefault(execute.NewDefaultInput{
-		CommGroupName:   b.commGroupName,
+		CommGroupName:   b.commGroupMetadata.Name,
 		Platform:        b.IntegrationName(),
 		NotifierHandler: b,
 		Conversation: execute.Conversation{

--- a/pkg/bot/teams.go
+++ b/pkg/bot/teams.go
@@ -147,8 +147,7 @@ func (b *Teams) Start(ctx context.Context) error {
 
 	err = b.reporter.ReportBotEnabled(b.IntegrationName(), b.commGroupMetadata.Index)
 	if err != nil {
-		b.setFailureReason(health.FailureReasonConnectionError)
-		return fmt.Errorf("while reporting analytics: %w", err)
+		b.log.Errorf("report analytics error: %s", err.Error())
 	}
 
 	srv := httpx.NewServer(b.log, addr, router)

--- a/pkg/bot/teams.go
+++ b/pkg/bot/teams.go
@@ -69,7 +69,7 @@ type Teams struct {
 	//channels map[string][ChannelBindingsByName]
 	bindings           config.BotBindings
 	conversationsMutex sync.RWMutex
-	commGroupName      string
+	commGroupMetadata  CommGroupMetadata
 	conversations      map[string]conversation
 	notifyMutex        sync.Mutex
 	botMentionRegex    *regexp.Regexp
@@ -91,7 +91,7 @@ type consentContext struct {
 }
 
 // NewTeams creates a new Teams instance.
-func NewTeams(log logrus.FieldLogger, commGroupName string, cfg config.Teams, clusterName string, executorFactory ExecutorFactory, reporter AnalyticsReporter) (*Teams, error) {
+func NewTeams(log logrus.FieldLogger, commGroupMetadata CommGroupMetadata, cfg config.Teams, clusterName string, executorFactory ExecutorFactory, reporter AnalyticsReporter) (*Teams, error) {
 	botMentionRegex, err := teamsBotMentionRegex(cfg.BotName)
 	if err != nil {
 		return nil, err
@@ -107,22 +107,22 @@ func NewTeams(log logrus.FieldLogger, commGroupName string, cfg config.Teams, cl
 	}
 
 	return &Teams{
-		log:             log,
-		executorFactory: executorFactory,
-		reporter:        reporter,
-		botName:         cfg.BotName,
-		ClusterName:     clusterName,
-		AppID:           cfg.AppID,
-		AppPassword:     cfg.AppPassword,
-		bindings:        cfg.Bindings,
-		commGroupName:   commGroupName,
-		MessagePath:     msgPath,
-		Port:            port,
-		renderer:        NewTeamsRenderer(),
-		conversations:   make(map[string]conversation),
-		botMentionRegex: botMentionRegex,
-		status:          health.StatusUnknown,
-		failureReason:   "",
+		log:               log,
+		executorFactory:   executorFactory,
+		reporter:          reporter,
+		botName:           cfg.BotName,
+		ClusterName:       clusterName,
+		AppID:             cfg.AppID,
+		AppPassword:       cfg.AppPassword,
+		bindings:          cfg.Bindings,
+		commGroupMetadata: commGroupMetadata,
+		MessagePath:       msgPath,
+		Port:              port,
+		renderer:          NewTeamsRenderer(),
+		conversations:     make(map[string]conversation),
+		botMentionRegex:   botMentionRegex,
+		status:            health.StatusUnknown,
+		failureReason:     "",
 	}, nil
 }
 
@@ -145,7 +145,7 @@ func (b *Teams) Start(ctx context.Context) error {
 	router := mux.NewRouter()
 	router.PathPrefix(b.MessagePath).HandlerFunc(b.processActivity)
 
-	err = b.reporter.ReportBotEnabled(b.IntegrationName())
+	err = b.reporter.ReportBotEnabled(b.IntegrationName(), b.commGroupMetadata.Index)
 	if err != nil {
 		b.setFailureReason(health.FailureReasonConnectionError)
 		return fmt.Errorf("while reporting analytics: %w", err)
@@ -289,7 +289,7 @@ func (b *Teams) processMessage(ctx context.Context, activity schema.Activity) (i
 	}
 
 	e := b.executorFactory.NewDefault(execute.NewDefaultInput{
-		CommGroupName:   b.commGroupName,
+		CommGroupName:   b.commGroupMetadata.Name,
 		Platform:        b.IntegrationName(),
 		NotifierHandler: newTeamsNotifMgrForActivity(b, ref),
 		Conversation: execute.Conversation{

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -258,12 +258,12 @@ func removeMultipleSpaces(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
-func (e *DefaultExecutor) reportCommand(ctx context.Context, pluginName, verb string, withFilter bool, cmdCtx CommandContext) {
-	if err := e.analyticsReporter.ReportCommand(e.platform, verb, e.conversation.CommandOrigin, withFilter); err != nil {
-		e.log.Errorf("while reporting %s command: %s", verb, err.Error())
+func (e *DefaultExecutor) reportCommand(ctx context.Context, pluginName, cmd string, withFilter bool, cmdCtx CommandContext) {
+	if err := e.analyticsReporter.ReportCommand(e.platform, pluginName, cmd, e.conversation.CommandOrigin, withFilter); err != nil {
+		e.log.Errorf("while reporting %s command: %s", cmd, err.Error())
 	}
 	if err := e.reportAuditEvent(ctx, pluginName, cmdCtx); err != nil {
-		e.log.Errorf("while reporting executor audit event for %s: %s", verb, err.Error())
+		e.log.Errorf("while reporting executor audit event for %s: %s", cmd, err.Error())
 	}
 }
 

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/kubeshop/botkube/internal/analytics"
 	"github.com/kubeshop/botkube/internal/audit"
 	"github.com/kubeshop/botkube/internal/plugin"
 	remoteapi "github.com/kubeshop/botkube/internal/remote"
@@ -259,7 +260,13 @@ func removeMultipleSpaces(s string) string {
 }
 
 func (e *DefaultExecutor) reportCommand(ctx context.Context, pluginName, cmd string, withFilter bool, cmdCtx CommandContext) {
-	if err := e.analyticsReporter.ReportCommand(e.platform, pluginName, cmd, e.conversation.CommandOrigin, withFilter); err != nil {
+	if err := e.analyticsReporter.ReportCommand(analytics.ReportCommand{
+		Platform:   e.platform,
+		PluginName: pluginName,
+		Command:    cmd,
+		Origin:     e.conversation.CommandOrigin,
+		WithFilter: withFilter,
+	}); err != nil {
 		e.log.Errorf("while reporting %s command: %s", cmd, err.Error())
 	}
 	if err := e.reportAuditEvent(ctx, pluginName, cmdCtx); err != nil {

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -260,7 +260,7 @@ func removeMultipleSpaces(s string) string {
 }
 
 func (e *DefaultExecutor) reportCommand(ctx context.Context, pluginName, cmd string, withFilter bool, cmdCtx CommandContext) {
-	if err := e.analyticsReporter.ReportCommand(analytics.ReportCommand{
+	if err := e.analyticsReporter.ReportCommand(analytics.ReportCommandInput{
 		Platform:   e.platform,
 		PluginName: pluginName,
 		Command:    cmd,

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -59,7 +59,7 @@ type Executor interface {
 // AnalyticsReporter defines a reporter that collects analytics data.
 type AnalyticsReporter interface {
 	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(in analytics.ReportCommand) error
+	ReportCommand(in analytics.ReportCommandInput) error
 }
 
 // CommandGuard is an interface that allows to check if a given command is allowed to be executed.

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/slack-go/slack"
 	"k8s.io/client-go/rest"
 
+	"github.com/kubeshop/botkube/internal/analytics"
 	"github.com/kubeshop/botkube/internal/audit"
 	guard "github.com/kubeshop/botkube/internal/command"
 	"github.com/kubeshop/botkube/internal/plugin"
@@ -58,7 +59,7 @@ type Executor interface {
 // AnalyticsReporter defines a reporter that collects analytics data.
 type AnalyticsReporter interface {
 	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(platform config.CommPlatformIntegration, pluginName, command string, origin command.Origin, withFilter bool) error
+	ReportCommand(in analytics.ReportCommand) error
 }
 
 // CommandGuard is an interface that allows to check if a given command is allowed to be executed.

--- a/pkg/execute/factory.go
+++ b/pkg/execute/factory.go
@@ -58,7 +58,7 @@ type Executor interface {
 // AnalyticsReporter defines a reporter that collects analytics data.
 type AnalyticsReporter interface {
 	// ReportCommand reports a new executed command. The command should be anonymized before using this method.
-	ReportCommand(platform config.CommPlatformIntegration, command string, origin command.Origin, withFilter bool) error
+	ReportCommand(platform config.CommPlatformIntegration, pluginName, command string, origin command.Origin, withFilter bool) error
 }
 
 // CommandGuard is an interface that allows to check if a given command is allowed to be executed.

--- a/pkg/sink/elasticsearch.go
+++ b/pkg/sink/elasticsearch.go
@@ -140,7 +140,7 @@ func NewElasticsearch(log logrus.FieldLogger, commGroupIdx int, c config.Elastic
 
 	err = reporter.ReportSinkEnabled(esNotifier.IntegrationName(), commGroupIdx)
 	if err != nil {
-		return nil, fmt.Errorf("while reporting analytics: %w", err)
+		log.Errorf("report analytics error: %s", err.Error())
 	}
 
 	return esNotifier, nil

--- a/pkg/sink/elasticsearch.go
+++ b/pkg/sink/elasticsearch.go
@@ -55,7 +55,7 @@ type Elasticsearch struct {
 }
 
 // NewElasticsearch creates a new Elasticsearch instance.
-func NewElasticsearch(log logrus.FieldLogger, c config.Elasticsearch, reporter AnalyticsReporter) (*Elasticsearch, error) {
+func NewElasticsearch(log logrus.FieldLogger, commGroupIdx int, c config.Elasticsearch, reporter AnalyticsReporter) (*Elasticsearch, error) {
 	var elsClient *elastic.Client
 	var err error
 
@@ -138,7 +138,7 @@ func NewElasticsearch(log logrus.FieldLogger, c config.Elasticsearch, reporter A
 		failureReason:  "",
 	}
 
-	err = reporter.ReportSinkEnabled(esNotifier.IntegrationName())
+	err = reporter.ReportSinkEnabled(esNotifier.IntegrationName(), commGroupIdx)
 	if err != nil {
 		return nil, fmt.Errorf("while reporting analytics: %w", err)
 	}

--- a/pkg/sink/types.go
+++ b/pkg/sink/types.go
@@ -13,5 +13,5 @@ type Sink interface {
 // AnalyticsReporter defines a reporter that collects analytics data for sinks.
 type AnalyticsReporter interface {
 	// ReportSinkEnabled reports an enabled sink.
-	ReportSinkEnabled(platform config.CommPlatformIntegration) error
+	ReportSinkEnabled(platform config.CommPlatformIntegration, commGroupIdx int) error
 }

--- a/pkg/sink/webhook.go
+++ b/pkg/sink/webhook.go
@@ -37,7 +37,7 @@ type WebhookPayload struct {
 }
 
 // NewWebhook creates a new Webhook instance.
-func NewWebhook(log logrus.FieldLogger, c config.Webhook, reporter AnalyticsReporter) (*Webhook, error) {
+func NewWebhook(log logrus.FieldLogger, commGroupIdx int, c config.Webhook, reporter AnalyticsReporter) (*Webhook, error) {
 	whNotifier := &Webhook{
 		log:           log,
 		reporter:      reporter,
@@ -47,7 +47,7 @@ func NewWebhook(log logrus.FieldLogger, c config.Webhook, reporter AnalyticsRepo
 		failureReason: "",
 	}
 
-	err := reporter.ReportSinkEnabled(whNotifier.IntegrationName())
+	err := reporter.ReportSinkEnabled(whNotifier.IntegrationName(), commGroupIdx)
 	if err != nil {
 		return nil, fmt.Errorf("while reporting analytics: %w", err)
 	}

--- a/pkg/sink/webhook.go
+++ b/pkg/sink/webhook.go
@@ -49,7 +49,7 @@ func NewWebhook(log logrus.FieldLogger, commGroupIdx int, c config.Webhook, repo
 
 	err := reporter.ReportSinkEnabled(whNotifier.IntegrationName(), commGroupIdx)
 	if err != nil {
-		return nil, fmt.Errorf("while reporting analytics: %w", err)
+		log.Errorf("report analytics error: %s", err.Error())
 	}
 
 	return whNotifier, nil


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Include full plugin name in reported command
- Report communication group anonymous ID
- Report Cloud Slack enabled

## Testing

No need, unit tests properly test it.

But, you can change the NoopReporter to:
```go
func (n NoopReporter) ReportBotEnabled(p config.CommPlatformIntegration, i int) error {
	fmt.Println(">>", p, i)
	return nil
}

// ReportSinkEnabled reports an enabled sink.
func (n NoopReporter) ReportSinkEnabled(p config.CommPlatformIntegration, i int) error {
	fmt.Println(">>", p, i)
	return nil
}

// ReportCommand reports a new executed command. The command should be anonymized before using this method.
func (n NoopReporter) ReportCommand(in ReportCommandInput) error {
	formatx.StructDumper().Dump("ReportCommandInput", in)
	return nil
}

```
And execute a few commands:

![image](https://github.com/kubeshop/botkube/assets/7155799/a144dcd5-2879-4ccd-9dc1-4596baa9e445)

![image](https://github.com/kubeshop/botkube/assets/7155799/7f13dd1c-1054-47f0-a416-fe25e075d09b)

![image](https://github.com/kubeshop/botkube/assets/7155799/c421667b-f389-4368-9fdb-f6461547fbef)
