### PR TITLE
Send ack when the new cfg 'resourceVersion' was loaded without restart

### DIFF
--- a/cmd/botkube-agent/main.go
+++ b/cmd/botkube-agent/main.go
@@ -353,13 +353,14 @@ func run(ctx context.Context) (err error) {
 		cfgReloader, err := reloader.Get(
 			remoteCfgEnabled,
 			logger.WithField(componentLogFieldKey, "Config Reloader"),
+			statusReporter,
 			deployClient,
 			dynamicCli,
 			restarter,
 			analyticsReporter,
 			*conf,
 			cfgVersion,
-			cfgManager,
+			cfgManager, statusReporter,
 		)
 		if err != nil {
 			return reportFatalError("while creating config reloader", err)
@@ -519,7 +520,7 @@ func getK8sClients(cfg *rest.Config) (dynamic.Interface, discovery.DiscoveryInte
 	return dynamicK8sCli, discoCacheClient, nil
 }
 
-func reportFatalErrFn(logger logrus.FieldLogger, reporter analytics.Reporter, status status.StatusReporter) func(ctx string, err error) error {
+func reportFatalErrFn(logger logrus.FieldLogger, reporter analytics.Reporter, status status.Reporter) func(ctx string, err error) error {
 	return func(ctx string, err error) error {
 		if err == nil {
 			return nil

--- a/internal/config/reloader/get.go
+++ b/internal/config/reloader/get.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/kubeshop/botkube/internal/analytics"
+	"github.com/kubeshop/botkube/internal/status"
 	"github.com/kubeshop/botkube/pkg/config"
 )
 
@@ -13,10 +14,10 @@ const (
 )
 
 // Get returns Reloader based on remoteCfgEnabled flag.
-func Get(remoteCfgEnabled bool, log logrus.FieldLogger, deployCli DeploymentClient, dynamicCli dynamic.Interface, restarter *Restarter, reporter analytics.Reporter, cfg config.Config, cfgVer int, resVerHolders ...ResourceVersionHolder) (Reloader, error) {
+func Get(remoteCfgEnabled bool, log logrus.FieldLogger, statusReporter status.Reporter, deployCli DeploymentClient, dynamicCli dynamic.Interface, restarter *Restarter, reporter analytics.Reporter, cfg config.Config, cfgVer int, resVerHolders ...ResourceVersionHolder) (Reloader, error) {
 	if remoteCfgEnabled {
 		log = log.WithField(typeKey, "remote")
-		return NewRemote(log, deployCli, restarter, cfg, cfgVer, resVerHolders...), nil
+		return NewRemote(log, statusReporter, deployCli, restarter, cfg, cfgVer, resVerHolders...), nil
 	}
 
 	log = log.WithField(typeKey, "in-cluster")

--- a/internal/config/reloader/remote_test.go
+++ b/internal/config/reloader/remote_test.go
@@ -1,6 +1,7 @@
 package reloader
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kubeshop/botkube/internal/status"
 	"github.com/kubeshop/botkube/pkg/config"
 	"github.com/kubeshop/botkube/pkg/loggerx"
 )
@@ -79,15 +81,16 @@ func TestRemote_ProcessConfig(t *testing.T) {
 		t.Run(testCase.Name, func(t *testing.T) {
 			resVerHldr := &sampleResVerHolder{testCase.InitialResVer}
 			remoteReloader := RemoteConfigReloader{
-				log:           loggerx.NewNoop(),
-				interval:      time.Minute,
-				deployCli:     nil,
-				resVerHolders: []ResourceVersionHolder{resVerHldr},
-				currentCfg:    testCase.InitialCfg,
-				resVersion:    testCase.InitialResVer,
+				log:            loggerx.NewNoop(),
+				interval:       time.Minute,
+				deployCli:      nil,
+				resVerHolders:  []ResourceVersionHolder{resVerHldr},
+				currentCfg:     testCase.InitialCfg,
+				resVersion:     testCase.InitialResVer,
+				statusReporter: status.NoopStatusReporter{},
 			}
 
-			cfgDiff, err := remoteReloader.processNewConfig([]byte(testCase.NewConfig), testCase.NewResVer)
+			cfgDiff, err := remoteReloader.processNewConfig(context.Background(), []byte(testCase.NewConfig), testCase.NewResVer)
 			if testCase.ExpectedErrMessage != "" {
 				require.Error(t, err)
 				assert.EqualError(t, err, testCase.ExpectedErrMessage)

--- a/internal/status/noop_reporter.go
+++ b/internal/status/noop_reporter.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var _ StatusReporter = (*NoopStatusReporter)(nil)
+var _ Reporter = (*NoopStatusReporter)(nil)
 
 type NoopStatusReporter struct{}
 
@@ -15,6 +15,10 @@ func (n NoopStatusReporter) ReportDeploymentConnectionInit(context.Context, stri
 }
 
 func (n NoopStatusReporter) ReportDeploymentStartup(context.Context) error {
+	return nil
+}
+
+func (n NoopStatusReporter) AckNewResourceVersion(context.Context) error {
 	return nil
 }
 

--- a/internal/status/reporter.go
+++ b/internal/status/reporter.go
@@ -9,16 +9,17 @@ import (
 	"github.com/kubeshop/botkube/pkg/loggerx"
 )
 
-type StatusReporter interface {
+type Reporter interface {
 	ReportDeploymentConnectionInit(ctx context.Context, k8sVer string) error
 	ReportDeploymentStartup(ctx context.Context) error
+	AckNewResourceVersion(ctx context.Context) error
 	ReportDeploymentShutdown(ctx context.Context) error
 	ReportDeploymentFailure(ctx context.Context, errMsg string) error
 	SetResourceVersion(resourceVersion int)
 	SetLogger(logger logrus.FieldLogger)
 }
 
-func GetReporter(remoteCfgEnabled bool, gql GraphQLClient, resVerClient ResVerClient, log logrus.FieldLogger) StatusReporter {
+func GetReporter(remoteCfgEnabled bool, gql GraphQLClient, resVerClient ResVerClient, log logrus.FieldLogger) Reporter {
 	if remoteCfgEnabled {
 		log = withDefaultLogger(log)
 		return newGraphQLStatusReporter(

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -25,11 +25,11 @@ type Controller struct {
 	log            logrus.FieldLogger
 	conf           *config.Config
 	notifiers      map[string]bot.Bot
-	statusReporter status.StatusReporter
+	statusReporter status.Reporter
 }
 
 // New create a new Controller instance.
-func New(log logrus.FieldLogger, conf *config.Config, notifiers map[string]bot.Bot, reporter status.StatusReporter) *Controller {
+func New(log logrus.FieldLogger, conf *config.Config, notifiers map[string]bot.Bot, reporter status.Reporter) *Controller {
 	return &Controller{
 		log:            log,
 		conf:           conf,

--- a/test/e2e/bots_test.go
+++ b/test/e2e/bots_test.go
@@ -853,17 +853,19 @@ func runBotTest(t *testing.T,
 		err = botDriver.WaitForLastMessageEqual(botDriver.BotUserID(), botDriver.SecondChannel().ID(), expectedMessage)
 		assert.NoError(t, err)
 
-		t.Log("Starting notifier in second channel...")
-		command = "enable notifications"
-		expectedBody = codeBlock(fmt.Sprintf("Brace yourselves, incoming notifications from cluster '%s'.", appCfg.ClusterName))
-		expectedMessage = fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
+		if botDriver.Type() != commplatform.TeamsBot { // base on the previous assertion, we know that notifications are enabled 
+			t.Log("Starting notifier in second channel...")
+			command = "enable notifications"
+			expectedBody = codeBlock(fmt.Sprintf("Brace yourselves, incoming notifications from cluster '%s'.", appCfg.ClusterName))
+			expectedMessage = fmt.Sprintf("%s\n%s", cmdHeader(command), expectedBody)
 
-		botDriver.PostMessageToBot(t, botDriver.SecondChannel().Identifier(), command)
-		err = botDriver.WaitForMessagePosted(botDriver.BotUserID(), botDriver.SecondChannel().ID(), limitMessages(), botDriver.AssertEquals(expectedMessage))
-		require.NoError(t, err)
+			botDriver.PostMessageToBot(t, botDriver.SecondChannel().Identifier(), command)
+			err = botDriver.WaitForMessagePosted(botDriver.BotUserID(), botDriver.SecondChannel().ID(), limitMessages(), botDriver.AssertEquals(expectedMessage))
+			require.NoError(t, err)
 
-		if botDriver.Type().IsCloud() {
-			waitForRestart(t, botDriver, botDriver.BotUserID(), botDriver.FirstChannel().ID(), appCfg.ClusterName)
+			if botDriver.Type().IsCloud() {
+				waitForRestart(t, botDriver, botDriver.BotUserID(), botDriver.FirstChannel().ID(), appCfg.ClusterName)
+			}
 		}
 
 		cfgMapCli := k8sCli.CoreV1().ConfigMaps(appCfg.Deployment.Namespace)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Send ack when the new cfg 'resourceVersion' was loaded without restart

## Testing

1. Create new Instance
2. Deploy Agent v1.12
3. Update plugin without making any changes
4. See that it stuck in 'Updating' phase
5. Redeploy Agent with the PR image by adding:
    ```sh
    --set settings.log.level="debug
    --set image.repository=kubeshop/pr/botkube
    ```
7. Again, to the plugin update without making any changes
8. See that Agent transition to 'Connected' within 1min

To see the logs you need to have `kubectl set env deployment/botkube BOTKUBE_SETTINGS_LOG_LEVEL="debug"`

https://github.com/kubeshop/botkube/assets/17568639/80e7b6f6-3c30-4cfd-a9b9-e8d5d9df8a60


## Related issue(s)

Fix https://github.com/kubeshop/botkube-cloud/issues/1127