### PR TITLE
Add single quote escaping while parsing input command

### DIFF
--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -88,12 +88,12 @@ func (e *DefaultExecutor) Execute(ctx context.Context) interactive.CoreMessage {
 
 	flags, err := ParseFlags(expandedRawCmd)
 	if err != nil {
-		e.log.Errorf("while parsing command flags %q: %s", expandedRawCmd, err.Error())
+		e.log.WithError(err).WithField("msg", expandedRawCmd).Error("Failed to parse user message")
 		return interactive.CoreMessage{
 			Description: header(cmdCtx),
 			Message: api.Message{
 				BaseBody: api.Body{
-					Plaintext: err.Error(),
+					Plaintext: cantParseCmd,
 				},
 			},
 		}

--- a/pkg/execute/params_test.go
+++ b/pkg/execute/params_test.go
@@ -92,6 +92,20 @@ func TestRemoveBotkubeRelatedFlags(t *testing.T) {
 			ClusterName: "api",
 			Filter:      "=./Users/botkube/somefile.txt [info]",
 		},
+		{
+			Name:        "Handle even number of single quotes with text filter and cluster name extraction",
+			Input:       `@botkube ai I'm not sure if it's what's best for us, but let's give it a try.   --cluster-name='api' --filter="=./Users/botkube/somefile.txt"`,
+			Cmd:         `@botkube ai I'm not sure if it's what's best for us, but let's give it a try.  `,
+			ClusterName: "api",
+			Filter:      "=./Users/botkube/somefile.txt",
+		},
+		{
+			Name:        "Handle odd number of single quotes with text filter and cluster name extraction",
+			Input:       `@botkube ai are there any failing pods? It's what's been keeping me energized lately  --cluster-name='api' --filter="=./Users/botkube/somefile.txt"`,
+			Cmd:         `@botkube ai are there any failing pods? It's what's been keeping me energized lately `,
+			ClusterName: "api",
+			Filter:      "=./Users/botkube/somefile.txt",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add single quote escaping while parsing input command. It's more like a workaround.  Ultimately, we should find a better and more generic way for extracting parameters. Additionally, we should delegate command tokenizing to the plugin. However, this would require a bigger refactor, so I deduced to not go into that direction right now.



## Related issue(s)

- https://github.com/kubeshop/botkube-cloud/issues/994