### PR TITLE
Reduce memory consumption for Kubernetes source configuration

### DIFF
--- a/cmd/botkube-agent/main.go
+++ b/cmd/botkube-agent/main.go
@@ -396,7 +396,7 @@ func run(ctx context.Context) (err error) {
 	scheduler := source.NewScheduler(ctx, logger, conf, sourcePluginDispatcher, schedulerChan)
 	err = scheduler.Start(ctx)
 	if err != nil {
-		return reportFatalError("while starting source plugin event dispatcher: %w", err)
+		return reportFatalError("while starting source plugin event dispatcher", err)
 	}
 
 	if conf.Plugins.IncomingWebhook.Enabled {

--- a/internal/source/dispatcher.go
+++ b/internal/source/dispatcher.go
@@ -88,8 +88,6 @@ func NewDispatcher(log logrus.FieldLogger, clusterName string, notifiers map[str
 }
 
 // Dispatch starts a given plugin, watches for incoming events and calling all notifiers to dispatch received event.
-// Once we will have the gRPC contract established with proper Cloud Event schema, we should move also this logic here:
-// https://github.com/kubeshop/botkube/blob/525c737956ff820a09321879284037da8bf5d647/pkg/controller/controller.go#L200-L253
 func (d *Dispatcher) Dispatch(dispatch PluginDispatch) error {
 	log := d.log.WithFields(logrus.Fields{
 		"pluginName": dispatch.pluginName,

--- a/internal/source/kubernetes/bg_processor.go
+++ b/internal/source/kubernetes/bg_processor.go
@@ -1,0 +1,64 @@
+package kubernetes
+
+import (
+	"context"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	"sync"
+	"time"
+)
+
+type backgroundProcessor struct {
+	mu          sync.RWMutex
+	cancelCtxFn func()
+	startTime   time.Time
+
+	errGroup *errgroup.Group
+}
+
+func newBackgroundProcessor() *backgroundProcessor {
+	return &backgroundProcessor{}
+}
+
+func (b *backgroundProcessor) StartTime() time.Time {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.startTime
+}
+
+func (b *backgroundProcessor) Run(parentCtx context.Context, fns []func(ctx context.Context)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.startTime = time.Now()
+	ctx, cancelFn := context.WithCancel(parentCtx)
+	b.cancelCtxFn = cancelFn
+
+	errGroup, errGroupCtx := errgroup.WithContext(ctx)
+	b.errGroup = errGroup
+
+	for _, fn := range fns {
+		fn := fn
+		errGroup.Go(func() error {
+			fn(errGroupCtx)
+			return nil
+		})
+	}
+}
+
+func (b *backgroundProcessor) StopAndWait(log logrus.FieldLogger) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.cancelCtxFn != nil {
+		log.Debug("Cancelling context of the background processor...")
+		b.cancelCtxFn()
+	}
+
+	if b.errGroup == nil {
+		return nil
+	}
+
+	log.Debug("Waiting for background processor to finish...")
+	return b.errGroup.Wait()
+}

--- a/internal/source/kubernetes/bg_processor.go
+++ b/internal/source/kubernetes/bg_processor.go
@@ -2,12 +2,14 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 	"sync"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
+// backgroundProcessor is responsible for running background processes.
 type backgroundProcessor struct {
 	mu          sync.RWMutex
 	cancelCtxFn func()
@@ -16,16 +18,19 @@ type backgroundProcessor struct {
 	errGroup *errgroup.Group
 }
 
+// newBackgroundProcessor creates new background processor.
 func newBackgroundProcessor() *backgroundProcessor {
 	return &backgroundProcessor{}
 }
 
+// StartTime returns the start time of the background processor.
 func (b *backgroundProcessor) StartTime() time.Time {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	return b.startTime
 }
 
+// Run starts the background processes.
 func (b *backgroundProcessor) Run(parentCtx context.Context, fns []func(ctx context.Context)) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -46,6 +51,7 @@ func (b *backgroundProcessor) Run(parentCtx context.Context, fns []func(ctx cont
 	}
 }
 
+// StopAndWait stops the background processes and waits for them to finish.
 func (b *backgroundProcessor) StopAndWait(log logrus.FieldLogger) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/source/kubernetes/configuration_store.go
+++ b/internal/source/kubernetes/configuration_store.go
@@ -1,0 +1,83 @@
+package kubernetes
+
+import (
+	"fmt"
+	"github.com/kubeshop/botkube/pkg/maputil"
+	"sync"
+)
+
+type ConfigurationStore struct {
+	store             map[string]SourceConfig
+	storeByKubeconfig map[string]map[string]SourceConfig
+
+	lock sync.RWMutex
+}
+
+func NewConfigurations() *ConfigurationStore {
+	return &ConfigurationStore{
+		store:             make(map[string]SourceConfig),
+		storeByKubeconfig: make(map[string]map[string]SourceConfig),
+	}
+}
+
+func (c *ConfigurationStore) Store(sourceName string, cfg SourceConfig) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	key := keyForStore(sourceName, cfg.isInteractivitySupported)
+
+	c.store[key] = cfg
+
+	kubeConfigKey := string(cfg.kubeConfig)
+	if _, ok := c.storeByKubeconfig[kubeConfigKey]; !ok {
+		c.storeByKubeconfig[kubeConfigKey] = make(map[string]SourceConfig)
+	}
+	c.storeByKubeconfig[kubeConfigKey][key] = cfg
+}
+
+func (c *ConfigurationStore) Get(sourceKey string) (SourceConfig, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	val, ok := c.store[sourceKey]
+	return val, ok
+}
+
+func (c *ConfigurationStore) GetGlobal() (SourceConfig, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	sortedKeys := c.sortedKeys()
+	if len(sortedKeys) == 0 {
+		return SourceConfig{}, false
+	}
+
+	return c.store[sortedKeys[0]], true
+}
+
+func (c *ConfigurationStore) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return len(c.store)
+}
+
+func (c *ConfigurationStore) sortedKeys() []string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return maputil.SortKeys(c.store)
+}
+
+func (c *ConfigurationStore) CloneByKubeconfig() map[string]map[string]SourceConfig {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	cloned := make(map[string]map[string]SourceConfig)
+	for k, v := range c.storeByKubeconfig {
+		cloned[k] = v
+	}
+
+	return cloned
+}
+
+func keyForStore(sourceName string, isInteractivitySupported bool) string {
+	return fmt.Sprintf("%s/%t", sourceName, isInteractivitySupported)
+}

--- a/internal/source/kubernetes/filterengine/filterengine.go
+++ b/internal/source/kubernetes/filterengine/filterengine.go
@@ -50,7 +50,6 @@ func New(log logrus.FieldLogger) *DefaultFilterEngine {
 func (f *DefaultFilterEngine) Run(ctx context.Context, event event.Event) event.Event {
 	f.log.Debug("Running registered filters")
 	filters := f.RegisteredFilters()
-	f.log.Debugf("registered filters: %+v", filters)
 
 	for _, filter := range filters {
 		if !filter.Enabled {
@@ -59,7 +58,7 @@ func (f *DefaultFilterEngine) Run(ctx context.Context, event event.Event) event.
 
 		err := filter.Run(ctx, &event)
 		if err != nil {
-			f.log.Errorf("while running filter %q: %w", filter.Name(), err)
+			f.log.Errorf("while running filter %q: %s", filter.Name(), err.Error())
 		}
 		f.log.Debugf("ran filter name: %q, event was skipped: %t", filter.Name(), event.Skip)
 	}

--- a/internal/source/kubernetes/router.go
+++ b/internal/source/kubernetes/router.go
@@ -2,7 +2,7 @@ package kubernetes
 
 import (
 	"context"
-	"github.com/kubeshop/botkube/pkg/formatx"
+
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/dynamic"
@@ -11,6 +11,7 @@ import (
 	"github.com/kubeshop/botkube/internal/source/kubernetes/config"
 	"github.com/kubeshop/botkube/internal/source/kubernetes/event"
 	"github.com/kubeshop/botkube/internal/source/kubernetes/recommendation"
+	"github.com/kubeshop/botkube/pkg/formatx"
 )
 
 const eventsResource = "v1/events"

--- a/internal/source/kubernetes/router.go
+++ b/internal/source/kubernetes/router.go
@@ -2,7 +2,7 @@ package kubernetes
 
 import (
 	"context"
-
+	"github.com/kubeshop/botkube/pkg/formatx"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/dynamic"
@@ -17,9 +17,11 @@ const eventsResource = "v1/events"
 
 type mergedEvents map[string]map[config.EventType]struct{}
 type registrationHandler func(resource string) (cache.SharedIndexInformer, error)
-type eventHandler func(ctx context.Context, source Source, event event.Event, updateDiffs []string)
+type eventHandler func(ctx context.Context, event event.Event, sources []string, updateDiffs []string)
 
 type route struct {
+	Source string
+
 	ResourceName  config.RegexConstraints
 	Labels        *map[string]string
 	Annotations   *map[string]string
@@ -60,16 +62,15 @@ func NewRouter(mapper meta.RESTMapper, dynamicCli dynamic.Interface, log logrus.
 
 // BuildTable builds the routers routing table marking it ready
 // to register, map and handle informer events.
-func (r *Router) BuildTable(cfg *config.Config) *Router {
-	mergedEvents := mergeResourceEvents(cfg)
-
+func (r *Router) BuildTable(cfgs map[string]SourceConfig) *Router {
+	mergedEvents := mergeResourceEvents(cfgs)
 	for resource, resourceEvents := range mergedEvents {
-		eventRoutes := r.mergeEventRoutes(resource, cfg)
+		eventRoutes := r.mergeEventRoutes(resource, cfgs)
 		for evt := range resourceEvents {
 			r.table[resource] = append(r.table[resource], entry{Event: evt, Routes: eventRoutes[evt]})
 		}
 	}
-	r.log.Debugf("routing table: %+v", r.table)
+	r.log.Debug("routing table:", formatx.StructDumper().Sdump(r.table))
 	return r
 }
 
@@ -123,21 +124,21 @@ func (r *Router) MapWithEventsInformer(srcEvent config.EventType, dstEvent confi
 
 // RegisterEventHandler allows router clients to create handlers that are
 // triggered for a target event.
-func (r *Router) RegisterEventHandler(ctx context.Context, s Source, eventType config.EventType, handlerFn func(ctx context.Context, s Source, e event.Event, updateDiffs []string)) {
+func (r *Router) RegisterEventHandler(ctx context.Context, eventType config.EventType, handlerFn eventHandler) {
 	for resource, reg := range r.registrations {
 		if !reg.canHandleEvent(eventType.String()) {
 			continue
 		}
 		sourceRoutes := r.getSourceRoutes(resource, eventType)
-		reg.handleEvent(ctx, s, resource, eventType, sourceRoutes, handlerFn)
+		reg.handleEvent(ctx, resource, eventType, sourceRoutes, handlerFn)
 	}
 }
 
 // HandleMappedEvent allows router clients to create handlers that are
 // triggered for a target mapped event.
-func (r *Router) HandleMappedEvent(ctx context.Context, s Source, targetEvent config.EventType, handlerFn eventHandler) {
+func (r *Router) HandleMappedEvent(ctx context.Context, targetEvent config.EventType, handlerFn eventHandler) {
 	if informer, ok := r.mappedInformer(targetEvent); ok {
-		informer.handleMapped(ctx, s, targetEvent, r.table, handlerFn)
+		informer.handleMapped(ctx, targetEvent, r.table, handlerFn)
 	}
 }
 
@@ -146,61 +147,67 @@ func (r *Router) getSourceRoutes(resource string, targetEvent config.EventType) 
 	return eventRoutes(r.table, resource, targetEvent)
 }
 
-func mergeResourceEvents(cfg *config.Config) mergedEvents {
+func mergeResourceEvents(cfgs map[string]SourceConfig) mergedEvents {
 	out := map[string]map[config.EventType]struct{}{}
-	for _, resource := range cfg.Resources {
-		if _, ok := out[resource.Type]; !ok {
-			out[resource.Type] = make(map[config.EventType]struct{})
+	for _, srcGroupCfg := range cfgs {
+		cfg := srcGroupCfg.cfg
+		for _, resource := range cfg.Resources {
+			if _, ok := out[resource.Type]; !ok {
+				out[resource.Type] = make(map[config.EventType]struct{})
+			}
+			for _, e := range flattenEventTypes(cfg.Event.Types, resource.Event.Types) {
+				out[resource.Type][e] = struct{}{}
+			}
 		}
-		for _, e := range flattenEventTypes(cfg.Event.Types, resource.Event.Types) {
-			out[resource.Type][e] = struct{}{}
-		}
-	}
 
-	resForRecomms := recommendation.ResourceEventsForConfig(cfg.Recommendations)
-	for resourceType, eventType := range resForRecomms {
-		if _, ok := out[resourceType]; !ok {
-			out[resourceType] = make(map[config.EventType]struct{})
+		resForRecomms := recommendation.ResourceEventsForConfig(cfg.Recommendations)
+		for resourceType, eventType := range resForRecomms {
+			if _, ok := out[resourceType]; !ok {
+				out[resourceType] = make(map[config.EventType]struct{})
+			}
+			out[resourceType][eventType] = struct{}{}
 		}
-		out[resourceType][eventType] = struct{}{}
 	}
 	return out
 }
 
-func (r *Router) mergeEventRoutes(resource string, cfg *config.Config) map[config.EventType][]route {
+func (r *Router) mergeEventRoutes(resource string, cfgs map[string]SourceConfig) map[config.EventType][]route {
 	out := make(map[config.EventType][]route)
-	for idx := range cfg.Resources {
-		r := cfg.Resources[idx] // make sure that we work on a copy
-		for _, e := range flattenEventTypes(cfg.Event.Types, r.Event.Types) {
-			if resource != r.Type {
-				continue
-			}
-			route := route{
-				Namespaces:   resourceNamespaces(cfg.Namespaces, &r.Namespaces),
-				Annotations:  resourceStringMap(cfg.Annotations, r.Annotations),
-				Labels:       resourceStringMap(cfg.Labels, r.Labels),
-				ResourceName: r.Name,
-				Event:        resourceEvent(*cfg.Event, r.Event),
-			}
-			if e == config.UpdateEvent {
-				route.UpdateSetting = &config.UpdateSetting{
-					Fields:      r.UpdateSetting.Fields,
-					IncludeDiff: r.UpdateSetting.IncludeDiff,
+	for srcGroupName, srcCfg := range cfgs {
+		cfg := srcCfg.cfg
+		for idx := range cfg.Resources {
+			r := cfg.Resources[idx] // make sure that we work on a copy
+			for _, e := range flattenEventTypes(cfg.Event.Types, r.Event.Types) {
+				if resource != r.Type {
+					continue
 				}
+				route := route{
+					Source:       srcGroupName,
+					Namespaces:   resourceNamespaces(cfg.Namespaces, &r.Namespaces),
+					Annotations:  resourceStringMap(cfg.Annotations, r.Annotations),
+					Labels:       resourceStringMap(cfg.Labels, r.Labels),
+					ResourceName: r.Name,
+					Event:        resourceEvent(*cfg.Event, r.Event),
+				}
+				if e == config.UpdateEvent {
+					route.UpdateSetting = &config.UpdateSetting{
+						Fields:      r.UpdateSetting.Fields,
+						IncludeDiff: r.UpdateSetting.IncludeDiff,
+					}
+				}
+
+				out[e] = append(out[e], route)
 			}
-
-			out[e] = append(out[e], route)
 		}
+		// add routes related to recommendations
+		resForRecomms := recommendation.ResourceEventsForConfig(cfg.Recommendations)
+		r.setEventRouteForRecommendationsIfShould(&out, resForRecomms, srcGroupName, resource, &cfg)
 	}
-
-	// add routes related to recommendations
-	resForRecomms := recommendation.ResourceEventsForConfig(cfg.Recommendations)
-	r.setEventRouteForRecommendationsIfShould(&out, resForRecomms, resource, cfg)
 
 	return out
 }
 
-func (r *Router) setEventRouteForRecommendationsIfShould(routeMap *map[config.EventType][]route, resForRecomms map[string]config.EventType, resourceType string, cfg *config.Config) {
+func (r *Router) setEventRouteForRecommendationsIfShould(routeMap *map[config.EventType][]route, resForRecomms map[string]config.EventType, srcGroupName, resourceType string, cfg *config.Config) {
 	if routeMap == nil {
 		r.log.Debug("Skipping setting event route for recommendations as the routeMap is nil")
 		return
@@ -212,6 +219,7 @@ func (r *Router) setEventRouteForRecommendationsIfShould(routeMap *map[config.Ev
 	}
 
 	recommRoute := route{
+		Source:     srcGroupName,
 		Namespaces: cfg.Namespaces,
 		Event: &config.KubernetesEvent{
 			Reason:  config.RegexConstraints{},
@@ -223,6 +231,10 @@ func (r *Router) setEventRouteForRecommendationsIfShould(routeMap *map[config.Ev
 	// Override route and get all these events for all namespaces.
 	// The events without recommendations will be filtered out when sending the event.
 	for i, r := range (*routeMap)[eventType] {
+		if r.Source != srcGroupName {
+			continue
+		}
+
 		recommRoute.Namespaces = resourceNamespaces(cfg.Namespaces, r.Namespaces)
 		(*routeMap)[eventType][i] = recommRoute
 		return

--- a/internal/source/kubernetes/source.go
+++ b/internal/source/kubernetes/source.go
@@ -4,28 +4,29 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"github.com/kubeshop/botkube/internal/command"
-	"github.com/kubeshop/botkube/internal/source/kubernetes/commander"
-	"github.com/kubeshop/botkube/internal/source/kubernetes/filterengine"
-	pkgConfig "github.com/kubeshop/botkube/pkg/config"
-	"github.com/kubeshop/botkube/pkg/loggerx"
-	"github.com/kubeshop/botkube/pkg/multierror"
-	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/tools/cache"
 	"os"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/kubeshop/botkube/internal/source/kubernetes/config"
-	"github.com/kubeshop/botkube/internal/source/kubernetes/event"
-	"github.com/kubeshop/botkube/internal/source/kubernetes/recommendation"
-	"github.com/kubeshop/botkube/pkg/api"
-	"github.com/kubeshop/botkube/pkg/api/source"
-	"github.com/kubeshop/botkube/pkg/plugin"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kubeshop/botkube/internal/command"
+	"github.com/kubeshop/botkube/internal/source/kubernetes/commander"
+	"github.com/kubeshop/botkube/internal/source/kubernetes/config"
+	"github.com/kubeshop/botkube/internal/source/kubernetes/event"
+	"github.com/kubeshop/botkube/internal/source/kubernetes/filterengine"
+	"github.com/kubeshop/botkube/internal/source/kubernetes/recommendation"
+	"github.com/kubeshop/botkube/pkg/api"
+	"github.com/kubeshop/botkube/pkg/api/source"
+	pkgConfig "github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/loggerx"
+	"github.com/kubeshop/botkube/pkg/multierror"
+	"github.com/kubeshop/botkube/pkg/plugin"
 )
 
 var _ source.Source = (*Source)(nil)
@@ -44,8 +45,6 @@ const (
 	description = "Consume Kubernetes events and get notifications with additional warnings and recommendations."
 
 	componentLogFieldKey = "component"
-
-	delayExecutionBy = 5 * time.Second
 )
 
 type RecommendationFactory interface {
@@ -56,7 +55,7 @@ type RecommendationFactory interface {
 type Source struct {
 	bgProcessor   *backgroundProcessor
 	pluginVersion string
-	configStore   *ConfigurationStore
+	configStore   *configurationStore
 
 	mu sync.Mutex
 
@@ -85,7 +84,7 @@ type ActiveSourceConfig struct {
 func NewSource(version string) *Source {
 	return &Source{
 		pluginVersion: version,
-		configStore:   NewConfigurations(),
+		configStore:   newConfigurations(),
 		bgProcessor:   newBackgroundProcessor(),
 	}
 }

--- a/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-apps.v1.deployments.golden.yaml
+++ b/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-apps.v1.deployments.golden.yaml
@@ -1,6 +1,7 @@
 - event: delete
   routes:
-    - resourcename:
+    - source: test
+      resourcename:
         include: []
       labels:
         test: label-1-level

--- a/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-v1.configmaps.golden.yaml
+++ b/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-v1.configmaps.golden.yaml
@@ -1,6 +1,7 @@
 - event: create
   routes:
-    - resourcename:
+    - source: test
+      resourcename:
         include: []
       labels:
         test: label-2-level

--- a/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-v1.pod.golden.yaml
+++ b/internal/source/kubernetes/testdata/TestRouterListMergingNestedFields/route-v1.pod.golden.yaml
@@ -1,6 +1,7 @@
 - event: delete
   routes:
-    - resourcename:
+    - source: test
+      resourcename:
         include: []
       labels:
         test: label-1-level

--- a/internal/source/scheduler.go
+++ b/internal/source/scheduler.go
@@ -3,7 +3,6 @@ package source
 import (
 	"context"
 	"fmt"
-	"github.com/kubeshop/botkube/pkg/maputil"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/kubeshop/botkube/pkg/api/source"
 	"github.com/kubeshop/botkube/pkg/config"
+	"github.com/kubeshop/botkube/pkg/maputil"
 )
 
 const (

--- a/internal/source/scheduler.go
+++ b/internal/source/scheduler.go
@@ -3,6 +3,7 @@ package source
 import (
 	"context"
 	"fmt"
+	"github.com/kubeshop/botkube/pkg/maputil"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -140,7 +141,14 @@ func (d *Scheduler) monitorHealth(ctx context.Context) {
 }
 
 func (d *Scheduler) schedule(pluginFilter string) error {
-	for configKey, sourceConfig := range d.dispatchConfig {
+	sortedKeys := maputil.SortKeys(d.dispatchConfig) // ensure config iteration order is alphabetical
+	for _, configKey := range sortedKeys {
+		sourceConfig, ok := d.dispatchConfig[configKey]
+		if !ok {
+			// shouldn't happen but still
+			continue
+		}
+
 		for pluginName, config := range sourceConfig {
 			if pluginFilter != emptyPluginFilter && pluginFilter != pluginName {
 				d.log.Debugf("Not starting %q as it doesn't pass plugin filter.", pluginName)

--- a/internal/source/scheduler.go
+++ b/internal/source/scheduler.go
@@ -143,13 +143,9 @@ func (d *Scheduler) monitorHealth(ctx context.Context) {
 func (d *Scheduler) schedule(pluginFilter string) error {
 	sortedKeys := maputil.SortKeys(d.dispatchConfig) // ensure config iteration order is alphabetical
 	for _, configKey := range sortedKeys {
-		sourceConfig, ok := d.dispatchConfig[configKey]
-		if !ok {
-			// shouldn't happen but still
-			continue
-		}
+		sourceConfig := d.dispatchConfig[configKey]
 
-		for pluginName, config := range sourceConfig {
+		for pluginName, srcCfg := range sourceConfig {
 			if pluginFilter != emptyPluginFilter && pluginFilter != pluginName {
 				d.log.Debugf("Not starting %q as it doesn't pass plugin filter.", pluginName)
 				continue
@@ -161,7 +157,7 @@ func (d *Scheduler) schedule(pluginFilter string) error {
 			}
 
 			d.log.Infof("Starting a new stream for plugin %q", pluginName)
-			if err := d.dispatcher.Dispatch(config); err != nil {
+			if err := d.dispatcher.Dispatch(srcCfg); err != nil {
 				return fmt.Errorf("while starting plugin source %s: %w", pluginName, err)
 			}
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Reduce memory consumption for Kubernetes source configuration

This change groups Kubernetes source configurations by different kubeconfigs and creates a single `dynamicInformerFactory` per group, which essentially brings the implementation close to the 0.18 Kubernetes source one. 

## Stats

Memory consumption shortly after startup:

| Description | v1.9.1 | This PR |
|--------|--------|--------|
| No sources enabled | 21.4 MiB | 23.1 MiB |
| 1 source (`k8s-all-events2` from the PR instruction) | 78.9MiB | 86.6 MiB |
| 12 sources (from the PR instruction) | 504MB |  92.9 MiB |

## Screenshots

### v1.9.1

12 sources:

#### 256Mi request, 384MB limit

Too low, source plugin restarts itself.

<img width="864" alt="Screenshot 2024-04-02 at 19 11 11" src="https://github.com/kubeshop/botkube/assets/7155799/4a452c3a-580e-47e9-9a34-e0a42c657a52">
<img width="868" alt="Screenshot 2024-04-02 at 19 11 17" src="https://github.com/kubeshop/botkube/assets/7155799/4086956b-fd91-4f94-b66f-ad25053732ae">

![Screenshot 2024-04-02 at 19 11 04](https://github.com/kubeshop/botkube/assets/7155799/e230588d-5d0f-4109-9315-937eb7fe26bc)

#### 1Gi request + 2Gi request

Plugin runs withourt restarting, still multiple DeltaFIFO logs

![image](https://github.com/kubeshop/botkube/assets/7155799/810d3b4e-fbcd-4bc4-90b2-6424a7cc008d)

![image](https://github.com/kubeshop/botkube/assets/7155799/bf517cc4-5807-4200-bc89-e7c80b6d15ad)

![image](https://github.com/kubeshop/botkube/assets/7155799/ffe77864-0db8-46cd-9488-3e6f780c37e1)

#### 1 source (`k8s-all-events2` from the testing instruction)

![image](https://github.com/kubeshop/botkube/assets/7155799/1247301d-984c-4c2e-bf89-a2dbbe2fe562)

#### No sources enabled

![image](https://github.com/kubeshop/botkube/assets/7155799/f790dc76-bffb-456c-9b74-07262c1f2f1a)


### After changes in this PR: 

#### 12 Sources (from the testing instruction)

Requests 128Mi, limit 256Mi:

![Screenshot 2024-04-03 at 10 43 05](https://github.com/kubeshop/botkube/assets/7155799/663f16fd-07fe-484e-896f-9c9fa5941b08)

![Screenshot 2024-04-03 at 10 43 20](https://github.com/kubeshop/botkube/assets/7155799/2233f389-d066-4656-90a3-c23c01a7c31b)

No DeltaFIFO logs, just a warning about client-side throttling:
```
{"level":"error","logger":"stderr","msg":"I0402 17:30:32.285424      13 request.go:697] Waited for 1.198321417s due to client-side throttling, not priority and fairness, request: GET:https://10.43.0.1:443/apis/networking.k8s.io/v1/ingresses?limit=500\u0026resourceVersion=0","plugin":"botkube/kubernetes","time":"2024-04-02T17:30:32Z"}
```
And Slack API rate limits:
```
{"level":"error","msg":"while sending bot message: 1 error occurred:\n\t* while sending Slack message to channel \"priv-channel\": while posting Slack message: slack rate limit exceeded, retry after 1s","time":"2024-04-03T07:51:21Z"}
{"level":"error","msg":"while sending bot message: 1 error occurred:\n\t* while sending Slack message to channel \"priv-channel\": while posting Slack message: slack rate limit exceeded, retry after 1s","time":"2024-04-03T07:51:21Z"}
```
#### 1 source (`k8s-all-events2` from the testing instruction)

![Screenshot 2024-04-03 at 10 37 07](https://github.com/kubeshop/botkube/assets/7155799/9f5284ec-6f8a-4e96-84fe-8d92c7ed6ea4)

#### No sources enabled

![image](https://github.com/kubeshop/botkube/assets/7155799/e2c0d016-35b1-455d-abf4-943116191e91)


## Testing


Check out this PR:
```
gh pr checkout 1425
```

Create k3d cluster

```
k3d cluster create
```

Build and serve plugins:
```
make build-plugins
PLUGIN_SERVER_HOST=http://host.k3d.internal go run ./hack/target/serve-plugins/main.go
```

Install kube-prometheus-stack:
```
helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
helm repo update
helm install prom prometheus-community/kube-prometheus-stack
```
Forward Grafana port:

```
kubectl port-forward svc/prom-grafana 3003:80
```

Navigate to http://localhost:3003 and log in with **admin** / **prom-operator** credentials.


Install ArgoCD + Flux on the cluster:
```
kubectl create namespace argocd
kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
kubectl apply -f https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
```
### Install previous Botkube

Install previous Botkube version with the following configuration (fill the Slack tokens):

<details><summary>Details</summary>
<p>

```bash
cat <<EOF > /tmp/prev-values.yaml
settings:
  clusterName: "prev"

sources:
  'k8s-all-events2':
    displayName: "All events"
    botkube/kubernetes: &k8s-all-events
      context:
        rbac:
          group:
            type: Static
            prefix: ""
            static:
              values: [ "botkube-plugins-default" ]
      enabled: true
      config:
        namespaces:
          include:
            - ".*"
        event:
          types:
            - error
            - create
            - update
            - delete
        resources:
          - type: apiextensions.k8s.io/v1/customresourcedefinitions
          - type: argoproj.io/v1alpha1/applications
          - type: argoproj.io/v1alpha1/appprojects
          - type: notification.toolkit.fluxcd.io/v1beta1/alerts
          - type: source.toolkit.fluxcd.io/v1beta1/buckets
          - type: source.toolkit.fluxcd.io/v1beta1/gitrepositories
          - type: source.toolkit.fluxcd.io/v1beta1/helmcharts
          - type: helm.toolkit.fluxcd.io/v2beta1/helmreleases
          - type: source.toolkit.fluxcd.io/v1beta1/helmrepositories
          - type: image.toolkit.fluxcd.io/v1beta1/imagepolicies
          - type: image.toolkit.fluxcd.io/v1beta1/imagerepositories
          - type: image.toolkit.fluxcd.io/v1beta1/imageupdateautomations
          - type: kustomize.toolkit.fluxcd.io/v1beta1/kustomizations
          - type: source.toolkit.fluxcd.io/v1beta2/ocirepositories
          - type: notification.toolkit.fluxcd.io/v1beta1/providers
          - type: notification.toolkit.fluxcd.io/v1beta1/receivers
          - type: v1/services
          - type: networking.k8s.io/v1/ingresses
          - type: v1/nodes
            event:
              message:
                exclude:
                  - ".*nf_conntrack_buckets.*" # Ignore node related noisy messages from GKE clusters
          - type: v1/namespaces
          - type: v1/persistentvolumes
          - type: v1/persistentvolumeclaims
          - type: v1/configmaps
          - type: rbac.authorization.k8s.io/v1/roles
          - type: rbac.authorization.k8s.io/v1/rolebindings
          - type: rbac.authorization.k8s.io/v1/clusterrolebindings
          - type: rbac.authorization.k8s.io/v1/clusterroles
          - type: apps/v1/daemonsets
            event: # Overrides 'source'.kubernetes.event
              types:
                - create
                - update
                - delete
                - error
            updateSetting:
              includeDiff: true
              fields:
                - spec.template.spec.containers[*].image
                - status.numberReady
          - type: batch/v1/jobs
            event: # Overrides 'source'.kubernetes.event
              types:
                - create
                - update
                - delete
                - error
            updateSetting:
              includeDiff: true
              fields:
                - spec.template.spec.containers[*].image
                - status.conditions[*].type
          - type: apps/v1/deployments
            event: # Overrides 'source'.kubernetes.event
              types:
                - create
                - update
                - delete
                - error
            updateSetting:
              includeDiff: true
              fields:
                - spec.template.spec.containers[*].image
                - status.availableReplicas
          - type: apps/v1/statefulsets
            event: # Overrides 'source'.kubernetes.event
              types:
                - create
                - update
                - delete
                - error
            updateSetting:
              includeDiff: true
              fields:
                - spec.template.spec.containers[*].image
                - status.readyReplicas   
  'k8s-all-events3':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events4':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events      
  'k8s-all-events5':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events6':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events7':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events8':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events9':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events10':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events11':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events12':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events    
communications:
  'default-group':
    socketSlack:
      enabled: true
      appToken: "xapp-..."
      botToken: "xoxb-..."
      channels:
        'default':
          name: 'priv-channel'
          bindings:
            sources:
              - k8s-err-events
              - k8s-recommendation-events
              - k8s-err-with-logs-events
              - k8s-create-events
              - k8s-all-events
              - k8s-all-events2
              - k8s-all-events3
              - k8s-all-events4
              - k8s-all-events5
              - k8s-all-events6
              - k8s-all-events7
              - k8s-all-events8
              - k8s-all-events9
              - k8s-all-events10
              - k8s-all-events11
              - k8s-all-events12              
resources:
  limits:
    cpu: 500m
    memory: 1Gi
  requests:
    cpu: 200m
    memory: 512Mi
EOF

botkube install --version v1.9.1 -f /tmp/prev-values.yaml
```

</p>
</details> 


In the Grafana dashboard, navigate to the `1. Kubernetes / Compute Resources / Pod` dashboard and select the Botkube pod. Observe the memory consumption.

### Install current Botkube

Install current Botkube version with the following configuration (fill the Slack tokens):

<details><summary>Details</summary>
<p>

```bash
cat <<EOF > /tmp/new-values.yaml 
image:
  repository: kubeshop/pr/botkube
  tag: 1425-PR

settings:
  clusterName: "new"

plugins:
  repositories:
    botkube:
       url: http://host.k3d.internal:3010/botkube.yaml

sources:
  'k8s-all-events2':
    displayName: "All events"
    botkube/kubernetes: &k8s-all-events
      context:
        rbac:
          group:
            type: Static
            prefix: ""
            static:
              values: [ "botkube-plugins-default" ]
      enabled: true
      config:
        namespaces:
          include:
            - ".*"
        event:
          types:
            - error
            - create
            - update
            - delete
        resources:
          - type: apiextensions.k8s.io/v1/customresourcedefinitions
          - type: argoproj.io/v1alpha1/applications
          - type: argoproj.io/v1alpha1/appprojects
          - type: notification.toolkit.fluxcd.io/v1beta1/alerts
          - type: source.toolkit.fluxcd.io/v1beta1/buckets
          - type: source.toolkit.fluxcd.io/v1beta1/gitrepositories
          - type: source.toolkit.fluxcd.io/v1beta1/helmcharts
          - type: helm.toolkit.fluxcd.io/v2beta1/helmreleases
          - type: source.toolkit.fluxcd.io/v1beta1/helmrepositories
          - type: image.toolkit.fluxcd.io/v1beta1/imagepolicies
          - type: image.toolkit.fluxcd.io/v1beta1/imagerepositories
          - type: image.toolkit.fluxcd.io/v1beta1/imageupdateautomations
          - type: kustomize.toolkit.fluxcd.io/v1beta1/kustomizations
          - type: source.toolkit.fluxcd.io/v1beta2/ocirepositories
          - type: notification.toolkit.fluxcd.io/v1beta1/providers
          - type: notification.toolkit.fluxcd.io/v1beta1/receivers
          - type: v1/services
          - type: networking.k8s.io/v1/ingresses
          - type: v1/nodes
            event:
              message:
                exclude:
                  - ".*nf_conntrack_buckets.*" # Ignore node related noisy messages from GKE clusters
          - type: v1/namespaces
          - type: v1/persistentvolumes
          - type: v1/persistentvolumeclaims
          - type: v1/configmaps
          - type: rbac.authorization.k8s.io/v1/roles
          - type: rbac.authorization.k8s.io/v1/rolebindings
          - type: rbac.authorization.k8s.io/v1/clusterrolebindings
          - type: rbac.authorization.k8s.io/v1/clusterroles
          - type: apps/v1/daemonsets
            event: # Overrides 'source'.kubernetes.event
              types:
                - create
                - update
                - delete
                - error
            updateSetting:
              includeDiff: true
              fields:
                - spec.template.spec.containers[*].image
                - status.numberReady
          - type: batch/v1/jobs
            event: # Overrides 'source'.kubernetes.event
              types:
                - create
                - update
                - delete
                - error
            updateSetting:
              includeDiff: true
              fields:
                - spec.template.spec.containers[*].image
                - status.conditions[*].type
          - type: apps/v1/deployments
            event: # Overrides 'source'.kubernetes.event
              types:
                - create
                - update
                - delete
                - error
            updateSetting:
              includeDiff: true
              fields:
                - spec.template.spec.containers[*].image
                - status.availableReplicas
          - type: apps/v1/statefulsets
            event: # Overrides 'source'.kubernetes.event
              types:
                - create
                - update
                - delete
                - error
            updateSetting:
              includeDiff: true
              fields:
                - spec.template.spec.containers[*].image
                - status.readyReplicas   
  'k8s-all-events3':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events4':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events      
  'k8s-all-events5':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events6':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events7':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events8':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events9':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events10':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events11':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events
  'k8s-all-events12':
    displayName: "All events"
    botkube/kubernetes: *k8s-all-events    
communications:
  'default-group':
    socketSlack:
      enabled: true
      appToken: "xapp-..."
      botToken: "xoxb-..."
      channels:
        'default':
          name: 'priv-channel'
          bindings:
            sources:
              - k8s-err-events
              - k8s-recommendation-events
              - k8s-err-with-logs-events
              - k8s-create-events
              - k8s-all-events
              - k8s-all-events2
              - k8s-all-events3
              - k8s-all-events4
              - k8s-all-events5
              - k8s-all-events6
              - k8s-all-events7
              - k8s-all-events8
              - k8s-all-events9
              - k8s-all-events10
              - k8s-all-events11
              - k8s-all-events12                
resources:
  limits:
    cpu: 200m
    memory: 256Mi
  requests:
    cpu: 100m
    memory: 128Mi
EOF

botkube install --version v1.9.1 -f /tmp/new-values.yaml
```

</p>
</details> 


In the Grafana dashboard, navigate to the `1. Kubernetes / Compute Resources / Pod` dashboard and select the Botkube pod. Observe the memory consumption.

## Related issue(s)

Resolves #1403 
