### PR TITLE
Fix Helm chart upgrade when `lookup` is not supported

### DIFF
--- a/helm/botkube/templates/persistent-config.yaml
+++ b/helm/botkube/templates/persistent-config.yaml
@@ -1,12 +1,12 @@
 {{- if not (include "botkube.remoteConfigEnabled" $) }}
 {{- $runtimeStateCfgMap := .Values.settings.persistentConfig.runtime.configMap.name -}}
-{{- $communications := .Values.communications }}
+{{- $communications := .Values.communications | default dict }}
 {{- if .Values.existingCommunicationsSecretName }}
   {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.existingCommunicationsSecretName | default dict  }}
   {{- $secretData := $secret.data | default dict -}}
   {{- $data := b64dec (index $secretData "comm_config.yaml" | default "") -}}
-  {{- $dataYaml := $data | fromYaml -}}
-  {{- $communications =  $dataYaml.communications }}
+  {{- $dataYaml := $data | fromYaml | default dict -}}
+  {{- $communications =  $dataYaml.communications | default dict }}
 {{- end }}
 apiVersion: v1
 kind: ConfigMap
@@ -24,7 +24,7 @@ metadata:
     botkube.io/config-watch: "true"
 data:
   {{- $prevRuntimeCfgMap := lookup "v1" "ConfigMap" .Release.Namespace $runtimeStateCfgMap | default dict }}
-  {{- $prevRuntimeFile := index ( $prevRuntimeCfgMap.data | default dict ) .Values.settings.persistentConfig.runtime.fileName | default "" | fromYaml -}}
+  {{- $prevRuntimeFile := index ( $prevRuntimeCfgMap.data | default dict ) .Values.settings.persistentConfig.runtime.fileName | default "" | fromYaml | default dict -}}
   {{- $mergedRuntimeCommunications := mustMergeOverwrite (mustDeepCopy (default (dict) $prevRuntimeFile.communications )) (mustDeepCopy $communications) }}
   {{- $mergedRuntimeAction := mustMergeOverwrite (mustDeepCopy (default (dict) $prevRuntimeFile.actions )) (mustDeepCopy .Values.actions) }}
   # This file has a special prefix to load it as the last config file during Botkube startup.
@@ -75,7 +75,7 @@ metadata:
     botkube.io/config-watch: "false" # Explicitly don't watch this ConfigMap
 data:
   {{- $prevStartupCfgMap := lookup "v1" "ConfigMap" .Release.Namespace $startupStateCfgMap | default dict }}
-  {{- $prevStartupFile := index ( $prevStartupCfgMap.data | default dict ) .Values.settings.persistentConfig.startup.fileName | default "" | fromYaml -}}
+  {{- $prevStartupFile := index ( $prevStartupCfgMap.data | default dict ) .Values.settings.persistentConfig.startup.fileName | default "" | fromYaml | default dict -}}
   {{- $mergedStartupCommunications := mustMergeOverwrite (mustDeepCopy (default (dict) $prevStartupFile.communications )) (mustDeepCopy .Values.communications) }}
   # This file has a special prefix to load it as the last config file during Botkube startup.
   {{ .Values.settings.persistentConfig.startup.fileName }}: |


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Fix Helm chart upgrade when `lookup` is not supported

## Testing

I don't think it's needed to test it but if you want to, see the instruction from https://github.com/kubeshop/botkube/pull/1274

## Related issue(s)

See conversation: https://botkube.slack.com/archives/C01CR1KS55K/p1709740107856559
See also: https://github.com/kubeshop/botkube/issues/1376