### PR TITLE
Stop building multi arch binaries for cli snapshot

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -159,7 +159,7 @@ jobs:
           key: ${{ runner.os }}-botkube-cli
 
       - name: Build CLI
-        run: make release-snapshot-cli
+        run: make build-single-arch-cli
 
       - name: Add Botkube CLI to env
         run: |
@@ -225,7 +225,7 @@ jobs:
           access_token: ${{ secrets.E2E_TEST_GH_DEV_ACCOUNT_PAT }}
           username: ${{ env.GIT_USER }}
       - name: Run GoReleaser
-        run: make release-snapshot-cli
+        run: make build-single-arch-cli
       - name: Add botkube alias
         run: |
           echo BOTKUBE_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -273,7 +273,7 @@ jobs:
           key: ${{ runner.os }}-botkube-cli
 
       - name: Build CLI
-        run: make release-snapshot-cli
+        run: make build-single-arch-cli
 
       - name: Add Botkube CLI to env
         run: |

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,11 @@ container-image-single: pre-build
 release-snapshot:
 	@./hack/goreleaser.sh release_snapshot
 
+build-single-arch-cli:
+	@./hack/goreleaser.sh build_single_arch_cli
+
 release-snapshot-cli:
-	@./hack/goreleaser.sh release_snapshot_cli
+	@./hack/goreleaser.sh build_single_arch_cli
 
 # Build project and save images with IMAGE_TAG tag
 save-images:

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -43,10 +43,9 @@ release_snapshot() {
     docker manifest push ${IMAGE_REGISTRY}/${CFG_EXPORTER_IMAGE_REPOSITORY}:${GORELEASER_CURRENT_TAG}
 }
 
-release_snapshot_cli() {
-  prepare
+build_single_arch_cli() {
   export GORELEASER_CURRENT_TAG=v9.99.9-dev
-  goreleaser build --clean --snapshot --id botkube-cli
+  goreleaser build --clean --snapshot --id botkube-cli --single-target
 }
 
 save_images() {
@@ -247,7 +246,7 @@ build_single() {
 
 usage() {
   cat <<EOM
-Usage: ${0} [build|release|release_snapshot|release_snapshot_cli]
+Usage: ${0} [build|release|release_snapshot|build_single_arch_cli]
 Where,
   build: Builds project with goreleaser without pushing images.
   release_snapshot: Builds project without publishing release. It builds and pushes Botkube image with v9.99.9-dev image tag.
@@ -272,8 +271,8 @@ build_single)
 release_snapshot)
   release_snapshot
   ;;
-release_snapshot_cli)
-  release_snapshot_cli
+build_single_arch_cli)
+  build_single_arch_cli
   ;;
 save_images)
   save_images


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Stop building multi arch binaries for CLI snapshot. For some reason, we built multi arch even though it's not needed and just make the e2e test longer.

