### PR TITLE
Improve resilience of E2E and integration tests

### DIFF
--- a/.github/actions/cloud-slack-e2e/action.yaml
+++ b/.github/actions/cloud-slack-e2e/action.yaml
@@ -110,6 +110,8 @@ runs:
     - name: Dump cluster state
       if: ${{ failure() }}
       uses: ./.github/actions/dump-cluster
+      with:
+        name: cloud-slack-e2e
 
     - name: Detect failed jobs
       if: ${{ failure() }}

--- a/.github/actions/cloud-slack-e2e/action.yaml
+++ b/.github/actions/cloud-slack-e2e/action.yaml
@@ -125,15 +125,15 @@ runs:
 
         echo "footer=${FOOTER}" >> $GITHUB_OUTPUT
 
-#    - name: Slack Notification
-#      uses: rtCamp/action-slack-notify@v2
-#      if: ${{ failure() }}
-#      env:
-#        SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
-#        SLACK_USERNAME: Botkube Cloud CI
-#        SLACK_COLOR: 'red'
-#        SLACK_TITLE: 'Message'
-#        SLACK_MESSAGE: "Cloud Slack ${{ inputs.e2e_type }} E2E tests failed :scream:"
-#        SLACK_ICON_EMOJI: ':this-is-fine-fire:'
-#        SLACK_FOOTER: ${{ steps.footer.outputs.footer }}
-#        SLACK_WEBHOOK: ${{ inputs.slack_alerts_webhook }}
+    - name: Slack Notification
+      uses: rtCamp/action-slack-notify@v2
+      if: ${{ failure() }}
+      env:
+        SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
+        SLACK_USERNAME: Botkube Cloud CI
+        SLACK_COLOR: 'red'
+        SLACK_TITLE: 'Message'
+        SLACK_MESSAGE: "Cloud Slack ${{ inputs.e2e_type }} E2E tests failed :scream:"
+        SLACK_ICON_EMOJI: ':this-is-fine-fire:'
+        SLACK_FOOTER: ${{ steps.footer.outputs.footer }}
+        SLACK_WEBHOOK: ${{ inputs.slack_alerts_webhook }}

--- a/.github/actions/cloud-slack-e2e/action.yaml
+++ b/.github/actions/cloud-slack-e2e/action.yaml
@@ -123,15 +123,15 @@ runs:
 
         echo "footer=${FOOTER}" >> $GITHUB_OUTPUT
 
-    - name: Slack Notification
-      uses: rtCamp/action-slack-notify@v2
-      if: ${{ failure() }}
-      env:
-        SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
-        SLACK_USERNAME: Botkube Cloud CI
-        SLACK_COLOR: 'red'
-        SLACK_TITLE: 'Message'
-        SLACK_MESSAGE: "Cloud Slack ${{ inputs.e2e_type }} E2E tests failed :scream:"
-        SLACK_ICON_EMOJI: ':this-is-fine-fire:'
-        SLACK_FOOTER: ${{ steps.footer.outputs.footer }}
-        SLACK_WEBHOOK: ${{ inputs.slack_alerts_webhook }}
+#    - name: Slack Notification
+#      uses: rtCamp/action-slack-notify@v2
+#      if: ${{ failure() }}
+#      env:
+#        SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
+#        SLACK_USERNAME: Botkube Cloud CI
+#        SLACK_COLOR: 'red'
+#        SLACK_TITLE: 'Message'
+#        SLACK_MESSAGE: "Cloud Slack ${{ inputs.e2e_type }} E2E tests failed :scream:"
+#        SLACK_ICON_EMOJI: ':this-is-fine-fire:'
+#        SLACK_FOOTER: ${{ steps.footer.outputs.footer }}
+#        SLACK_WEBHOOK: ${{ inputs.slack_alerts_webhook }}

--- a/.github/actions/dump-cluster/action.yaml
+++ b/.github/actions/dump-cluster/action.yaml
@@ -1,6 +1,11 @@
 name: Dump cluster state
 description: "Creates an artifacts with cluster dump"
 
+inputs:
+  name:
+    description: "Cluster name"
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -17,6 +22,6 @@ runs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: cluster_dump_${{github.sha}}
+        name: cluster_dump_${{github.sha}}_${{ inputs.name }}
         path: "output"
         retention-days: 5 # Default 90 days

--- a/.github/actions/dump-cluster/action.yaml
+++ b/.github/actions/dump-cluster/action.yaml
@@ -20,7 +20,7 @@ runs:
         echo "Dumping cluster info into ${LOGS_DIR}"
         kubectl cluster-info dump --all-namespaces --output-directory="${LOGS_DIR}"
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: cluster_dump_${{github.sha}}_${{ inputs.name }}
         path: "output"

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -16,201 +16,201 @@ env:
   GIT_USER: botkube-dev
 
 jobs:
-  extract-metadata:
-    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
-    runs-on: ubuntu-latest
-    outputs:
-      versions: ${{ steps.extract-version.outputs.versions }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Extract version
-        id: extract-version
-        run: |
-          IMAGE_VERSION=$(git rev-parse --short HEAD)
-          echo "versions={\"image-version\":[\"v9.99.9-dev\",\"0.0.0-${IMAGE_VERSION}\"]}" >> $GITHUB_OUTPUT
-  build:
-    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
-    needs: [extract-metadata]
-    strategy:
-      matrix: ${{ fromJson(needs.extract-metadata.outputs.versions) }}
-    runs-on: ubuntu-latest
-    env:
-      GO111MODULE: on
-      GOPATH: /home/runner/work/botkube
-      GOBIN: /home/runner/work/botkube/bin
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Docker Login
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          install-only: true
-          version: latest
-      - name: Run GoReleaser
-        run: |
-          make release-snapshot
-        env:
-          ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
-          GORELEASER_CURRENT_TAG: ${{ matrix.image-version }}
-          IMAGE_TAG: ${{ matrix.image-version }}
-
-  integration-tests:
-    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
-    name: Integration tests
-    runs-on: ubuntu-latest
-    needs: [ build ]
-    permissions:
-      contents: read
-      packages: read
-
-    strategy:
-      # make the jobs independent
-      fail-fast: false
-
-      matrix:
-        integration:
-          - slack
-          - discord
-          - teams
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Go modules
-        uses: ./.github/actions/setup-go-mod-private
-        with:
-          access_token: ${{ secrets.E2E_TEST_GH_DEV_ACCOUNT_PAT }}
-          username: ${{ env.GIT_USER }}
-
-      - name: Pub/Sub auth
-        uses: 'google-github-actions/auth@v1'
-        if: matrix.integration == 'teams'
-        with:
-          credentials_json: ${{ secrets.E2E_TEST_GCP_PUB_SUB_CREDENTIALS }}
-
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: ${{ env.HELM_VERSION }}
-
-      - name: Download k3d
-        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
-
-      - name: Create cluster to test ${{ matrix.integration }}
-        run: "k3d cluster create ${{ matrix.integration }}-test-cluster --wait --timeout=5m"
-
-      - name: Install Botkube locally via helm
-        if: matrix.integration == 'discord'
-        env:
-          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
-        run: |
-          helm install botkube --namespace botkube ./helm/botkube --wait --create-namespace \
-           -f ./helm/botkube/e2e-test-values.yaml \
-           --set communications.default-group.discord.token="${DISCORD_BOT_TOKEN}" \
-           --set communications.default-group.discord.botID="${DISCORD_BOT_ID}" \
-           --set image.registry="${IMAGE_REGISTRY}" \
-           --set image.repository="${IMAGE_REPOSITORY}" \
-           --set image.tag="${IMAGE_TAG}" \
-
-      - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          install-only: true
-          version: latest
-
-      - name: Build all plugins into dist directory
-        env:
-          # we hardcode plugins version, so it's predictable in e2e tests
-          GORELEASER_CURRENT_TAG: "v0.0.0-latest"
-          OUTPUT_MODE: "binary"
-          SINGLE_PLATFORM: "true"
-          PLUGIN_TARGETS: "kubernetes,kubectl,cm-watcher,echo,helm"
-        run: |
-          make build-plugins
-
-      - name: CLI Cache
-        if: matrix.integration != 'discord'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            dist/botkube-cli_linux_amd64_v1/botkube
-          key: ${{ runner.os }}-botkube-cli
-
-      - name: Build CLI
-        if: matrix.integration != 'discord'
-        run: make build-single-arch-cli
-
-      - name: Add Botkube CLI to env
-        run: |
-          echo CONFIG_PROVIDER_BOTKUBE_CLI_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
-
-      - name: Run ${{ matrix.integration }} tests
-        env:
-          SLACK_TESTER_APP_TOKEN: ${{ secrets.SLACK_TESTER_APP_TOKEN }}
-          SLACK_CLOUD_TESTER_APP_TOKEN: ${{ secrets.SLACK_CLOUD_TESTER_APP_TOKEN }}
-          SLACK_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
-
-          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
-          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
-          DISCORD_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
-
-          TEAMS_BOT_TESTER_APP_ID: ${{ secrets.TEAMS_BOT_TESTER_APP_ID }}
-          TEAMS_BOT_TESTER_APP_PASSWORD: ${{ secrets.TEAMS_BOT_TESTER_APP_PASSWORD }}
-          TEAMS_ORGANIZATION_TEAM_ID: ${{ secrets.TEAMS_ORGANIZATION_TEAM_ID }}
-          TEAMS_ORGANIZATION_TENANT_ID: ${{ secrets.TEAMS_ORGANIZATION_TENANT_ID }}
-          TEAMS_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
-
-          PLUGINS_BINARIES_DIRECTORY: ${{ github.workspace }}/plugin-dist
-          CONFIG_PROVIDER_API_KEY: ${{ secrets.CONFIG_PROVIDER_API_KEY }}
-          CONFIG_PROVIDER_ENDPOINT: ${{ secrets.CONFIG_PROVIDER_ENDPOINT }}
-          CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID: ${{ secrets.CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID }}
-          CONFIG_PROVIDER_IMAGE_REPOSITORY: ${{ env.IMAGE_REPOSITORY }}
-          CONFIG_PROVIDER_IMAGE_TAG: ${{ env.IMAGE_TAG }}
-          CONFIG_PROVIDER_HELM_REPO_DIRECTORY: ${{ github.workspace }}/helm
-        run: |
-          KUBECONFIG=$(k3d kubeconfig write ${{ matrix.integration }}-test-cluster) \
-            make test-integration-${{ matrix.integration }}
-
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        if: ${{ failure() }}
-        env:
-          SLACK_USERNAME: Botkube Cloud CI
-          SLACK_COLOR: 'red'
-          SLACK_TITLE: 'Message'
-          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
-          SLACK_MESSAGE: 'Integration ${{ matrix.integration }} test failed :scream:'
-          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}
-          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
+#  extract-metadata:
+#    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
+#    runs-on: ubuntu-latest
+#    outputs:
+#      versions: ${{ steps.extract-version.outputs.versions }}
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#        with:
+#          fetch-depth: 0
+#      - name: Extract version
+#        id: extract-version
+#        run: |
+#          IMAGE_VERSION=$(git rev-parse --short HEAD)
+#          echo "versions={\"image-version\":[\"v9.99.9-dev\",\"0.0.0-${IMAGE_VERSION}\"]}" >> $GITHUB_OUTPUT
+#  build:
+#    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
+#    needs: [extract-metadata]
+#    strategy:
+#      matrix: ${{ fromJson(needs.extract-metadata.outputs.versions) }}
+#    runs-on: ubuntu-latest
+#    env:
+#      GO111MODULE: on
+#      GOPATH: /home/runner/work/botkube
+#      GOBIN: /home/runner/work/botkube/bin
+#      DOCKER_CLI_EXPERIMENTAL: "enabled"
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#      - name: Setup Go
+#        uses: actions/setup-go@v5
+#        with:
+#          go-version-file: 'go.mod'
+#          cache: true
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@v3
+#      - name: Docker Login
+#        uses: docker/login-action@v1
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Install GoReleaser
+#        uses: goreleaser/goreleaser-action@v5
+#        with:
+#          install-only: true
+#          version: latest
+#      - name: Run GoReleaser
+#        run: |
+#          make release-snapshot
+#        env:
+#          ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
+#          GORELEASER_CURRENT_TAG: ${{ matrix.image-version }}
+#          IMAGE_TAG: ${{ matrix.image-version }}
+#
+#  integration-tests:
+#    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
+#    name: Integration tests
+#    runs-on: ubuntu-latest
+#    needs: [ build ]
+#    permissions:
+#      contents: read
+#      packages: read
+#
+#    strategy:
+#      # make the jobs independent
+#      fail-fast: false
+#
+#      matrix:
+#        integration:
+#          - slack
+#          - discord
+#          - teams
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#        with:
+#          persist-credentials: false
+#
+#      - name: Setup Go modules
+#        uses: ./.github/actions/setup-go-mod-private
+#        with:
+#          access_token: ${{ secrets.E2E_TEST_GH_DEV_ACCOUNT_PAT }}
+#          username: ${{ env.GIT_USER }}
+#
+#      - name: Pub/Sub auth
+#        uses: 'google-github-actions/auth@v1'
+#        if: matrix.integration == 'teams'
+#        with:
+#          credentials_json: ${{ secrets.E2E_TEST_GCP_PUB_SUB_CREDENTIALS }}
+#
+#      - name: Install Helm
+#        uses: azure/setup-helm@v3
+#        with:
+#          version: ${{ env.HELM_VERSION }}
+#
+#      - name: Download k3d
+#        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
+#
+#      - name: Create cluster to test ${{ matrix.integration }}
+#        run: "k3d cluster create ${{ matrix.integration }}-test-cluster --wait --timeout=5m"
+#
+#      - name: Install Botkube locally via helm
+#        if: matrix.integration == 'discord'
+#        env:
+#          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+#          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
+#        run: |
+#          helm install botkube --namespace botkube ./helm/botkube --wait --create-namespace \
+#           -f ./helm/botkube/e2e-test-values.yaml \
+#           --set communications.default-group.discord.token="${DISCORD_BOT_TOKEN}" \
+#           --set communications.default-group.discord.botID="${DISCORD_BOT_ID}" \
+#           --set image.registry="${IMAGE_REGISTRY}" \
+#           --set image.repository="${IMAGE_REPOSITORY}" \
+#           --set image.tag="${IMAGE_TAG}" \
+#
+#      - name: Install GoReleaser
+#        uses: goreleaser/goreleaser-action@v5
+#        with:
+#          install-only: true
+#          version: latest
+#
+#      - name: Build all plugins into dist directory
+#        env:
+#          # we hardcode plugins version, so it's predictable in e2e tests
+#          GORELEASER_CURRENT_TAG: "v0.0.0-latest"
+#          OUTPUT_MODE: "binary"
+#          SINGLE_PLATFORM: "true"
+#          PLUGIN_TARGETS: "kubernetes,kubectl,cm-watcher,echo,helm"
+#        run: |
+#          make build-plugins
+#
+#      - name: CLI Cache
+#        if: matrix.integration != 'discord'
+#        uses: actions/cache@v3
+#        with:
+#          path: |
+#            ~/.cache/go-build
+#            ~/go/pkg/mod
+#            dist/botkube-cli_linux_amd64_v1/botkube
+#          key: ${{ runner.os }}-botkube-cli
+#
+#      - name: Build CLI
+#        if: matrix.integration != 'discord'
+#        run: make build-single-arch-cli
+#
+#      - name: Add Botkube CLI to env
+#        run: |
+#          echo CONFIG_PROVIDER_BOTKUBE_CLI_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
+#
+#      - name: Run ${{ matrix.integration }} tests
+#        env:
+#          SLACK_TESTER_APP_TOKEN: ${{ secrets.SLACK_TESTER_APP_TOKEN }}
+#          SLACK_CLOUD_TESTER_APP_TOKEN: ${{ secrets.SLACK_CLOUD_TESTER_APP_TOKEN }}
+#          SLACK_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
+#
+#          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
+#          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+#          DISCORD_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
+#
+#          TEAMS_BOT_TESTER_APP_ID: ${{ secrets.TEAMS_BOT_TESTER_APP_ID }}
+#          TEAMS_BOT_TESTER_APP_PASSWORD: ${{ secrets.TEAMS_BOT_TESTER_APP_PASSWORD }}
+#          TEAMS_ORGANIZATION_TEAM_ID: ${{ secrets.TEAMS_ORGANIZATION_TEAM_ID }}
+#          TEAMS_ORGANIZATION_TENANT_ID: ${{ secrets.TEAMS_ORGANIZATION_TENANT_ID }}
+#          TEAMS_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
+#
+#          PLUGINS_BINARIES_DIRECTORY: ${{ github.workspace }}/plugin-dist
+#          CONFIG_PROVIDER_API_KEY: ${{ secrets.CONFIG_PROVIDER_API_KEY }}
+#          CONFIG_PROVIDER_ENDPOINT: ${{ secrets.CONFIG_PROVIDER_ENDPOINT }}
+#          CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID: ${{ secrets.CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID }}
+#          CONFIG_PROVIDER_IMAGE_REPOSITORY: ${{ env.IMAGE_REPOSITORY }}
+#          CONFIG_PROVIDER_IMAGE_TAG: ${{ env.IMAGE_TAG }}
+#          CONFIG_PROVIDER_HELM_REPO_DIRECTORY: ${{ github.workspace }}/helm
+#        run: |
+#          KUBECONFIG=$(k3d kubeconfig write ${{ matrix.integration }}-test-cluster) \
+#            make test-integration-${{ matrix.integration }}
+#
+#      - name: Slack Notification
+#        uses: rtCamp/action-slack-notify@v2
+#        if: ${{ failure() }}
+#        env:
+#          SLACK_USERNAME: Botkube Cloud CI
+#          SLACK_COLOR: 'red'
+#          SLACK_TITLE: 'Message'
+#          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
+#          SLACK_MESSAGE: 'Integration ${{ matrix.integration }} test failed :scream:'
+#          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
+#          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}
+#          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
 
   cli-migration-e2e:
     name: CLI Migration E2E tests
     runs-on: ubuntu-latest
-    needs: [ build ]
+#    needs: [ build ]
     permissions:
       contents: read
       packages: read
@@ -290,7 +290,7 @@ jobs:
   cloud-slack-dev-e2e:
     name: Botkube Cloud Slack Dev E2E
     runs-on: ubuntu-latest
-    needs: [ build ]
+#    needs: [ build ]
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-e2e-tests
   repository_dispatch:
     types: [ trigger-e2e-tests ]
 
@@ -17,208 +16,207 @@ env:
   GIT_USER: botkube-dev
 
 jobs:
-#  extract-metadata:
-#    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
-#    runs-on: ubuntu-latest
-#    outputs:
-#      versions: ${{ steps.extract-version.outputs.versions }}
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#        with:
-#          fetch-depth: 0
-#      - name: Extract version
-#        id: extract-version
-#        run: |
-#          IMAGE_VERSION=$(git rev-parse --short HEAD)
-#          echo "versions={\"image-version\":[\"v9.99.9-dev\",\"0.0.0-${IMAGE_VERSION}\"]}" >> $GITHUB_OUTPUT
-#  build:
-#    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
-#    needs: [extract-metadata]
-#    strategy:
-#      matrix: ${{ fromJson(needs.extract-metadata.outputs.versions) }}
-#    runs-on: ubuntu-latest
-#    env:
-#      GO111MODULE: on
-#      GOPATH: /home/runner/work/botkube
-#      GOBIN: /home/runner/work/botkube/bin
-#      DOCKER_CLI_EXPERIMENTAL: "enabled"
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#      - name: Setup Go
-#        uses: actions/setup-go@v5
-#        with:
-#          go-version-file: 'go.mod'
-#          cache: true
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@v3
-#      - name: Docker Login
-#        uses: docker/login-action@v1
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.actor }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
-#      - name: Install GoReleaser
-#        uses: goreleaser/goreleaser-action@v5
-#        with:
-#          install-only: true
-#          version: latest
-#      - name: Run GoReleaser
-#        run: |
-#          make release-snapshot
-#        env:
-#          ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
-#          GORELEASER_CURRENT_TAG: ${{ matrix.image-version }}
-#          IMAGE_TAG: ${{ matrix.image-version }}
-#
-#  integration-tests:
-#    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
-#    name: Integration tests
-#    runs-on: ubuntu-latest
-#    needs: [ build ]
-#    permissions:
-#      contents: read
-#      packages: read
-#
-#    strategy:
-#      # make the jobs independent
-#      fail-fast: false
-#
-#      matrix:
-#        integration:
-#          - slack
-#          - discord
-#          - teams
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#        with:
-#          persist-credentials: false
-#
-#      - name: Setup Go modules
-#        uses: ./.github/actions/setup-go-mod-private
-#        with:
-#          access_token: ${{ secrets.E2E_TEST_GH_DEV_ACCOUNT_PAT }}
-#          username: ${{ env.GIT_USER }}
-#
-#      - name: Pub/Sub auth
-#        uses: 'google-github-actions/auth@v1'
-#        if: matrix.integration == 'teams'
-#        with:
-#          credentials_json: ${{ secrets.E2E_TEST_GCP_PUB_SUB_CREDENTIALS }}
-#
-#      - name: Install Helm
-#        uses: azure/setup-helm@v3
-#        with:
-#          version: ${{ env.HELM_VERSION }}
-#
-#      - name: Download k3d
-#        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
-#
-#      - name: Create cluster to test ${{ matrix.integration }}
-#        run: "k3d cluster create ${{ matrix.integration }}-test-cluster --wait --timeout=5m"
-#
-#      - name: Install Botkube locally via helm
-#        if: matrix.integration == 'discord'
-#        env:
-#          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-#          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
-#        run: |
-#          helm install botkube --namespace botkube ./helm/botkube --wait --create-namespace \
-#           -f ./helm/botkube/e2e-test-values.yaml \
-#           --set communications.default-group.discord.token="${DISCORD_BOT_TOKEN}" \
-#           --set communications.default-group.discord.botID="${DISCORD_BOT_ID}" \
-#           --set image.registry="${IMAGE_REGISTRY}" \
-#           --set image.repository="${IMAGE_REPOSITORY}" \
-#           --set image.tag="${IMAGE_TAG}" \
-#
-#      - name: Install GoReleaser
-#        uses: goreleaser/goreleaser-action@v5
-#        with:
-#          install-only: true
-#          version: latest
-#
-#      - name: Build all plugins into dist directory
-#        env:
-#          # we hardcode plugins version, so it's predictable in e2e tests
-#          GORELEASER_CURRENT_TAG: "v0.0.0-latest"
-#          OUTPUT_MODE: "binary"
-#          SINGLE_PLATFORM: "true"
-#          PLUGIN_TARGETS: "kubernetes,kubectl,cm-watcher,echo,helm"
-#        run: |
-#          make build-plugins
-#
-#      - name: CLI Cache
-#        if: matrix.integration != 'discord'
-#        uses: actions/cache@v3
-#        with:
-#          path: |
-#            ~/.cache/go-build
-#            ~/go/pkg/mod
-#            dist/botkube-cli_linux_amd64_v1/botkube
-#          key: ${{ runner.os }}-botkube-cli
-#
-#      - name: Build CLI
-#        if: matrix.integration != 'discord'
-#        run: make build-single-arch-cli
-#
-#      - name: Add Botkube CLI to env
-#        run: |
-#          echo CONFIG_PROVIDER_BOTKUBE_CLI_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
-#
-#      - name: Run ${{ matrix.integration }} tests
-#        env:
-#          SLACK_TESTER_APP_TOKEN: ${{ secrets.SLACK_TESTER_APP_TOKEN }}
-#          SLACK_CLOUD_TESTER_APP_TOKEN: ${{ secrets.SLACK_CLOUD_TESTER_APP_TOKEN }}
-#          SLACK_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
-#
-#          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
-#          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
-#          DISCORD_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
-#
-#          TEAMS_BOT_TESTER_APP_ID: ${{ secrets.TEAMS_BOT_TESTER_APP_ID }}
-#          TEAMS_BOT_TESTER_APP_PASSWORD: ${{ secrets.TEAMS_BOT_TESTER_APP_PASSWORD }}
-#          TEAMS_ORGANIZATION_TEAM_ID: ${{ secrets.TEAMS_ORGANIZATION_TEAM_ID }}
-#          TEAMS_ORGANIZATION_TENANT_ID: ${{ secrets.TEAMS_ORGANIZATION_TENANT_ID }}
-#          TEAMS_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
-#
-#          PLUGINS_BINARIES_DIRECTORY: ${{ github.workspace }}/plugin-dist
-#          CONFIG_PROVIDER_API_KEY: ${{ secrets.CONFIG_PROVIDER_API_KEY }}
-#          CONFIG_PROVIDER_ENDPOINT: ${{ secrets.CONFIG_PROVIDER_ENDPOINT }}
-#          CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID: ${{ secrets.CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID }}
-#          CONFIG_PROVIDER_IMAGE_REPOSITORY: ${{ env.IMAGE_REPOSITORY }}
-#          CONFIG_PROVIDER_IMAGE_TAG: ${{ env.IMAGE_TAG }}
-#          CONFIG_PROVIDER_HELM_REPO_DIRECTORY: ${{ github.workspace }}/helm
-#        run: |
-#          KUBECONFIG=$(k3d kubeconfig write ${{ matrix.integration }}-test-cluster) \
-#            make test-integration-${{ matrix.integration }}
+  extract-metadata:
+    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.extract-version.outputs.versions }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Extract version
+        id: extract-version
+        run: |
+          IMAGE_VERSION=$(git rev-parse --short HEAD)
+          echo "versions={\"image-version\":[\"v9.99.9-dev\",\"0.0.0-${IMAGE_VERSION}\"]}" >> $GITHUB_OUTPUT
+  build:
+    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
+    needs: [extract-metadata]
+    strategy:
+      matrix: ${{ fromJson(needs.extract-metadata.outputs.versions) }}
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+      GOPATH: /home/runner/work/botkube
+      GOBIN: /home/runner/work/botkube/bin
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Docker Login
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          install-only: true
+          version: latest
+      - name: Run GoReleaser
+        run: |
+          make release-snapshot
+        env:
+          ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}
+          GORELEASER_CURRENT_TAG: ${{ matrix.image-version }}
+          IMAGE_TAG: ${{ matrix.image-version }}
 
-# TODO: Uncomment
-#      - name: Dump cluster state
-#        if: ${{ failure() }}
-#        uses: ./.github/actions/dump-cluster
-#        with:
-#          name: ${{ matrix.integration }}
+  integration-tests:
+    if: github.event_name != 'repository_dispatch' # skip if triggered by repository_dispatch
+    name: Integration tests
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    permissions:
+      contents: read
+      packages: read
 
-#      - name: Slack Notification
-#        uses: rtCamp/action-slack-notify@v2
-#        if: ${{ failure() }}
-#        env:
-#          SLACK_USERNAME: Botkube Cloud CI
-#          SLACK_COLOR: 'red'
-#          SLACK_TITLE: 'Message'
-#          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
-#          SLACK_MESSAGE: 'Integration ${{ matrix.integration }} test failed :scream:'
-#          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
-#          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}
-#          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
+    strategy:
+      # make the jobs independent
+      fail-fast: false
+
+      matrix:
+        integration:
+          - slack
+          - discord
+          - teams
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Go modules
+        uses: ./.github/actions/setup-go-mod-private
+        with:
+          access_token: ${{ secrets.E2E_TEST_GH_DEV_ACCOUNT_PAT }}
+          username: ${{ env.GIT_USER }}
+
+      - name: Pub/Sub auth
+        uses: 'google-github-actions/auth@v1'
+        if: matrix.integration == 'teams'
+        with:
+          credentials_json: ${{ secrets.E2E_TEST_GCP_PUB_SUB_CREDENTIALS }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Download k3d
+        run: "wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=${K3D_VERSION} bash"
+
+      - name: Create cluster to test ${{ matrix.integration }}
+        run: "k3d cluster create ${{ matrix.integration }}-test-cluster --wait --timeout=5m"
+
+      - name: Install Botkube locally via helm
+        if: matrix.integration == 'discord'
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_BOT_ID: ${{ secrets.DISCORD_BOT_ID }}
+        run: |
+          helm install botkube --namespace botkube ./helm/botkube --wait --create-namespace \
+           -f ./helm/botkube/e2e-test-values.yaml \
+           --set communications.default-group.discord.token="${DISCORD_BOT_TOKEN}" \
+           --set communications.default-group.discord.botID="${DISCORD_BOT_ID}" \
+           --set image.registry="${IMAGE_REGISTRY}" \
+           --set image.repository="${IMAGE_REPOSITORY}" \
+           --set image.tag="${IMAGE_TAG}" \
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          install-only: true
+          version: latest
+
+      - name: Build all plugins into dist directory
+        env:
+          # we hardcode plugins version, so it's predictable in e2e tests
+          GORELEASER_CURRENT_TAG: "v0.0.0-latest"
+          OUTPUT_MODE: "binary"
+          SINGLE_PLATFORM: "true"
+          PLUGIN_TARGETS: "kubernetes,kubectl,cm-watcher,echo,helm"
+        run: |
+          make build-plugins
+
+      - name: CLI Cache
+        if: matrix.integration != 'discord'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            dist/botkube-cli_linux_amd64_v1/botkube
+          key: ${{ runner.os }}-botkube-cli
+
+      - name: Build CLI
+        if: matrix.integration != 'discord'
+        run: make build-single-arch-cli
+
+      - name: Add Botkube CLI to env
+        run: |
+          echo CONFIG_PROVIDER_BOTKUBE_CLI_BINARY_PATH="$PWD/dist/botkube-cli_linux_amd64_v1/botkube" >> $GITHUB_ENV
+
+      - name: Run ${{ matrix.integration }} tests
+        env:
+          SLACK_TESTER_APP_TOKEN: ${{ secrets.SLACK_TESTER_APP_TOKEN }}
+          SLACK_CLOUD_TESTER_APP_TOKEN: ${{ secrets.SLACK_CLOUD_TESTER_APP_TOKEN }}
+          SLACK_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
+
+          DISCORD_TESTER_APP_TOKEN: ${{ secrets.DISCORD_TESTER_APP_TOKEN }}
+          DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+          DISCORD_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
+
+          TEAMS_BOT_TESTER_APP_ID: ${{ secrets.TEAMS_BOT_TESTER_APP_ID }}
+          TEAMS_BOT_TESTER_APP_PASSWORD: ${{ secrets.TEAMS_BOT_TESTER_APP_PASSWORD }}
+          TEAMS_ORGANIZATION_TEAM_ID: ${{ secrets.TEAMS_ORGANIZATION_TEAM_ID }}
+          TEAMS_ORGANIZATION_TENANT_ID: ${{ secrets.TEAMS_ORGANIZATION_TENANT_ID }}
+          TEAMS_ADDITIONAL_CONTEXT_MESSAGE: "Branch test - commit SHA: ${{github.sha}} - https://github.com/kubeshop/botkube/commit/${{github.sha}}"
+
+          PLUGINS_BINARIES_DIRECTORY: ${{ github.workspace }}/plugin-dist
+          CONFIG_PROVIDER_API_KEY: ${{ secrets.CONFIG_PROVIDER_API_KEY }}
+          CONFIG_PROVIDER_ENDPOINT: ${{ secrets.CONFIG_PROVIDER_ENDPOINT }}
+          CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID: ${{ secrets.CONFIG_PROVIDER_SLACK_WORKSPACE_TEAM_ID }}
+          CONFIG_PROVIDER_IMAGE_REPOSITORY: ${{ env.IMAGE_REPOSITORY }}
+          CONFIG_PROVIDER_IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          CONFIG_PROVIDER_HELM_REPO_DIRECTORY: ${{ github.workspace }}/helm
+        run: |
+          KUBECONFIG=$(k3d kubeconfig write ${{ matrix.integration }}-test-cluster) \
+            make test-integration-${{ matrix.integration }}
+
+      - name: Dump cluster state
+        if: ${{ failure() }}
+        uses: ./.github/actions/dump-cluster
+        with:
+          name: ${{ matrix.integration }}
+
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        if: ${{ failure() }}
+        env:
+          SLACK_USERNAME: Botkube Cloud CI
+          SLACK_COLOR: 'red'
+          SLACK_TITLE: 'Message'
+          SLACK_CHANNEL: 'botkube-cloud-ci-alerts'
+          SLACK_MESSAGE: 'Integration ${{ matrix.integration }} test failed :scream:'
+          SLACK_ICON_EMOJI: ':this-is-fine-fire:'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_ALERTS_WEBHOOK }}
+          SLACK_FOOTER: "Fingers crossed it's just an outdated/flaky test..."
 
   cli-migration-e2e:
     name: CLI Migration E2E tests
     runs-on: ubuntu-latest
-#    needs: [ build ]
+    needs: [ build ]
     permissions:
       contents: read
       packages: read
@@ -271,7 +269,7 @@ jobs:
           KUBECONFIG=$(k3d kubeconfig write cli-migration-e2e-cluster) make test-cli-migration-e2e
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: screenshots_dump_${{github.sha}}
@@ -300,7 +298,7 @@ jobs:
   cloud-slack-dev-e2e:
     name: Botkube Cloud Slack Dev E2E
     runs-on: ubuntu-latest
-#    needs: [ build ]
+    needs: [ build ]
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-e2e-tests
   repository_dispatch:
     types: [ trigger-e2e-tests ]
 
@@ -193,7 +194,14 @@ jobs:
 #        run: |
 #          KUBECONFIG=$(k3d kubeconfig write ${{ matrix.integration }}-test-cluster) \
 #            make test-integration-${{ matrix.integration }}
-#
+
+# TODO: Uncomment
+#      - name: Dump cluster state
+#        if: ${{ failure() }}
+#        uses: ./.github/actions/dump-cluster
+#        with:
+#          name: ${{ matrix.integration }}
+
 #      - name: Slack Notification
 #        uses: rtCamp/action-slack-notify@v2
 #        if: ${{ failure() }}

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -273,6 +273,8 @@ jobs:
       - name: Dump cluster state
         if: ${{ failure() }}
         uses: ./.github/actions/dump-cluster
+        with:
+          name: cli-migration-e2e
 
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -69,7 +69,7 @@ jobs:
           make save-images
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: botkube-${{github.sha}}
           path: ${{ env.IMAGE_SAVE_LOAD_DIR }}
@@ -91,7 +91,7 @@ jobs:
           persist-credentials: false
 
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: botkube-${{github.sha}}
           path: ${{ env.IMAGE_SAVE_LOAD_DIR }}

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -304,3 +304,9 @@ jobs:
         run: |
           KUBECONFIG=$(k3d kubeconfig write ${{ matrix.integration }}-test-cluster) \
             make test-integration-${{ matrix.integration }}
+
+      - name: Dump cluster state
+        if: ${{ failure() }}
+        uses: ./.github/actions/dump-cluster
+        with:
+          name: ${{ matrix.integration }}

--- a/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
+++ b/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
@@ -89,6 +89,7 @@ func TestCloudSlackE2E(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg.Slack.Tester.CloudBasedTestEnabled = false // override property used only in the Cloud Slack E2E tests
+	cfg.Slack.Tester.RecentMessagesLimit = 4       // this is used effectively only for the Botkube restarts. There are two of them in a short time window so it shouldn't be higher than 5.
 
 	authHeaderValue := ""
 	var botkubeDeploymentUninstalled atomic.Bool
@@ -471,9 +472,9 @@ func TestCloudSlackE2E(t *testing.T) {
 		t.Run("Botkube Deployment -> Cloud sync", func(t *testing.T) {
 			t.Log("Disabling notification...")
 			tester.PostMessageToBot(t, channel.Identifier(), "disable notifications")
+
 			t.Log("Waiting for config reload message...")
 			expectedReloadMsg := fmt.Sprintf(":arrows_counterclockwise: Configuration reload requested for cluster '%s'. Hold on a sec...", deployment.Name)
-
 			err = tester.OnChannel().WaitForMessagePostedRecentlyEqual(tester.BotUserID(), channel.ID(), expectedReloadMsg)
 			require.NoError(t, err)
 

--- a/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
+++ b/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
@@ -89,7 +89,7 @@ func TestCloudSlackE2E(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg.Slack.Tester.CloudBasedTestEnabled = false // override property used only in the Cloud Slack E2E tests
-	cfg.Slack.Tester.RecentMessagesLimit = 4       // this is used effectively only for the Botkube restarts. There are two of them in a short time window so it shouldn't be higher than 5.
+	cfg.Slack.Tester.RecentMessagesLimit = 4       // this is used effectively only for the Botkube restarts. There are two of them in a short time window, so it shouldn't be higher than 5.
 
 	authHeaderValue := ""
 	var botkubeDeploymentUninstalled atomic.Bool
@@ -239,7 +239,7 @@ func TestCloudSlackE2E(t *testing.T) {
 		go router.Run()
 		defer router.MustStop()
 
-		t.Log("Ensuring proper organizaton is selected")
+		t.Log("Ensuring proper organization is selected")
 		botkubePage.MustWaitOpen()
 		screenshotIfShould(t, cfg, botkubePage)
 		botkubePage.MustElement("a.logo-link")

--- a/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
+++ b/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
@@ -301,6 +301,7 @@ func TestCloudSlackE2E(t *testing.T) {
 			if !cfg.Slack.DisconnectWorkspaceAfterTests {
 				return
 			}
+			t.Log("Disconnecting Slack workspace...")
 			gqlCli.MustDeleteSlackWorkspace(t, cfg.BotkubeCloud.TeamOrganizationID, slackWorkspace.ID)
 		})
 

--- a/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
+++ b/test/cloud-slack-dev-e2e/cloud_slack_dev_e2e_test.go
@@ -347,8 +347,13 @@ func TestCloudSlackE2E(t *testing.T) {
 		}
 		helmInstallCallback := helmx.InstallChart(t, params)
 		t.Cleanup(func() {
-			t.Log("Uninstalling Helm chart...")
-			helmInstallCallback(t)
+			if t.Failed() {
+				t.Log("Tests failed, keeping the Botkube instance installed for debugging purposes.")
+			} else {
+				t.Log("Uninstalling Helm chart...")
+				helmInstallCallback(t)
+			}
+
 			botkubeDeploymentUninstalled.Store(true)
 		})
 

--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -1686,7 +1686,7 @@ func crashConfigMapSourcePlugin(t *testing.T, cfgMapCli corev1.ConfigMapInterfac
 }
 
 func waitForRestart(t *testing.T, tester commplatform.BotDriver, userID, channel, clusterName string) {
-	t.Logf("Waiting for restart (timestamp: %s)...", time.Now().String())
+	t.Logf("Waiting for restart (timestamp: %s)...", time.Now().Format(time.DateTime))
 
 	originalTimeout := tester.Timeout()
 	tester.SetTimeout(120 * time.Second)
@@ -1703,7 +1703,12 @@ func waitForRestart(t *testing.T, tester commplatform.BotDriver, userID, channel
 	err := tester.OnChannel().WaitForMessagePosted(userID, channel, 2, assertFn)
 	assert.NoError(t, err)
 
-	t.Logf("Detected a successful restart (timestamp: %s).", time.Now().String())
+	t.Logf("Detected a successful restart (timestamp: %s).", time.Now().Format(time.DateTime))
+
+	t.Logf("Waiting a bit longer just to make sure Botkube connects to the Cloud Router...")
+	// Yes, it's ugly but "My watch begins..." doesn't really mean the Slack/Teams gRPC connection has been established.
+	// So we wait a bit longer to avoid a race condition.
+	time.Sleep(3 * time.Second)
 
 	tester.SetTimeout(originalTimeout)
 }

--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -1078,8 +1078,7 @@ func runBotTest(t *testing.T,
 
 		limitMessagesNo := 2
 		if botDriver.Type().IsCloud() {
-			// There are 2 config reload requested after second cm update
-			limitMessagesNo = 2 * limitLastMessageAfterCloudReload
+			limitMessagesNo = limitLastMessageAfterCloudReload
 		}
 		err = botDriver.OnChannel().WaitForMessagePostedWithAttachment(botDriver.BotUserID(), botDriver.SecondChannel().ID(), limitMessagesNo, secondCMUpdate)
 		require.NoError(t, err)

--- a/test/helmx/helm_helpers.go
+++ b/test/helmx/helm_helpers.go
@@ -137,7 +137,8 @@ func WaitForUninstallation(ctx context.Context, t *testing.T, alreadyUninstalled
 	}
 
 	if waitInterrupted {
-		t.Log("Force uninstalling the Helm chart after a wait timeout")
+		t.Log("Helm chart uninstallation timed out. Proceeding with deleting other resources...")
+		return nil
 	}
 
 	t.Log("Waiting a bit more...")

--- a/test/helmx/helm_helpers.go
+++ b/test/helmx/helm_helpers.go
@@ -1,12 +1,17 @@
 package helmx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/stretchr/testify/require"
 )
@@ -107,4 +112,35 @@ func redactAPIKey(in []string) []string {
 		dst[i] = apiKeyRegex.ReplaceAllString(dst[i], "$1=REDACTED")
 	}
 	return dst
+}
+
+const (
+	uninstallPollInterval = 1 * time.Second
+	uninstallTimeout      = 30 * time.Second
+)
+
+// WaitForUninstallation waits until a Helm chart is uninstalled, based on the atomic value.
+// It's a workaround for the Helm chart uninstallation issue.
+// We have a glitch on backend side and the logic below is a workaround for that.
+// Tl;dr uninstalling Helm chart reports "DISCONNECTED" status, and deployment deletion reports "DELETED" status.
+// If we do these two things too quickly, we'll run into resource version mismatch in repository logic.
+// Read more here: https://github.com/kubeshop/botkube-cloud/pull/486#issuecomment-1604333794
+func WaitForUninstallation(ctx context.Context, t *testing.T, alreadyUninstalled *atomic.Bool) error {
+	t.Helper()
+	t.Log("Waiting for Helm chart uninstallation, in order to proceed with deleting Botkube Cloud instance...")
+	err := wait.PollUntilContextTimeout(ctx, uninstallPollInterval, uninstallTimeout, false, func(ctx context.Context) (done bool, err error) {
+		return alreadyUninstalled.Load(), nil
+	})
+	waitInterrupted := wait.Interrupted(err)
+	if err != nil && !waitInterrupted {
+		return err
+	}
+
+	if waitInterrupted {
+		t.Log("Force uninstalling the Helm chart after a wait timeout")
+	}
+
+	t.Log("Waiting a bit more...")
+	time.Sleep(3 * time.Second) // ugly, but at least we will be pretty sure we won't run into the resource version mismatch
+	return nil
 }

--- a/test/helmx/helm_helpers.go
+++ b/test/helmx/helm_helpers.go
@@ -137,7 +137,7 @@ func WaitForUninstallation(ctx context.Context, t *testing.T, alreadyUninstalled
 	}
 
 	if waitInterrupted {
-		t.Log("Helm chart uninstallation timed out. Proceeding with deleting other resources...")
+		t.Log("Waiting for Helm chart uninstallation timed out. Proceeding with deleting other resources...")
 		return nil
 	}
 

--- a/test/helmx/redact_test.go
+++ b/test/helmx/redact_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestRedactAPIKey(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		input    []string


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Force remove Cloud resources when Botkube uninstall timeouts
- Do not uninstall Botkube on failure, always dump logs
- Fix waiting on bot after restart
- Fix overwriting artifacts from multiple jobs
- Fix waiting for Botkube Helm chart uninstall

## Testing

No need to do it, CI tests it.

- Slack: https://github.com/kubeshop/botkube/actions/runs/8205276642/job/22441872428?pr=1406
- Discord: https://github.com/kubeshop/botkube/actions/runs/8205276642/job/22441872686?pr=1406
- Teams: https://github.com/kubeshop/botkube/actions/runs/8205276642/job/22441872995?pr=1406
- Dev E2E Cloud Slack: https://github.com/kubeshop/botkube/actions/runs/8205276255/job/22441772142?pr=1406