### PR TITLE
chore: Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-charts.botkube.io


### PR DESCRIPTION
The domain `botkube.io` has expired, let's go back to using GitHub's default subdomain/path `kubeshop.github.io/botkube`.

```
# whois.namecheap.com

Domain name: botkube.io
[...]
Registrar Registration Expiration Date: 2026-01-02T06:40:21.82Z
```