### PR TITLE
Ignore upgrade checker error

### DIFF
--- a/cmd/botkube-agent/main.go
+++ b/cmd/botkube-agent/main.go
@@ -381,7 +381,12 @@ func run(ctx context.Context) (err error) {
 		)
 		errGroup.Go(func() error {
 			defer analytics.ReportPanicIfOccurs(logger, analyticsReporter)
-			return upgradeChecker.Run(ctx)
+			err := upgradeChecker.Run(ctx)
+			if err != nil {
+				// we ignore error to make sure that upgrade checker does not stop the agent
+				logger.WithError(err).Errorf("Failed to notify about upgrade")
+			}
+			return nil
 		})
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Ignore upgrade checker error, otherwise engine cannot start until e.g. rate limit is reset:
    ```
    [OS]     https://api.github.com/repos/kubeshop/botkube/releases/latest: 403 API rate limit exceeded for 188.147.12.104. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 48m53s]
    ```


This can be done using HEAD request, that doesn't count against rate limits, I can do it in the follow-up, see example: https://github.com/mszostok/version/blob/a69cf43b345ccd616da915912e2dc9deb8bfc992/upgrade/github/head_fetch.go#L23-L54