### PR TITLE
Fix slight confusion in agent built bin name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,11 @@ This section describes how to build and run Botkube from source code.
 - Kubernetes cluster, at least 1.21
 - Cloned Botkube repository
 
-   Use the following command to clone it:
-   ```sh
-   git clone https://github.com/kubeshop/botkube.git
-   ```
+  Use the following command to clone it:
+
+  ```sh
+  git clone https://github.com/kubeshop/botkube.git
+  ```
 
 ### Build and install on Kubernetes
 
@@ -39,12 +40,13 @@ This section describes how to build and run Botkube from source code.
 
      For example, the command below builds the `linux/arm64` target:
 
-        ```sh
-        IMAGE_PLATFORM=linux/arm64 make container-image-single
-        docker tag ghcr.io/kubeshop/botkube:v9.99.9-dev {your_account}/botkube:v9.99.9-dev
-        docker push {your_account}/botkube:v9.99.9-dev
-        ```
-        Where `{your_account}` is Docker hub or any other registry provider account to which you can push the image.
+     ```sh
+     IMAGE_PLATFORM=linux/arm64 make container-image-single
+     docker tag ghcr.io/kubeshop/botkube:v9.99.9-dev {your_account}/botkube:v9.99.9-dev
+     docker push {your_account}/botkube:v9.99.9-dev
+     ```
+
+     Where `{your_account}` is Docker hub or any other registry provider account to which you can push the image.
 
    - **Multi-arch target builds for any K8s cluster**
 
@@ -89,11 +91,11 @@ For faster development, you can also build and run Botkube outside K8s cluster.
    # Fetch the dependencies
    go mod download
    # Build the binary
-   go build -o botkube ./cmd/botkube-agent/
+   go build -o botkube-agent ./cmd/botkube-agent/
    ```
 
-2. Create a local configuration file to override default values. For example, set communication credentials, specify cluster name, and disable analytics:  
-   
+2. Create a local configuration file to override default values. For example, set communication credentials, specify cluster name, and disable analytics:
+
    ```yaml
    cat <<EOF > local_config.yaml
    communications:
@@ -104,7 +106,7 @@ For faster development, you can also build and run Botkube outside K8s cluster.
            default:
              name: random
          appToken: "xapp-xxxx"
-         botToken: "xoxb-xxxx"   
+         botToken: "xoxb-xxxx"
    configWatcher:
       enabled: false
    settings:
@@ -119,7 +121,7 @@ For faster development, you can also build and run Botkube outside K8s cluster.
    To learn more about configuration, visit https://docs.botkube.io/configuration/.
 
 3. Export paths to configuration files. The priority will be given to the last (right-most) file specified.
-   
+
    ```sh
    export BOTKUBE_CONFIG_PATHS="$(pwd)/helm/botkube/values.yaml,$(pwd)/local_config.yaml"
    ```
@@ -135,16 +137,17 @@ For faster development, you can also build and run Botkube outside K8s cluster.
    ```sh
    kubectl cluster-info
    ```
+
    ```sh
    Kubernetes master is running at https://192.168.39.233:8443
    CoreDNS is running at https://192.168.39.233:8443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
    ...
    ```
 
-6. Run Botkube binary:
+6. Run Botkube agent binary:
 
    ```sh
-   ./botkube
+   ./botkube-agent
    ```
 
 #### Develop Botkube plugins
@@ -179,7 +182,7 @@ For faster development, you can also build and run Botkube outside K8s cluster.
    # remove cached plugins
    rm -rf $BOTKUBE_PLUGINS_CACHE__DIR &&
    # start botkube to download fresh plugins
-   ./botkube
+   ./botkube-agent
    ```
 
    > **Note**
@@ -202,6 +205,7 @@ For faster development, you can also build and run Botkube outside K8s cluster.
   # From project root directory
   make lint-fix
   ```
+
   This will run the `golangci-lint` tool to lint the Go code.
 
 ### Run the e2e tests
@@ -211,6 +215,7 @@ Here [are the details you need](./test/README.md) to set up and run the e2e test
 ### Create a Pull Request
 
 - Make sure your pull request has [good commit messages](https://chris.beams.io/posts/git-commit/):
+
   - Separate subject from body with a blank line
   - Limit the subject line to 50 characters
   - Capitalize the subject line

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,6 @@ test-cloud-slack-dev-e2e: system-check
 test-cloud-slack-dev-e2e-show-browser: system-check
 	@go test -tags=cloud_slack_dev_e2e -race -p 1 -v -timeout 30m -rod=show ./test/cloud-slack-dev-e2e/...
 
-# Build the binary
-build: pre-build
-	@cd cmd/botkube-agent;GOOS_VAL=$(shell go env GOOS) CGO_ENABLED=0 GOARCH_VAL=$(shell go env GOARCH) go build -o $(shell go env GOPATH)/bin/botkube
-	@echo "Build completed successfully"
-
 # Build Botkube official plugins for all supported platforms.
 build-plugins: pre-build gen-plugins-goreleaser
 	@echo "Building plugins binaries"


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Remove `make build` target since it's not used anywhere.
- Make sure botkube agent binary is name `botkube-agent`.
- Incidental markdown lint fixes.

## Testing

<!-- Describe necessary steps to test the changes.
You can refer to the existing documentation if some steps are already described. -->

## Related issue(s)

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
