### PR TITLE
Fix Helm chart upgrade when using existing secret

### DIFF
--- a/helm/botkube/templates/persistent-config.yaml
+++ b/helm/botkube/templates/persistent-config.yaml
@@ -3,7 +3,8 @@
 {{- $communications := .Values.communications }}
 {{- if .Values.existingCommunicationsSecretName }}
   {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.existingCommunicationsSecretName | default dict  }}
-  {{- $data := b64dec (index $secret.data "comm_config.yaml") -}}
+  {{- $secretData := $secret.data | default dict -}}
+  {{- $data := b64dec (index $secretData "comm_config.yaml" | default "") -}}
   {{- $dataYaml := $data | fromYaml -}}
   {{- $communications =  $dataYaml.communications }}
 {{- end }}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Bug in the Helm chart when using existing secret

`Error: template: sre-botkube/charts/botkube/templates/persistent-config.yaml:6:23: executing "sre-botkube/charts/botkube/templates/persistent-config.yaml" at <index $secret.data "comm_config.yaml">: error calling index: index of untyped nil`

## Related issue(s)

Fixes #1376.