### PR TITLE
Improve Cloud Slack e2e test resiliency around Slack workspace connect

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - improve-slack-e2e-test-resiliency # TODO: To remove
   repository_dispatch:
     types: [ trigger-e2e-tests ]
 
@@ -30,240 +31,240 @@ jobs:
         run: |
           IMAGE_VERSION=$(git rev-parse --short HEAD)
           echo "versions={\"image-version\":[\"v9.99.9-dev\",\"0.0.0-${IMAGE_VERSION}\"]}" >> $GITHUB_OUTPUT
-  build:
-    needs: [extract-metadata]
-    strategy:
-      matrix: ${{ fromJson(needs.extract-metadata.outputs.versions) }}
-    runs-on: ubuntu-latest
-    env:
-      GO111MODULE: on
-      GOPATH: /home/runner/work/botkube
-      GOBIN: /home/runner/work/botkube/bin
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Docker Login
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          install-only: true
-          version: latest
-      - name: Run GoReleaser
-        run: |
-          make release-snapshot
-        env:
-          ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
-          GORELEASER_CURRENT_TAG: ${{ matrix.image-version }}
-          IMAGE_TAG: ${{ matrix.image-version }}
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: ${{ env.HELM_VERSION }}
-
-  integration-tests:
-    name: Integration tests
-    runs-on: ubuntu-latest
-    needs: [ build ]
-    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
-    permissions:
-      contents: read
-      packages: read
-
-    strategy:
-      # make the jobs independent
-      fail-fast: false
-
-      matrix:
-        integration:
-          - slack
-          - discord
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: ${{ env.HELM_VERSION }}
-
-      - name: Download k3d
-        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
-
-      - name: Create cluster to test ${{ matrix.integration }}
-        run: "k3d cluster create ${{ matrix.integration }}-test-cluster --wait --timeout=5m"
-
-      - name: Install Botkube to test ${{ matrix.integration }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
-        run: |
-          helm install botkube --namespace botkube ./helm/botkube --wait --create-namespace \
-           -f ./helm/botkube/e2e-test-values.yaml \
-           --set communications.default-group.slack.token="${SLACK_BOT_TOKEN}" \
-           --set communications.default-group.discord.token="${DISCORD_BOT_TOKEN}" \
-           --set communications.default-group.discord.botID="${DISCORD_BOT_ID}" \
-           --set image.registry="${IMAGE_REGISTRY}" \
-           --set image.repository="${IMAGE_REPOSITORY}" \
-           --set image.tag="${IMAGE_TAG}" \
-
-      - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          install-only: true
-          version: latest
-
-      - name: Build all plugins into dist directory
-        env:
-          # we hardcode plugins version, so it's predictable in e2e tests
-          GORELEASER_CURRENT_TAG: "v0.0.0-latest"
-          OUTPUT_MODE: "binary"
-          SINGLE_PLATFORM: "true"
-          PLUGIN_TARGETS: "kubernetes,kubectl,cm-watcher,echo,helm"
-        run: |
-          make build-plugins
-
-      - name: CLI Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            dist/botkube-cli_linux_amd64_v1/botkube
-          key: ${{ runner.os }}-botkube-cli
-
-      - name: Build CLI
-        run: make release-snapshot-cli
-
-      - name: Add Botkube CLI to env
-        run: |
-          echo CONFIG_PROVIDER_BOTKUBE_CLI_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
-
-      - name: Run ${{ matrix.integration }} tests
-        env:
-          SLACK_TESTER_APP_TOKEN: ${{ secrets.SLACK_TESTER_APP_TOKEN }}
-          SLACK_CLOUD_TESTER_APP_TOKEN: ${{ secrets.SLACK_CLOUD_TESTER_APP_TOKEN }}
-          SLACK_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
-          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
-          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
-          DISCORD_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
-          PLUGINS_BINARIES_DIRECTORY: ${{ github.workspace }}/plugin-dist
-          CONFIG_PROVIDER_API_KEY: ${{ secrets.CONFIG_PROVIDER_API_KEY }}
-          CONFIG_PROVIDER_ENDPOINT: ${{ secrets.CONFIG_PROVIDER_ENDPOINT }}
-          CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID: ${{ secrets.CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID }}
-          CONFIG_PROVIDER_IMAGE_REPOSITORY: ${{ env.IMAGE_REPOSITORY }}
-          CONFIG_PROVIDER_IMAGE_TAG: ${{ env.IMAGE_TAG }}
-          CONFIG_PROVIDER_HELM_REPO_DIRECTORY: ${{ github.workspace }}/helm
-        run: |
-          KUBECONFIG=$(k3d kubeconfig write ${{ matrix.integration }}-test-cluster) \
-            make test-integration-${{ matrix.integration }}
-
-  cli-migration-e2e:
-    name: CLI Migration E2E tests
-    runs-on: ubuntu-latest
-    needs: [ build ]
-    permissions:
-      contents: read
-      packages: read
-    concurrency:
-      group: cli-migration-e2e
-      cancel-in-progress: false
-    strategy:
-      fail-fast: false
-      matrix:
-        e2e:
-          - discord
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          install-only: true
-          version: latest
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-      - name: Run GoReleaser
-        run: make release-snapshot-cli
-      - name: Add botkube alias
-        run: |
-          echo BOTKUBE_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: ${{ env.HELM_VERSION }}
-      - name: Download k3d
-        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
-      - name: Create k3d cluster
-        run: "k3d cluster create cli-migration-e2e-cluster --wait --timeout=5m"
-      - name: Run e2e tests for botkube client
-        env:
-          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
-          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
-          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
-          BOTKUBE_CLOUD_DEV_GQL_ENDPOINT: ${{ secrets.BOTKUBE_CLOUD_DEV_GQL_ENDPOINT }}
-          BOTKUBE_CLOUD_DEV_REFRESH_TOKEN: ${{ secrets.BOTKUBE_CLOUD_DEV_REFRESH_TOKEN }}
-          BOTKUBE_CLOUD_DEV_AUTH0_CLIENT_ID: ${{ secrets.BOTKUBE_CLOUD_DEV_AUTH0_CLIENT_ID }}
-        run: |
-          KUBECONFIG=$(k3d kubeconfig write cli-migration-e2e-cluster) make test-cli-migration-e2e
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: screenshots_dump_${{github.sha}}
-          path: ${{ runner.temp }}/screenshots
-          retention-days: 5
-
-      - name: Dump cluster state
-        if: ${{ failure() }}
-        uses: ./.github/actions/dump-cluster
-
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        if: ${{ failure() }}
-        env:
-          SLACK_USERNAME: Botkube Cloud CI
-          SLACK_COLOR: 'red'
-          SLACK_TITLE: 'Message'
-          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
-          SLACK_MESSAGE: 'CLI Migration E2E tests failed :scream:'
-          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
-          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
-          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}
+#  build:
+#    needs: [extract-metadata]
+#    strategy:
+#      matrix: ${{ fromJson(needs.extract-metadata.outputs.versions) }}
+#    runs-on: ubuntu-latest
+#    env:
+#      GO111MODULE: on
+#      GOPATH: /home/runner/work/botkube
+#      GOBIN: /home/runner/work/botkube/bin
+#      DOCKER_CLI_EXPERIMENTAL: "enabled"
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#      - name: Setup Go
+#        uses: actions/setup-go@v4
+#        with:
+#          go-version-file: 'go.mod'
+#          cache: true
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@v3
+#      - name: Docker Login
+#        uses: docker/login-action@v1
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Install GoReleaser
+#        uses: goreleaser/goreleaser-action@v5
+#        with:
+#          install-only: true
+#          version: latest
+#      - name: Run GoReleaser
+#        run: |
+#          make release-snapshot
+#        env:
+#          ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
+#          GORELEASER_CURRENT_TAG: ${{ matrix.image-version }}
+#          IMAGE_TAG: ${{ matrix.image-version }}
+#      - name: Install Helm
+#        uses: azure/setup-helm@v3
+#        with:
+#          version: ${{ env.HELM_VERSION }}
+#
+#  integration-tests:
+#    name: Integration tests
+#    runs-on: ubuntu-latest
+#    needs: [ build ]
+#    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
+#    permissions:
+#      contents: read
+#      packages: read
+#
+#    strategy:
+#      # make the jobs independent
+#      fail-fast: false
+#
+#      matrix:
+#        integration:
+#          - slack
+#          - discord
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#        with:
+#          persist-credentials: false
+#
+#      - name: Setup Go
+#        uses: actions/setup-go@v4
+#        with:
+#          go-version-file: 'go.mod'
+#          cache: true
+#
+#      - name: Install Helm
+#        uses: azure/setup-helm@v3
+#        with:
+#          version: ${{ env.HELM_VERSION }}
+#
+#      - name: Download k3d
+#        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
+#
+#      - name: Create cluster to test ${{ matrix.integration }}
+#        run: "k3d cluster create ${{ matrix.integration }}-test-cluster --wait --timeout=5m"
+#
+#      - name: Install Botkube to test ${{ matrix.integration }}
+#        env:
+#          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+#          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+#          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
+#        run: |
+#          helm install botkube --namespace botkube ./helm/botkube --wait --create-namespace \
+#           -f ./helm/botkube/e2e-test-values.yaml \
+#           --set communications.default-group.slack.token="${SLACK_BOT_TOKEN}" \
+#           --set communications.default-group.discord.token="${DISCORD_BOT_TOKEN}" \
+#           --set communications.default-group.discord.botID="${DISCORD_BOT_ID}" \
+#           --set image.registry="${IMAGE_REGISTRY}" \
+#           --set image.repository="${IMAGE_REPOSITORY}" \
+#           --set image.tag="${IMAGE_TAG}" \
+#
+#      - name: Install GoReleaser
+#        uses: goreleaser/goreleaser-action@v5
+#        with:
+#          install-only: true
+#          version: latest
+#
+#      - name: Build all plugins into dist directory
+#        env:
+#          # we hardcode plugins version, so it's predictable in e2e tests
+#          GORELEASER_CURRENT_TAG: "v0.0.0-latest"
+#          OUTPUT_MODE: "binary"
+#          SINGLE_PLATFORM: "true"
+#          PLUGIN_TARGETS: "kubernetes,kubectl,cm-watcher,echo,helm"
+#        run: |
+#          make build-plugins
+#
+#      - name: CLI Cache
+#        uses: actions/cache@v3
+#        with:
+#          path: |
+#            ~/.cache/go-build
+#            ~/go/pkg/mod
+#            dist/botkube-cli_linux_amd64_v1/botkube
+#          key: ${{ runner.os }}-botkube-cli
+#
+#      - name: Build CLI
+#        run: make release-snapshot-cli
+#
+#      - name: Add Botkube CLI to env
+#        run: |
+#          echo CONFIG_PROVIDER_BOTKUBE_CLI_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
+#
+#      - name: Run ${{ matrix.integration }} tests
+#        env:
+#          SLACK_TESTER_APP_TOKEN: ${{ secrets.SLACK_TESTER_APP_TOKEN }}
+#          SLACK_CLOUD_TESTER_APP_TOKEN: ${{ secrets.SLACK_CLOUD_TESTER_APP_TOKEN }}
+#          SLACK_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
+#          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
+#          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+#          DISCORD_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
+#          PLUGINS_BINARIES_DIRECTORY: ${{ github.workspace }}/plugin-dist
+#          CONFIG_PROVIDER_API_KEY: ${{ secrets.CONFIG_PROVIDER_API_KEY }}
+#          CONFIG_PROVIDER_ENDPOINT: ${{ secrets.CONFIG_PROVIDER_ENDPOINT }}
+#          CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID: ${{ secrets.CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID }}
+#          CONFIG_PROVIDER_IMAGE_REPOSITORY: ${{ env.IMAGE_REPOSITORY }}
+#          CONFIG_PROVIDER_IMAGE_TAG: ${{ env.IMAGE_TAG }}
+#          CONFIG_PROVIDER_HELM_REPO_DIRECTORY: ${{ github.workspace }}/helm
+#        run: |
+#          KUBECONFIG=$(k3d kubeconfig write ${{ matrix.integration }}-test-cluster) \
+#            make test-integration-${{ matrix.integration }}
+#
+#  cli-migration-e2e:
+#    name: CLI Migration E2E tests
+#    runs-on: ubuntu-latest
+#    needs: [ build ]
+#    permissions:
+#      contents: read
+#      packages: read
+#    concurrency:
+#      group: cli-migration-e2e
+#      cancel-in-progress: false
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        e2e:
+#          - discord
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#        with:
+#          persist-credentials: false
+#      - name: Install GoReleaser
+#        uses: goreleaser/goreleaser-action@v5
+#        with:
+#          install-only: true
+#          version: latest
+#      - name: Setup Go
+#        uses: actions/setup-go@v4
+#        with:
+#          go-version-file: 'go.mod'
+#          cache: true
+#      - name: Run GoReleaser
+#        run: make release-snapshot-cli
+#      - name: Add botkube alias
+#        run: |
+#          echo BOTKUBE_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
+#      - name: Install Helm
+#        uses: azure/setup-helm@v3
+#        with:
+#          version: ${{ env.HELM_VERSION }}
+#      - name: Download k3d
+#        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
+#      - name: Create k3d cluster
+#        run: "k3d cluster create cli-migration-e2e-cluster --wait --timeout=5m"
+#      - name: Run e2e tests for botkube client
+#        env:
+#          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
+#          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+#          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+#          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
+#          BOTKUBE_CLOUD_DEV_GQL_ENDPOINT: ${{ secrets.BOTKUBE_CLOUD_DEV_GQL_ENDPOINT }}
+#          BOTKUBE_CLOUD_DEV_REFRESH_TOKEN: ${{ secrets.BOTKUBE_CLOUD_DEV_REFRESH_TOKEN }}
+#          BOTKUBE_CLOUD_DEV_AUTH0_CLIENT_ID: ${{ secrets.BOTKUBE_CLOUD_DEV_AUTH0_CLIENT_ID }}
+#        run: |
+#          KUBECONFIG=$(k3d kubeconfig write cli-migration-e2e-cluster) make test-cli-migration-e2e
+#
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@v3
+#        if: ${{ always() }}
+#        with:
+#          name: screenshots_dump_${{github.sha}}
+#          path: ${{ runner.temp }}/screenshots
+#          retention-days: 5
+#
+#      - name: Dump cluster state
+#        if: ${{ failure() }}
+#        uses: ./.github/actions/dump-cluster
+#
+#      - name: Slack Notification
+#        uses: rtCamp/action-slack-notify@v2
+#        if: ${{ failure() }}
+#        env:
+#          SLACK_USERNAME: Botkube Cloud CI
+#          SLACK_COLOR: 'red'
+#          SLACK_TITLE: 'Message'
+#          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
+#          SLACK_MESSAGE: 'CLI Migration E2E tests failed :scream:'
+#          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
+#          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
+#          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}
 
   cloud-slack-dev-e2e:
     name: Botkube Cloud Slack Dev E2E
     runs-on: ubuntu-latest
-    needs: [ build ]
+#    needs: [ build ]
     permissions:
       contents: read
       packages: read
@@ -313,15 +314,15 @@ jobs:
         if: ${{ failure() }}
         uses: ./.github/actions/dump-cluster
 
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        if: ${{ failure() }}
-        env:
-          SLACK_USERNAME: Botkube Cloud CI
-          SLACK_COLOR: 'red'
-          SLACK_TITLE: 'Message'
-          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
-          SLACK_MESSAGE: 'Cloud Slack Dev E2E tests failed :scream:'
-          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
-          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
-          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}
+#      - name: Slack Notification
+#        uses: rtCamp/action-slack-notify@v2
+#        if: ${{ failure() }}
+#        env:
+#          SLACK_USERNAME: Botkube Cloud CI
+#          SLACK_COLOR: 'red'
+#          SLACK_TITLE: 'Message'
+#          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
+#          SLACK_MESSAGE: 'Cloud Slack Dev E2E tests failed :scream:'
+#          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
+#          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
+#          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - improve-slack-e2e-test-resiliency # TODO: To remove
   repository_dispatch:
     types: [ trigger-e2e-tests ]
 
@@ -31,240 +30,240 @@ jobs:
         run: |
           IMAGE_VERSION=$(git rev-parse --short HEAD)
           echo "versions={\"image-version\":[\"v9.99.9-dev\",\"0.0.0-${IMAGE_VERSION}\"]}" >> $GITHUB_OUTPUT
-#  build:
-#    needs: [extract-metadata]
-#    strategy:
-#      matrix: ${{ fromJson(needs.extract-metadata.outputs.versions) }}
-#    runs-on: ubuntu-latest
-#    env:
-#      GO111MODULE: on
-#      GOPATH: /home/runner/work/botkube
-#      GOBIN: /home/runner/work/botkube/bin
-#      DOCKER_CLI_EXPERIMENTAL: "enabled"
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#      - name: Setup Go
-#        uses: actions/setup-go@v4
-#        with:
-#          go-version-file: 'go.mod'
-#          cache: true
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@v3
-#      - name: Docker Login
-#        uses: docker/login-action@v1
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.actor }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
-#      - name: Install GoReleaser
-#        uses: goreleaser/goreleaser-action@v5
-#        with:
-#          install-only: true
-#          version: latest
-#      - name: Run GoReleaser
-#        run: |
-#          make release-snapshot
-#        env:
-#          ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
-#          GORELEASER_CURRENT_TAG: ${{ matrix.image-version }}
-#          IMAGE_TAG: ${{ matrix.image-version }}
-#      - name: Install Helm
-#        uses: azure/setup-helm@v3
-#        with:
-#          version: ${{ env.HELM_VERSION }}
-#
-#  integration-tests:
-#    name: Integration tests
-#    runs-on: ubuntu-latest
-#    needs: [ build ]
-#    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
-#    permissions:
-#      contents: read
-#      packages: read
-#
-#    strategy:
-#      # make the jobs independent
-#      fail-fast: false
-#
-#      matrix:
-#        integration:
-#          - slack
-#          - discord
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#        with:
-#          persist-credentials: false
-#
-#      - name: Setup Go
-#        uses: actions/setup-go@v4
-#        with:
-#          go-version-file: 'go.mod'
-#          cache: true
-#
-#      - name: Install Helm
-#        uses: azure/setup-helm@v3
-#        with:
-#          version: ${{ env.HELM_VERSION }}
-#
-#      - name: Download k3d
-#        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
-#
-#      - name: Create cluster to test ${{ matrix.integration }}
-#        run: "k3d cluster create ${{ matrix.integration }}-test-cluster --wait --timeout=5m"
-#
-#      - name: Install Botkube to test ${{ matrix.integration }}
-#        env:
-#          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-#          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-#          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
-#        run: |
-#          helm install botkube --namespace botkube ./helm/botkube --wait --create-namespace \
-#           -f ./helm/botkube/e2e-test-values.yaml \
-#           --set communications.default-group.slack.token="${SLACK_BOT_TOKEN}" \
-#           --set communications.default-group.discord.token="${DISCORD_BOT_TOKEN}" \
-#           --set communications.default-group.discord.botID="${DISCORD_BOT_ID}" \
-#           --set image.registry="${IMAGE_REGISTRY}" \
-#           --set image.repository="${IMAGE_REPOSITORY}" \
-#           --set image.tag="${IMAGE_TAG}" \
-#
-#      - name: Install GoReleaser
-#        uses: goreleaser/goreleaser-action@v5
-#        with:
-#          install-only: true
-#          version: latest
-#
-#      - name: Build all plugins into dist directory
-#        env:
-#          # we hardcode plugins version, so it's predictable in e2e tests
-#          GORELEASER_CURRENT_TAG: "v0.0.0-latest"
-#          OUTPUT_MODE: "binary"
-#          SINGLE_PLATFORM: "true"
-#          PLUGIN_TARGETS: "kubernetes,kubectl,cm-watcher,echo,helm"
-#        run: |
-#          make build-plugins
-#
-#      - name: CLI Cache
-#        uses: actions/cache@v3
-#        with:
-#          path: |
-#            ~/.cache/go-build
-#            ~/go/pkg/mod
-#            dist/botkube-cli_linux_amd64_v1/botkube
-#          key: ${{ runner.os }}-botkube-cli
-#
-#      - name: Build CLI
-#        run: make release-snapshot-cli
-#
-#      - name: Add Botkube CLI to env
-#        run: |
-#          echo CONFIG_PROVIDER_BOTKUBE_CLI_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
-#
-#      - name: Run ${{ matrix.integration }} tests
-#        env:
-#          SLACK_TESTER_APP_TOKEN: ${{ secrets.SLACK_TESTER_APP_TOKEN }}
-#          SLACK_CLOUD_TESTER_APP_TOKEN: ${{ secrets.SLACK_CLOUD_TESTER_APP_TOKEN }}
-#          SLACK_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
-#          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
-#          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
-#          DISCORD_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
-#          PLUGINS_BINARIES_DIRECTORY: ${{ github.workspace }}/plugin-dist
-#          CONFIG_PROVIDER_API_KEY: ${{ secrets.CONFIG_PROVIDER_API_KEY }}
-#          CONFIG_PROVIDER_ENDPOINT: ${{ secrets.CONFIG_PROVIDER_ENDPOINT }}
-#          CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID: ${{ secrets.CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID }}
-#          CONFIG_PROVIDER_IMAGE_REPOSITORY: ${{ env.IMAGE_REPOSITORY }}
-#          CONFIG_PROVIDER_IMAGE_TAG: ${{ env.IMAGE_TAG }}
-#          CONFIG_PROVIDER_HELM_REPO_DIRECTORY: ${{ github.workspace }}/helm
-#        run: |
-#          KUBECONFIG=$(k3d kubeconfig write ${{ matrix.integration }}-test-cluster) \
-#            make test-integration-${{ matrix.integration }}
-#
-#  cli-migration-e2e:
-#    name: CLI Migration E2E tests
-#    runs-on: ubuntu-latest
-#    needs: [ build ]
-#    permissions:
-#      contents: read
-#      packages: read
-#    concurrency:
-#      group: cli-migration-e2e
-#      cancel-in-progress: false
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        e2e:
-#          - discord
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#        with:
-#          persist-credentials: false
-#      - name: Install GoReleaser
-#        uses: goreleaser/goreleaser-action@v5
-#        with:
-#          install-only: true
-#          version: latest
-#      - name: Setup Go
-#        uses: actions/setup-go@v4
-#        with:
-#          go-version-file: 'go.mod'
-#          cache: true
-#      - name: Run GoReleaser
-#        run: make release-snapshot-cli
-#      - name: Add botkube alias
-#        run: |
-#          echo BOTKUBE_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
-#      - name: Install Helm
-#        uses: azure/setup-helm@v3
-#        with:
-#          version: ${{ env.HELM_VERSION }}
-#      - name: Download k3d
-#        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
-#      - name: Create k3d cluster
-#        run: "k3d cluster create cli-migration-e2e-cluster --wait --timeout=5m"
-#      - name: Run e2e tests for botkube client
-#        env:
-#          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
-#          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-#          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
-#          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
-#          BOTKUBE_CLOUD_DEV_GQL_ENDPOINT: ${{ secrets.BOTKUBE_CLOUD_DEV_GQL_ENDPOINT }}
-#          BOTKUBE_CLOUD_DEV_REFRESH_TOKEN: ${{ secrets.BOTKUBE_CLOUD_DEV_REFRESH_TOKEN }}
-#          BOTKUBE_CLOUD_DEV_AUTH0_CLIENT_ID: ${{ secrets.BOTKUBE_CLOUD_DEV_AUTH0_CLIENT_ID }}
-#        run: |
-#          KUBECONFIG=$(k3d kubeconfig write cli-migration-e2e-cluster) make test-cli-migration-e2e
-#
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@v3
-#        if: ${{ always() }}
-#        with:
-#          name: screenshots_dump_${{github.sha}}
-#          path: ${{ runner.temp }}/screenshots
-#          retention-days: 5
-#
-#      - name: Dump cluster state
-#        if: ${{ failure() }}
-#        uses: ./.github/actions/dump-cluster
-#
-#      - name: Slack Notification
-#        uses: rtCamp/action-slack-notify@v2
-#        if: ${{ failure() }}
-#        env:
-#          SLACK_USERNAME: Botkube Cloud CI
-#          SLACK_COLOR: 'red'
-#          SLACK_TITLE: 'Message'
-#          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
-#          SLACK_MESSAGE: 'CLI Migration E2E tests failed :scream:'
-#          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
-#          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
-#          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}
+  build:
+    needs: [extract-metadata]
+    strategy:
+      matrix: ${{ fromJson(needs.extract-metadata.outputs.versions) }}
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+      GOPATH: /home/runner/work/botkube
+      GOBIN: /home/runner/work/botkube/bin
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Docker Login
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          install-only: true
+          version: latest
+      - name: Run GoReleaser
+        run: |
+          make release-snapshot
+        env:
+          ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
+          GORELEASER_CURRENT_TAG: ${{ matrix.image-version }}
+          IMAGE_TAG: ${{ matrix.image-version }}
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+  integration-tests:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
+    permissions:
+      contents: read
+      packages: read
+
+    strategy:
+      # make the jobs independent
+      fail-fast: false
+
+      matrix:
+        integration:
+          - slack
+          - discord
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Download k3d
+        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
+
+      - name: Create cluster to test ${{ matrix.integration }}
+        run: "k3d cluster create ${{ matrix.integration }}-test-cluster --wait --timeout=5m"
+
+      - name: Install Botkube to test ${{ matrix.integration }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
+        run: |
+          helm install botkube --namespace botkube ./helm/botkube --wait --create-namespace \
+           -f ./helm/botkube/e2e-test-values.yaml \
+           --set communications.default-group.slack.token="${SLACK_BOT_TOKEN}" \
+           --set communications.default-group.discord.token="${DISCORD_BOT_TOKEN}" \
+           --set communications.default-group.discord.botID="${DISCORD_BOT_ID}" \
+           --set image.registry="${IMAGE_REGISTRY}" \
+           --set image.repository="${IMAGE_REPOSITORY}" \
+           --set image.tag="${IMAGE_TAG}" \
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          install-only: true
+          version: latest
+
+      - name: Build all plugins into dist directory
+        env:
+          # we hardcode plugins version, so it's predictable in e2e tests
+          GORELEASER_CURRENT_TAG: "v0.0.0-latest"
+          OUTPUT_MODE: "binary"
+          SINGLE_PLATFORM: "true"
+          PLUGIN_TARGETS: "kubernetes,kubectl,cm-watcher,echo,helm"
+        run: |
+          make build-plugins
+
+      - name: CLI Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            dist/botkube-cli_linux_amd64_v1/botkube
+          key: ${{ runner.os }}-botkube-cli
+
+      - name: Build CLI
+        run: make release-snapshot-cli
+
+      - name: Add Botkube CLI to env
+        run: |
+          echo CONFIG_PROVIDER_BOTKUBE_CLI_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
+
+      - name: Run ${{ matrix.integration }} tests
+        env:
+          SLACK_TESTER_APP_TOKEN: ${{ secrets.SLACK_TESTER_APP_TOKEN }}
+          SLACK_CLOUD_TESTER_APP_TOKEN: ${{ secrets.SLACK_CLOUD_TESTER_APP_TOKEN }}
+          SLACK_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
+          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          DISCORD_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
+          PLUGINS_BINARIES_DIRECTORY: ${{ github.workspace }}/plugin-dist
+          CONFIG_PROVIDER_API_KEY: ${{ secrets.CONFIG_PROVIDER_API_KEY }}
+          CONFIG_PROVIDER_ENDPOINT: ${{ secrets.CONFIG_PROVIDER_ENDPOINT }}
+          CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID: ${{ secrets.CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID }}
+          CONFIG_PROVIDER_IMAGE_REPOSITORY: ${{ env.IMAGE_REPOSITORY }}
+          CONFIG_PROVIDER_IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          CONFIG_PROVIDER_HELM_REPO_DIRECTORY: ${{ github.workspace }}/helm
+        run: |
+          KUBECONFIG=$(k3d kubeconfig write ${{ matrix.integration }}-test-cluster) \
+            make test-integration-${{ matrix.integration }}
+
+  cli-migration-e2e:
+    name: CLI Migration E2E tests
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    permissions:
+      contents: read
+      packages: read
+    concurrency:
+      group: cli-migration-e2e
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        e2e:
+          - discord
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          install-only: true
+          version: latest
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Run GoReleaser
+        run: make release-snapshot-cli
+      - name: Add botkube alias
+        run: |
+          echo BOTKUBE_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: ${{ env.HELM_VERSION }}
+      - name: Download k3d
+        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
+      - name: Create k3d cluster
+        run: "k3d cluster create cli-migration-e2e-cluster --wait --timeout=5m"
+      - name: Run e2e tests for botkube client
+        env:
+          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
+          BOTKUBE_CLOUD_DEV_GQL_ENDPOINT: ${{ secrets.BOTKUBE_CLOUD_DEV_GQL_ENDPOINT }}
+          BOTKUBE_CLOUD_DEV_REFRESH_TOKEN: ${{ secrets.BOTKUBE_CLOUD_DEV_REFRESH_TOKEN }}
+          BOTKUBE_CLOUD_DEV_AUTH0_CLIENT_ID: ${{ secrets.BOTKUBE_CLOUD_DEV_AUTH0_CLIENT_ID }}
+        run: |
+          KUBECONFIG=$(k3d kubeconfig write cli-migration-e2e-cluster) make test-cli-migration-e2e
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: screenshots_dump_${{github.sha}}
+          path: ${{ runner.temp }}/screenshots
+          retention-days: 5
+
+      - name: Dump cluster state
+        if: ${{ failure() }}
+        uses: ./.github/actions/dump-cluster
+
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ failure() }}
+        env:
+          SLACK_USERNAME: Botkube Cloud CI
+          SLACK_COLOR: 'red'
+          SLACK_TITLE: 'Message'
+          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
+          SLACK_MESSAGE: 'CLI Migration E2E tests failed :scream:'
+          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
+          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}
 
   cloud-slack-dev-e2e:
     name: Botkube Cloud Slack Dev E2E
     runs-on: ubuntu-latest
-#    needs: [ build ]
+    needs: [ build ]
     permissions:
       contents: read
       packages: read
@@ -314,15 +313,15 @@ jobs:
         if: ${{ failure() }}
         uses: ./.github/actions/dump-cluster
 
-#      - name: Slack Notification
-#        uses: rtCamp/action-slack-notify@v2
-#        if: ${{ failure() }}
-#        env:
-#          SLACK_USERNAME: Botkube Cloud CI
-#          SLACK_COLOR: 'red'
-#          SLACK_TITLE: 'Message'
-#          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
-#          SLACK_MESSAGE: 'Cloud Slack Dev E2E tests failed :scream:'
-#          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
-#          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
-#          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ failure() }}
+        env:
+          SLACK_USERNAME: Botkube Cloud CI
+          SLACK_COLOR: 'red'
+          SLACK_TITLE: 'Message'
+          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
+          SLACK_MESSAGE: 'Cloud Slack Dev E2E tests failed :scream:'
+          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
+          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}

--- a/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
+++ b/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
@@ -267,19 +267,17 @@ func TestCloudSlackE2E(t *testing.T) {
 			botkubePage.MustElementR("div.ant-result-title", "Organization Already Connected!")
 		} else {
 			t.Log("Finalizing connection...")
-
-			prevSlackConnectURL := botkubePage.MustInfo().URL
-			t.Logf("Removing the auto-close query parameter from %q...", prevSlackConnectURL)
-			slackConnectURL := deleteAutoCloseQueryParam(t, prevSlackConnectURL)
-			t.Logf("Navigating to %q...", slackConnectURL)
-			botkubePage.MustNavigate(slackConnectURL).MustWaitLoad()
 			screenshotIfShould(t, cfg, botkubePage)
 			botkubePage.MustElement("a.logo-link")
 			screenshotIfShould(t, cfg, botkubePage)
 			botkubePage.MustElementR("button > span", "Connect").MustParent().MustClick()
 			screenshotIfShould(t, cfg, botkubePage)
 			// detect homepage
-			botkubePage.MustElementR(".ant-layout-content p", "All Botkube installations managed by Botkube Cloud.")
+			_, err := botkubePage.ElementR(".ant-layout-content p", "All Botkube installations managed by Botkube Cloud.")
+			assert.NoError(t, err) // fail the test, but move on: capture the screenshot and try to disconnect Slack workspace later
+			if err != nil {
+				screenshotIfShould(t, cfg, botkubePage)
+			}
 		}
 	})
 
@@ -685,17 +683,6 @@ func appendOrgIDQueryParam(t *testing.T, inURL, orgID string) string {
 	queryValues := parsedURL.Query()
 	queryValues.Set("organizationId", orgID)
 	parsedURL.RawQuery = queryValues.Encode()
-
-	return parsedURL.String()
-}
-
-func deleteAutoCloseQueryParam(t *testing.T, inURL string) string {
-	parsedURL, err := url.Parse(inURL)
-	require.NoError(t, err)
-
-	queryParams := parsedURL.Query()
-	queryParams.Del("close-tab")
-	parsedURL.RawQuery = queryParams.Encode()
 
 	return parsedURL.String()
 }

--- a/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
+++ b/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
@@ -267,9 +267,16 @@ func TestCloudSlackE2E(t *testing.T) {
 			botkubePage.MustElementR("div.ant-result-title", "Organization Already Connected!")
 		} else {
 			t.Log("Finalizing connection...")
-			botkubePage.MustElementR("button > span", "Connect").MustParent().MustClick()
-			// detect homepage
+
+			t.Log("Removing the auto-close query parameter...")
+			slackConnectURL := deleteAutoCloseQueryParam(t, botkubePage.MustInfo().URL)
+			botkubePage.MustNavigate(slackConnectURL).MustWaitLoad()
 			screenshotIfShould(t, cfg, botkubePage)
+			botkubePage.MustElement("a.logo-link")
+			screenshotIfShould(t, cfg, botkubePage)
+			botkubePage.MustElementR("button > span", "Connect").MustParent().MustClick()
+			screenshotIfShould(t, cfg, botkubePage)
+			// detect homepage
 			botkubePage.MustElementR(".ant-layout-content p", "All Botkube installations managed by Botkube Cloud.")
 		}
 	})
@@ -676,6 +683,17 @@ func appendOrgIDQueryParam(t *testing.T, inURL, orgID string) string {
 	queryValues := parsedURL.Query()
 	queryValues.Set("organizationId", orgID)
 	parsedURL.RawQuery = queryValues.Encode()
+
+	return parsedURL.String()
+}
+
+func deleteAutoCloseQueryParam(t *testing.T, inURL string) string {
+	parsedURL, err := url.Parse(inURL)
+	require.NoError(t, err)
+
+	queryParams := parsedURL.Query()
+	queryParams.Del("close-tab")
+	parsedURL.RawQuery = queryParams.Encode()
 
 	return parsedURL.String()
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Improve Cloud Slack e2e test resiliency

After connecting Slack workspace, the homepage sometimes isn't able to fully load. I'm not sure why, that's why this PR introduces:
- screenshot after connecting Slack workspace, when homepage can't be loaded
- continuing the tests with an error, to make sure the Slack workspace is properly disconnected

## Testing

No need - CI verifies it:
- https://github.com/kubeshop/botkube/actions/runs/7556642651/job/20574105015?pr=1352
- https://github.com/kubeshop/botkube/actions/runs/7556642651/attempts/1