### PR TITLE
Add opt to use regex for json path values

### DIFF
--- a/internal/source/github_events/jsonschema.json
+++ b/internal/source/github_events/jsonschema.json
@@ -221,10 +221,12 @@
                     },
                     "jsonPath": {
                       "title": "JSONPath Expression",
+                      "description": "The JSONPath expression to filter based on specific criteria within the event payload.",
                       "type": "string"
                     },
                     "value": {
                       "title": "Value",
+                      "description": "The regex value to match in the JSONPath result.",
                       "type": "string"
                     },
                     "notificationTemplate": {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add opt to use regex for json path values

- Docs: https://github.com/kubeshop/botkube-docs/pull/293

## Testing

Config:
```
        repositories:
          - name: mszostok/gh-test-repo
            on:
              events:
                # IssuesEvent with json path filter
                - type: "IssueCommentEvent"
                  # The JSONPath expression to filter events
                  jsonPath: ".comment.html_url"
                  # The value to match in the JSONPath result
                  value: ".*/pull.*"
                  notificationTemplate:
                    previewTpl: |-
                      Commented on #{{ .Issue.Number }} {{ .Issue.Title }}
                      
                      State:   {{ .Issue.State }}
                      Comment: {{ .Comment.Body }}

                    extraButtons:
                      - displayName: Open
                        url: "{{ .Issue.HTMLURL }}"
                        style: primary
```

![Screenshot 2023-11-20 at 13 10 37](https://github.com/kubeshop/botkube/assets/17568639/77e6a077-06bd-4c9f-ae40-3e9a058410ed)
