### PR TITLE
Only log incorrect k8s buttons definitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ For faster development, you can also build and run Botkube outside K8s cluster.
    > Each time you make a change to the [source](cmd/source) or [executors](cmd/executor) plugins re-run the above command.
 
    > **Note**
-   > To build specific plugin binaries, use `PLUGIN_TARGETS`. For example `PLUGIN_TARGETS="x, kubectl" make build-plugins-single`.
+   > To build specific plugin binaries, use `PLUGIN_TARGETS`. For example `PLUGIN_TARGETS="kubernetes,echo" make build-plugins-single`.
 
 ## Making A Change
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 .DEFAULT_GOAL := build
-.PHONY: container-image test test-integration-slack test-integration-discord build pre-build publish lint lint-fix go-import-fmt system-check save-images load-and-push-images gen-grpc-resources gen-plugins-index build-plugins build-plugins-single gen-docs-cli gen-plugins-goreleaser
+.PHONY: container-image test test-integration-slack test-integration-discord build pre-build publish lint lint-fix go-import-fmt system-check save-images load-and-push-images gen-grpc-resources gen-plugins-index build-plugins build-plugins-single gen-docs-cli gen-plugins-goreleaser serve-local-plugins
 
 # Show this help.
 help:
 	@awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][[:alnum:]_-]+:/{print substr($$1,1,index($$1,":")),c}1{c=0}' $(MAKEFILE_LIST) | column -s: -t
+
+serve-local-plugins: ## Serve local plugins
+	go run hack/target/serve-plugins/main.go
 
 lint-fix: go-import-fmt
 	@go mod tidy

--- a/internal/source/kubernetes/filterengine/filterengine.go
+++ b/internal/source/kubernetes/filterengine/filterengine.go
@@ -69,7 +69,7 @@ func (f *DefaultFilterEngine) Run(ctx context.Context, event event.Event) event.
 // Register filter(s) to engine.
 func (f *DefaultFilterEngine) Register(filters ...RegisteredFilter) {
 	for _, filter := range filters {
-		f.log.Infof("Registering filter %q (enabled: %t)...", filter.Name(), filter.Enabled)
+		f.log.Debugf("Registering filter %q (enabled: %t)...", filter.Name(), filter.Enabled)
 		f.filters[filter.Name()] = filter
 	}
 }

--- a/internal/source/kubernetes/msg_test.go
+++ b/internal/source/kubernetes/msg_test.go
@@ -1,0 +1,81 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/botkube/internal/source/kubernetes/config"
+	"github.com/kubeshop/botkube/internal/source/kubernetes/event"
+)
+
+func TestGetExtraButtonsAssignedToEvent(t *testing.T) {
+	// given
+	builder := MessageBuilder{}
+	givenButtons := []config.ExtraButtons{
+		{
+			// This is fully valid
+			Enabled: true,
+			Trigger: config.Trigger{
+				Type: []config.EventType{"error"},
+			},
+			Button: config.Button{
+				DisplayName: "Ask AI",
+				CommandTpl:  "ai --resource={{ .Namespace }}/{{ .Kind | lower }}/{{ .Name }} --error={{ .Reason }} --bk-cmd-header='AI assistance'",
+			},
+		},
+		{
+			// This is valid, as the 'ERROR' type should be normalized to "error"
+			Enabled: true,
+			Trigger: config.Trigger{
+				Type: []config.EventType{"ERROR"},
+			},
+			Button: config.Button{
+				DisplayName: "Get",
+				CommandTpl:  "kubectl get {{ .Kind | lower }}",
+			},
+		},
+		{
+			// This is invalid, as we can't render `.Event`
+			Enabled: true,
+			Trigger: config.Trigger{
+				Type: []config.EventType{"error"},
+			},
+			Button: config.Button{
+				DisplayName: "Ask AI v2",
+				CommandTpl:  "ai {{.Event.Namespace}} this one is wrong",
+			},
+		},
+		{
+			// This is invalid, as the DisplayName and Trigger is not set
+			Enabled: true,
+			Trigger: config.Trigger{},
+			Button: config.Button{
+				CommandTpl: "ai {{.Event.Namespace}} this one is wrong",
+			},
+		},
+		{
+			// This is invalid, but should be ignored as it's disabled
+			Enabled: false,
+			Trigger: config.Trigger{},
+			Button: config.Button{
+				CommandTpl: "ai {{.Event.Namespace}} this one is wrong",
+			},
+		},
+	}
+
+	// when
+	gotBtns, err := builder.getExtraButtonsAssignedToEvent(givenButtons, event.Event{Type: "error"})
+	assert.EqualError(t, err, heredoc.Doc(`
+        2 errors occurred:
+        	* invalid extraButtons[2].commandTpl: template: Ask AI v2:1:11: executing "Ask AI v2" at <.Event.Namespace>: can't evaluate field Event in type event.Event
+        	* invalid extraButtons[3]: displayName cannot be empty, trigger.type cannot be empty`))
+
+	// then
+	require.Len(t, gotBtns, 2)
+	for idx, btn := range gotBtns {
+		assert.Equal(t, givenButtons[idx].Button.DisplayName, btn.Name)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -620,8 +620,8 @@ const (
 	// FormatterText text formatter for logging
 	FormatterText Formatter = "text"
 
-	// FormatterJson json formatter for logging
-	FormatterJson Formatter = "json"
+	// FormatterJSON json formatter for logging
+	FormatterJSON Formatter = "json"
 )
 
 // Logger holds logger configuration parameters.

--- a/pkg/loggerx/logger.go
+++ b/pkg/loggerx/logger.go
@@ -36,7 +36,7 @@ func newWithOutput(cfg config.Logger, output io.Writer) logrus.FieldLogger {
 		logLevel = logrus.InfoLevel
 	}
 	logger.SetLevel(logLevel)
-	if cfg.Formatter == config.FormatterJson {
+	if cfg.Formatter == config.FormatterJSON {
 		logger.Formatter = &logrus.JSONFormatter{}
 	} else {
 		logger.Formatter = &logrus.TextFormatter{FullTimestamp: true, DisableColors: cfg.DisableColors, ForceColors: true}

--- a/pkg/loggerx/logger.go
+++ b/pkg/loggerx/logger.go
@@ -1,6 +1,7 @@
 package loggerx
 
 import (
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -9,10 +10,24 @@ import (
 )
 
 // New returns a new logger based on a given configuration.
+// It logs to stdout by default. It's a helper function to maintain backward compatibility.
 func New(cfg config.Logger) logrus.FieldLogger {
+	return NewStdout(cfg)
+}
+
+// NewStderr returns a new logger based on a given configuration. It logs to stderr.
+func NewStderr(cfg config.Logger) logrus.FieldLogger {
+	return newWithOutput(cfg, os.Stderr)
+}
+
+// NewStdout returns a new logger based on a given configuration. It logs to stdout.
+func NewStdout(cfg config.Logger) logrus.FieldLogger {
+	return newWithOutput(cfg, os.Stdout)
+}
+
+func newWithOutput(cfg config.Logger, output io.Writer) logrus.FieldLogger {
 	logger := logrus.New()
-	// Output to stdout instead of the default stderr
-	logger.SetOutput(os.Stdout)
+	logger.SetOutput(output)
 
 	// Only logger the warning severity or above.
 	logLevel, err := logrus.ParseLevel(cfg.Level)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Only log incorrect k8s buttons definitions
- Agent without debug enabled, shows k8s plugin errors too.

## Testing
You can see the unit-test, additionally I tested that e2e:
- when Agent uses `text` logger:
    ```text
    ERRO[2024-03-11T18:17:30+01:00] ERRO[2024-03-11T18:17:30+01:00] Failed to convert extra buttons assigned to "error" event. Those buttons will be omitted. Issues:  logger=stderr plugin=botkube/kubernetes
    ERRO[2024-03-11T18:17:30+01:00] 3 errors occurred:                            logger=stderr plugin=botkube/kubernetes
    ERRO[2024-03-11T18:17:30+01:00] 	* invalid extraButtons[1].commandTpl: template: Ask AI v2:1:11: executing "Ask AI v2" at <.Event.Namespace>: can't evaluate field Event in type event.Event  logger=stderr plugin=botkube/kubernetes
    ERRO[2024-03-11T18:17:30+01:00] 	* invalid extraButtons[2]: displayName cannot be empty  logger=stderr plugin=botkube/kubernetes
    ERRO[2024-03-11T18:17:30+01:00] 	* invalid extraButtons[3]: displayName cannot be empty, unknown trigger.type["fatal"]  component="Message Builder"  logger=stderr plugin=botkube/kubernetes
    ```
- when agent uses `json` logger:
    ```json
    {"level":"error","logger":"stderr","msg":"\u001b[31mERRO\u001b[0m[2024-03-11T18:37:36+01:00] Failed to convert extra buttons assigned to \"error\" event. Those buttons will be omitted. Issues:","plugin":"botkube/kubernetes","time":"2024-03-11T18:37:36+01:00"}
    {"level":"error","logger":"stderr","msg":"3 errors occurred:","plugin":"botkube/kubernetes","time":"2024-03-11T18:37:36+01:00"}
    {"level":"error","logger":"stderr","msg":"\t* invalid extraButtons[1].commandTpl: template: Ask AI v2:1:11: executing \"Ask AI v2\" at \u003c.Event.Namespace\u003e: can't evaluate field Event in type event.Event","plugin":"botkube/kubernetes","time":"2024-03-11T18:37:36+01:00"}
    {"level":"error","logger":"stderr","msg":"\t* invalid extraButtons[2]: displayName cannot be empty","plugin":"botkube/kubernetes","time":"2024-03-11T18:37:36+01:00"}
    {"level":"error","logger":"stderr","msg":"\t* invalid extraButtons[3]: displayName cannot be empty, unknown trigger.type[\"fatal\"]  \u001b[31mcomponent\u001b[0m=\"Message Builder\"","plugin":"botkube/kubernetes","time":"2024-03-11T18:37:36+01:00"}
    ```

1. Checkout PR
2. Build plugin: `PLUGIN_TARGETS="kubernetes" make build-plugins-single`
3. Start server: `make serve-local-plugins`
4. Start Botkube Agent with such configuration:
    
    <details><summary>Config</summary>
    <p>
    
    
    ```yaml
    communications:
      default-group:
        socketSlack:
          enabled: true
          channels:
            default:
              name: hakuna-matata
              bindings:
                sources:
                  - k8s-ai-support-err-events
                executors: []
          appToken: "xapp-1-"
          botToken: "xoxb-"
    
    sources:
      'k8s-ai-support-err-events':
        displayName: "K8s AI-powered errors"
        botkube/kubernetes:
          enabled: true
          context:
            defaultNamespace: "default"
            rbac:
              group:
                type: Static
                static:
                  values: [ "botkube-plugins-default" ]
          config:
            # -- Define extra buttons to be displayed beside notification message.
            extraButtons:
              - enabled: true
                trigger:
                  type: [ "ERROR" ]
                button:
                  displayName: "Ask AI"
                  commandTpl: "ai --resource={{ .Namespace }}/{{ .Kind | lower }}/{{ .Name }} --error={{ .Reason }} --bk-cmd-header='AI assistance'"
              - enabled: true
                trigger:
                  type: [ "error" ]
                button:
                  displayName: "Ask AI v2"
                  commandTpl: "ai {{.Event.Namespace}} this one is wrong"
    
              - enabled: true
                trigger:
                  type: [ "error" ]
                button:
                  commandTpl: "ai {{.Event.Namespace}} this one is wrong"
    
              - enabled: true
                trigger:
                  type: [ "fatal" ]
                button:
                  commandTpl: "ai {{.Event.Namespace}} this one is wrong"
    
            namespaces:
              include:
                - ".*"
            event:
              types:
                - error
            resources:
              - type: v1/pods
    
    plugins:
      cacheDir: "/tmp/plugins"
      repositories:
        botkube:
          url: http://localhost:3010/botkube.yaml
    
    settings:
      log:
        level: "info"
        formatter: text
      kubeconfig: "your kubeconfig path"
      clusterName: "labs"
      upgradeNotifier: false
    
    analytics:
      disable: true
    ```
    
    
    </p>
    </details> 

You should still get Pods error, if you will try the same on main, it won't get you a notification.

## Related issue(s)

Fix https://github.com/kubeshop/botkube/issues/1407