### PR TITLE
Fix redacting credentials and hide CA certificate when showing config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -502,7 +502,7 @@ type GRPCServer struct {
 
 // GRPCServerTLSConfig describes gRPC server TLS configuration.m
 type GRPCServerTLSConfig struct {
-	CACertificate      []byte `yaml:"caCertificate"`
+	CACertificate      []byte `yaml:"caCertificate,omitempty"`
 	UseSystemCertPool  bool   `yaml:"useSystemCertPool"`
 	InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
 }

--- a/pkg/execute/config.go
+++ b/pkg/execute/config.go
@@ -62,17 +62,22 @@ func (e *ConfigExecutor) renderBotkubeConfiguration() (string, error) {
 
 	// hide sensitive info
 	// TODO: avoid printing sensitive data without need to resetting them manually (which is an error-prone approach)
-	for key, old := range cfg.Communications {
-		old.Slack.Token = redactedSecretStr
-		old.SocketSlack.AppToken = redactedSecretStr
-		old.SocketSlack.BotToken = redactedSecretStr
-		old.Elasticsearch.Password = redactedSecretStr
-		old.Discord.Token = redactedSecretStr
-		old.Mattermost.Token = redactedSecretStr
-		old.Teams.AppPassword = redactedSecretStr
+	for key, val := range cfg.Communications {
+		val.Slack.Token = redactedSecretStr
+		val.SocketSlack.AppToken = redactedSecretStr
+		val.SocketSlack.BotToken = redactedSecretStr
+		val.Elasticsearch.Password = redactedSecretStr
+		val.Discord.Token = redactedSecretStr
+		val.Mattermost.Token = redactedSecretStr
+		val.Teams.AppPassword = redactedSecretStr
+		val.CloudSlack.Token = redactedSecretStr
+
+		// To keep the printed config readable, we don't print the certificate bytes.
+		val.CloudSlack.Server.TLS.CACertificate = nil
+		val.CloudTeams.Server.TLS.CACertificate = nil
 
 		// maps are not addressable: https://stackoverflow.com/questions/42605337/cannot-assign-to-struct-field-in-a-map
-		cfg.Communications[key] = old
+		cfg.Communications[key] = val
 	}
 
 	b, err := yaml.Marshal(cfg)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix redacting credentials when showing config
- Hide CA cert as it makes the config unreadable

## Testing

<img width="629" alt="Screenshot 2023-12-22 at 11 03 08" src="https://github.com/kubeshop/botkube/assets/7155799/7e54b8e7-6e7d-4529-8346-2658077e7b3b">

