### PR TITLE
Fix Botkube version constraint during migration

### DIFF
--- a/cmd/cli/docs/botkube_migrate.md
+++ b/cmd/cli/docs/botkube_migrate.md
@@ -46,7 +46,7 @@ botkube migrate [OPTIONS] [flags]
       --cloud-env-endpoint string            Endpoint environment variable name specified under Deployment for cloud installation. (default "CONFIG_PROVIDER_ENDPOINT")
       --cloud-env-id string                  Identifier environment variable name specified under Deployment for cloud installation. (default "CONFIG_PROVIDER_IDENTIFIER")
   -h, --help                                 help for migrate
-      --image-tag string                     Botkube image tag, possible values latest, v1.2.0, ...
+      --image-tag string                     Botkube image tag, e.g. "latest" or "v1.7.0"
       --instance-name string                 Botkube Cloud Instance name that will be created
       --kubeconfig string                    Paths to a kubeconfig. Only required if out-of-cluster.
   -l, --label string                         Label used for identifying the Botkube pod (default "app=botkube")

--- a/test/e2e/migration_test.go
+++ b/test/e2e/migration_test.go
@@ -36,6 +36,7 @@ const (
 	--set communications.default-group.discord.token=%s \
 	--set settings.clusterName=%s \
 	--set executors.k8s-default-tools.botkube/kubectl.enabled=true \
+	--set executors.k8s-default-tools.botkube/helm.enabled=true \
 	--set analytics.disable=true \
 	--set image.tag=v9.99.9-dev \
 	--set plugins.repositories.botkube.url=https://storage.googleapis.com/botkube-plugins-latest/plugins-index.yaml \
@@ -385,6 +386,14 @@ func assertPlugins(t *testing.T, actual []*gqlModel.Plugin) {
 			Type:              "EXECUTOR",
 			ConfigurationName: "k8s-default-tools",
 			Configuration:     "{\"defaultNamespace\":\"default\"}",
+			Rbac:              defaultRBAC,
+		},
+		{
+			Name:              "botkube/helm",
+			DisplayName:       "botkube/helm",
+			Type:              "EXECUTOR",
+			ConfigurationName: "k8s-default-tools",
+			Configuration:     "{\"defaultNamespace\":\"default\",\"helmCacheDir\":\"/tmp/helm/.cache\",\"helmConfigDir\":\"/tmp/helm/\",\"helmDriver\":\"secret\"}",
 			Rbac:              defaultRBAC,
 		},
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix Botkube version constraint during migration
- Update E2E migration test to cover the case for two executors under executor config group

The actual issue:
```
   FATA while running application: while merging app configuration: found critical validation errors: 3 errors occurred:
        * Key: 'Config.Actions[show-logs-on-error].Bindings.k8s-default-tools_jJkwz' 'k8s-default-tools_jJkwz' binding not defined in Config.Executors
        * Key: 'Config.Actions[describe-created-resource].Bindings.k8s-default-tools_jJkwz' 'k8s-default-tools_jJkwz' binding not defined in Config.Executors
```
has been resolved on Cloud side.

## Testing

Test this against Botkube Cloud dev setup.

Check out the PR and build the latest CLI:

```bash
export IMAGE_TAG=v9.99.9-dev
make release-snapshot-cli
chmod +x ./dist/botkube-cli_darwin_amd64_v1/botkube && cp ./dist/botkube-cli_darwin_amd64_v1/botkube /usr/local/bin/botkube
```

Then, install Botkube in your k3d cluster

**Option 1:** Without actions
```bash
export ALLOW_KUBECTL=true
export ALLOW_HELM=true
export SLACK_CHANNEL_NAME=botkube-demo \
export SLACK_API_APP_TOKEN=xapp-... \
export SLACK_API_BOT_TOKEN=xoxb-... \
export CLUSTER_NAME=dev
botkube install --version 1.7.0 \
--set communications.default-group.socketSlack.enabled=true \
--set communications.default-group.socketSlack.channels.default.name=${SLACK_CHANNEL_NAME} \
--set communications.default-group.socketSlack.appToken=${SLACK_API_APP_TOKEN} \
--set communications.default-group.socketSlack.botToken=${SLACK_API_BOT_TOKEN} \
--set settings.clusterName=${CLUSTER_NAME} \
--set 'executors.k8s-default-tools.botkube/kubectl.enabled'=${ALLOW_KUBECTL} \
--set 'executors.k8s-default-tools.botkube/helm.enabled'=${ALLOW_HELM}
```

**Option 2: With actions**
```bash
export ALLOW_KUBECTL=true
export ALLOW_HELM=true
export SLACK_CHANNEL_NAME=botkube-demo \
export SLACK_API_APP_TOKEN=xapp-... \
export SLACK_API_BOT_TOKEN=xoxb-... \
export CLUSTER_NAME=dev
botkube install --version 1.7.0 \
--set communications.default-group.socketSlack.enabled=true \
--set communications.default-group.socketSlack.channels.default.name=${SLACK_CHANNEL_NAME} \
--set communications.default-group.socketSlack.appToken=${SLACK_API_APP_TOKEN} \
--set communications.default-group.socketSlack.botToken=${SLACK_API_BOT_TOKEN} \
--set "communications.default-group.socketSlack.channels.default.bindings.sources={k8s-err-with-logs-events,k8s-create-events}" \
--set settings.clusterName=${CLUSTER_NAME} \
--set 'executors.k8s-default-tools.botkube/kubectl.enabled'=${ALLOW_KUBECTL} \
--set 'executors.k8s-default-tools.botkube/helm.enabled'=${ALLOW_HELM} \
--set 'actions.describe-created-resource.enabled=true' \
--set 'actions.show-logs-on-error.enabled=true'
```

Migrate it:
```bash
botkube login --cloud-dashboard-url http://localhost:3000
botkube migrate --cloud-api-url http://host.k3d.internal:8080/graphql --cloud-dashboard-url http://localhost:3000
```

After running botkube, run:
```
@Botkube list executors
```
and see two executors there instead of one (that was a bug).

## Related issue(s)

Resolves https://github.com/kubeshop/botkube/issues/1321
